### PR TITLE
Create radio button group component

### DIFF
--- a/src/components/fields/checkbox-group/checkbox-group.styles.tsx
+++ b/src/components/fields/checkbox-group/checkbox-group.styles.tsx
@@ -1,17 +1,22 @@
 import { Checkbox } from "@lifesg/react-design-system/checkbox";
 import styled from "styled-components";
 
-export const Label = styled.label`
-	display: flex;
-	align-items: center;
-	margin-bottom: 10px;
-	cursor: pointer;
+interface ILabelProps {
+	disabled?: boolean;
+}
 
-	&:last-child {
-		margin-bottom: 0;
-	}
+export const Label = styled.label<ILabelProps>`
+	cursor: ${(props) => (props.disabled ? "not-allowed" : "pointer")};
 `;
 
 export const StyledCheckbox = styled(Checkbox)`
-	margin-right: 10px;
+	margin-right: 5px;
+`;
+
+export const CheckboxContainer = styled.div`
+	display: flex;
+	align-items: center;
+	:not(:last-of-type) {
+		margin-bottom: 1rem;
+	}
 `;

--- a/src/components/fields/checkbox-group/checkbox-group.tsx
+++ b/src/components/fields/checkbox-group/checkbox-group.tsx
@@ -5,7 +5,7 @@ import * as Yup from "yup";
 import { useValidationSchema } from "../../../utils/hooks";
 import { IGenericFieldProps } from "../../frontend-engine";
 import { ERROR_MESSAGES } from "../../shared";
-import { Label, StyledCheckbox } from "./checkbox-group.styles";
+import { CheckboxContainer, Label, StyledCheckbox } from "./checkbox-group.styles";
 import { ICheckboxGroupSchema } from "./types";
 
 export const CheckboxGroup = (props: IGenericFieldProps<ICheckboxGroupSchema>) => {
@@ -13,7 +13,7 @@ export const CheckboxGroup = (props: IGenericFieldProps<ICheckboxGroupSchema>) =
 	// CONST, STATE, REFS
 	// =============================================================================
 	const {
-		schema: { label, options, validation, ...otherSchema },
+		schema: { label, options, validation, disabled, ...otherSchema },
 		id,
 		value,
 		error,
@@ -84,19 +84,26 @@ export const CheckboxGroup = (props: IGenericFieldProps<ICheckboxGroupSchema>) =
 	const renderCheckboxes = () => {
 		return (
 			options.length > 0 &&
-			options.map((option, index) => (
-				<Label key={option.label}>
-					<StyledCheckbox
-						{...otherSchema}
-						id={formatCheckboxId(id, index)}
-						name={option.label}
-						value={option.value}
-						checked={getCheckboxStatus(option.value)}
-						onChange={handleChange}
-					/>
-					{option.label}
-				</Label>
-			))
+			options.map((option, index) => {
+				const checkboxId = formatCheckboxId(id, index);
+
+				return (
+					<CheckboxContainer key={index}>
+						<StyledCheckbox
+							{...otherSchema}
+							id={checkboxId}
+							disabled={disabled}
+							name={option.label}
+							value={option.value}
+							checked={getCheckboxStatus(option.value)}
+							onChange={handleChange}
+						/>
+						<Label htmlFor={checkboxId} disabled={disabled}>
+							{option.label}
+						</Label>
+					</CheckboxContainer>
+				);
+			})
 		);
 	};
 

--- a/src/components/fields/checkbox-group/checkbox-group.tsx
+++ b/src/components/fields/checkbox-group/checkbox-group.tsx
@@ -2,6 +2,7 @@ import { Form } from "@lifesg/react-design-system/form";
 import without from "lodash/without";
 import React, { useEffect, useState } from "react";
 import * as Yup from "yup";
+import { TestHelper } from "../../../utils";
 import { useValidationSchema } from "../../../utils/hooks";
 import { IGenericFieldProps } from "../../frontend-engine";
 import { ERROR_MESSAGES } from "../../shared";
@@ -74,10 +75,6 @@ export const CheckboxGroup = (props: IGenericFieldProps<ICheckboxGroupSchema>) =
 		return stateValue.includes(value);
 	};
 
-	const formatCheckboxId = (id: string, index: number): string => {
-		return `${id}-${index}`;
-	};
-
 	// =============================================================================
 	// RENDER FUNCTIONS
 	// =============================================================================
@@ -85,7 +82,7 @@ export const CheckboxGroup = (props: IGenericFieldProps<ICheckboxGroupSchema>) =
 		return (
 			options.length > 0 &&
 			options.map((option, index) => {
-				const checkboxId = formatCheckboxId(id, index);
+				const checkboxId = TestHelper.generateId(id, "checkbox");
 
 				return (
 					<CheckboxContainer key={index}>

--- a/src/components/fields/index.ts
+++ b/src/components/fields/index.ts
@@ -2,6 +2,7 @@ export * from "./checkbox-group";
 export * from "./contact-number";
 export * from "./date-input";
 export * from "./multi-select";
+export * from "./radio-button";
 export * from "./select";
 export * from "./submit-button";
 export * from "./textarea";

--- a/src/components/fields/radio-button/index.ts
+++ b/src/components/fields/radio-button/index.ts
@@ -1,0 +1,2 @@
+export * from "./radio-button";
+export * from "./types";

--- a/src/components/fields/radio-button/radio-button.styles.tsx
+++ b/src/components/fields/radio-button/radio-button.styles.tsx
@@ -1,0 +1,16 @@
+import { RadioButton } from "@lifesg/react-design-system/radio-button";
+import styled from "styled-components";
+
+export const Label = styled.label``;
+
+export const StyledRadioButton = styled(RadioButton)`
+	margin-right: 5px;
+`;
+
+export const RadioContainer = styled.div`
+	display: flex;
+	align-items: center;
+	:not(:last-of-type) {
+		margin-bottom: 1rem;
+	}
+`;

--- a/src/components/fields/radio-button/radio-button.styles.tsx
+++ b/src/components/fields/radio-button/radio-button.styles.tsx
@@ -1,7 +1,13 @@
 import { RadioButton } from "@lifesg/react-design-system/radio-button";
 import styled from "styled-components";
 
-export const Label = styled.label``;
+interface ILabelProps {
+	disabled?: boolean;
+}
+
+export const Label = styled.label<ILabelProps>`
+	cursor: ${(props) => (props.disabled ? "not-allowed" : "pointer")};
+`;
 
 export const StyledRadioButton = styled(RadioButton)`
 	margin-right: 5px;

--- a/src/components/fields/radio-button/radio-button.tsx
+++ b/src/components/fields/radio-button/radio-button.tsx
@@ -1,6 +1,7 @@
 import { Form } from "@lifesg/react-design-system/form";
 import React, { useEffect, useState } from "react";
 import * as Yup from "yup";
+import { TestHelper } from "../../../utils";
 import { useValidationSchema } from "../../../utils/hooks";
 import { IGenericFieldProps } from "../../frontend-engine";
 import { Label, RadioContainer, StyledRadioButton } from "./radio-button.styles";
@@ -30,7 +31,7 @@ export const RadioButtonGroup = (props: IGenericFieldProps<IRadioButtonGroupSche
 	}, [validation]);
 
 	useEffect(() => {
-		setStateValue(value || []);
+		setStateValue(value || "");
 	}, [value]);
 
 	// =============================================================================
@@ -47,10 +48,6 @@ export const RadioButtonGroup = (props: IGenericFieldProps<IRadioButtonGroupSche
 		return stateValue === value;
 	};
 
-	const formatRadioButtonId = (id: string, index: number): string => {
-		return `${id}-${index}`;
-	};
-
 	// =============================================================================
 	// RENDER FUNCTIONS
 	// =============================================================================
@@ -58,7 +55,7 @@ export const RadioButtonGroup = (props: IGenericFieldProps<IRadioButtonGroupSche
 		return (
 			options.length > 0 &&
 			options.map((option, index) => {
-				const radioButtonId = formatRadioButtonId(id, index);
+				const radioButtonId = TestHelper.generateId(id, "radio");
 
 				return (
 					<RadioContainer key={index}>

--- a/src/components/fields/radio-button/radio-button.tsx
+++ b/src/components/fields/radio-button/radio-button.tsx
@@ -71,7 +71,9 @@ export const RadioButtonGroup = (props: IGenericFieldProps<IRadioButtonGroupSche
 							checked={getRadioButtonStatus(option.value)}
 							onChange={handleChange}
 						/>
-						<Label htmlFor={radioButtonId}>{option.label}</Label>
+						<Label htmlFor={radioButtonId} disabled={disabled}>
+							{option.label}
+						</Label>
 					</RadioContainer>
 				);
 			})

--- a/src/components/fields/radio-button/radio-button.tsx
+++ b/src/components/fields/radio-button/radio-button.tsx
@@ -1,0 +1,86 @@
+import { Form } from "@lifesg/react-design-system/form";
+import React, { useEffect, useState } from "react";
+import * as Yup from "yup";
+import { useValidationSchema } from "../../../utils/hooks";
+import { IGenericFieldProps } from "../../frontend-engine";
+import { Label, RadioContainer, StyledRadioButton } from "./radio-button.styles";
+import { IRadioButtonGroupSchema } from "./types";
+
+export const RadioButtonGroup = (props: IGenericFieldProps<IRadioButtonGroupSchema>) => {
+	// =============================================================================
+	// CONST, STATE, REFS
+	// =============================================================================
+	const {
+		schema: { label, options, disabled, validation, ...otherSchema },
+		id,
+		value,
+		error,
+		onChange,
+	} = props;
+
+	const [stateValue, setStateValue] = useState<string>(value || "");
+	const { setFieldValidationConfig } = useValidationSchema();
+
+	// =============================================================================
+	// EFFECTS
+	// =============================================================================
+	useEffect(() => {
+		setFieldValidationConfig(id, Yup.string(), validation);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [validation]);
+
+	useEffect(() => {
+		setStateValue(value || []);
+	}, [value]);
+
+	// =============================================================================
+	// EVENT HANDLERS
+	// =============================================================================
+	const handleChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+		onChange(event);
+	};
+
+	// =============================================================================
+	// HELPER FUNCTIONS
+	// =============================================================================
+	const getRadioButtonStatus = (value: string): boolean => {
+		return stateValue === value;
+	};
+
+	const formatRadioButtonId = (id: string, index: number): string => {
+		return `${id}-${index}`;
+	};
+
+	// =============================================================================
+	// RENDER FUNCTIONS
+	// =============================================================================
+	const renderRadioButtons = () => {
+		return (
+			options.length > 0 &&
+			options.map((option, index) => {
+				const radioButtonId = formatRadioButtonId(id, index);
+
+				return (
+					<RadioContainer key={index}>
+						<StyledRadioButton
+							{...otherSchema}
+							id={radioButtonId}
+							disabled={disabled}
+							name={option.label}
+							value={option.value}
+							checked={getRadioButtonStatus(option.value)}
+							onChange={handleChange}
+						/>
+						<Label htmlFor={radioButtonId}>{option.label}</Label>
+					</RadioContainer>
+				);
+			})
+		);
+	};
+
+	return (
+		<Form.CustomField id={id} label={label} errorMessage={error?.message}>
+			{renderRadioButtons()}
+		</Form.CustomField>
+	);
+};

--- a/src/components/fields/radio-button/types.ts
+++ b/src/components/fields/radio-button/types.ts
@@ -1,0 +1,13 @@
+import { RadioButtonProps } from "@lifesg/react-design-system/radio-button";
+import { IFrontendEngineBaseFieldJsonSchema, TFrontendEngineBaseFieldJsonSchemaKeys } from "../../frontend-engine";
+
+interface IOption {
+	label: string;
+	value: string;
+}
+
+export interface IRadioButtonGroupSchema
+	extends IFrontendEngineBaseFieldJsonSchema<"radio">,
+		Omit<RadioButtonProps, TFrontendEngineBaseFieldJsonSchemaKeys> {
+	options: IOption[];
+}

--- a/src/components/frontend-engine/types.ts
+++ b/src/components/frontend-engine/types.ts
@@ -11,6 +11,7 @@ import {
 	ITextareaSchema,
 	ITextfieldSchema,
 } from "../fields";
+import { IRadioButtonGroupSchema } from "../fields/radio-button/types";
 import { IWrapperSchema } from "../fields/wrapper";
 import { IYupValidationRule, TRenderRules } from "./yup/types";
 
@@ -44,7 +45,8 @@ export type TFrontendEngineFieldSchema =
 	| ICheckboxGroupSchema
 	| IDateInputSchema
 	| IWrapperSchema
-	| IContactNumberSchema;
+	| IContactNumberSchema
+	| IRadioButtonGroupSchema;
 
 export type TFrontendEngineValues<T = any> = Record<keyof T, T[keyof T]>;
 export type TRevalidationMode = Exclude<keyof ValidationMode, "onTouched" | "all">;
@@ -95,6 +97,7 @@ export enum EFieldType {
 	P = "Wrapper",
 	CHECKBOX = "CheckboxGroup",
 	CONTACT = "ContactNumber",
+	RADIO = "RadioButtonGroup",
 }
 
 // =============================================================================

--- a/src/stories/3-fields/radio-button/radio-button.stories.tsx
+++ b/src/stories/3-fields/radio-button/radio-button.stories.tsx
@@ -1,0 +1,105 @@
+import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
+import { Meta, Story } from "@storybook/react/types-6-0";
+import { FrontendEngine } from "../../../components";
+import { IRadioButtonGroupSchema } from "../../../components/fields/radio-button/types";
+import { CommonFieldStoryProps, ExcludeReactFormHookProps, SubmitButtonStorybook } from "../../common";
+
+export default {
+	title: "Field/RadioButton",
+	parameters: {
+		docs: {
+			page: () => (
+				<>
+					<Title>Radio Button</Title>
+					<Description>This component provides a set of radio buttons for user to select</Description>
+					<Heading>Props</Heading>
+					<ArgsTable story={PRIMARY_STORY} />
+					<Stories includePrimary={true} title="Examples" />
+				</>
+			),
+		},
+	},
+	argTypes: {
+		...ExcludeReactFormHookProps,
+		...CommonFieldStoryProps("radio"),
+		"radio-button-default": { table: { disable: true } },
+		disabled: {
+			description: "Specifies if the radio buttons should be disabled",
+			table: {
+				type: {
+					summary: "boolean",
+				},
+			},
+			options: [true, false],
+			control: {
+				type: "boolean",
+			},
+			defaultValue: false,
+		},
+		options: {
+			description: "A list of options that a user can choose from",
+			table: {
+				type: {
+					summary: "IOption[]",
+				},
+			},
+			type: { name: "object", value: {} },
+		},
+		label: {
+			description: "Specifies the label text",
+			table: {
+				type: {
+					summary: "string",
+				},
+			},
+			control: {
+				type: "text",
+			},
+		},
+	},
+} as Meta;
+
+const Template: Story<Record<string, IRadioButtonGroupSchema>> = (args) => (
+	<FrontendEngine data={{ fields: { ...args, ...SubmitButtonStorybook } }} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+	"radio-button-default": {
+		fieldType: "radio",
+		label: "Radio Button",
+		options: [
+			{ label: "Apple", value: "Apple" },
+			{ label: "Berry", value: "Berry" },
+			{ label: "Cherry", value: "Cherry" },
+		],
+	},
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+	"radio-button-disabled": {
+		fieldType: "radio",
+		label: "Radio Button",
+		options: [
+			{ label: "Apple", value: "Apple" },
+			{ label: "Berry", value: "Berry" },
+			{ label: "Cherry", value: "Cherry" },
+		],
+		disabled: true,
+	},
+};
+
+export const WithValidation = Template.bind({});
+WithValidation.args = {
+	"radio-button-with-validation": {
+		fieldType: "radio",
+		label: "Radio Button",
+		options: [
+			{ label: "Apple", value: "Apple" },
+			{ label: "Berry", value: "Berry" },
+			{ label: "Cherry", value: "Cherry" },
+		],
+		validation: [{ required: true }],
+	},
+};

--- a/src/stories/3-fields/radio-button/radio-button.stories.tsx
+++ b/src/stories/3-fields/radio-button/radio-button.stories.tsx
@@ -76,6 +76,27 @@ Default.args = {
 	},
 };
 
+export const DefaultValue = () => (
+	<FrontendEngine
+		data={{
+			fields: {
+				"radio-button-default-value": {
+					fieldType: "radio",
+					label: "Fruits",
+					options: [
+						{ label: "Apple", value: "Apple" },
+						{ label: "Berry", value: "Berry" },
+						{ label: "Cherry", value: "Cherry" },
+					],
+				},
+				...SubmitButtonStorybook,
+			},
+			defaultValues: { "radio-button-default-value": "Apple" },
+		}}
+	/>
+);
+DefaultValue.parameters = { controls: { hideNoControlsWarning: true } };
+
 export const Disabled = Template.bind({});
 Disabled.args = {
 	"radio-button-disabled": {


### PR DESCRIPTION
- Create `RadioButtonGroup` component and corresponding storybook (MOL-11617)
- Standardize container styling for `RadioButtonGroup` and `CheckboxGroup` to open up flexibility for CSS selectors
