### PR TITLE
Fixes

### DIFF
--- a/src/__tests__/components/fields/chips/chips.spec.tsx
+++ b/src/__tests__/components/fields/chips/chips.spec.tsx
@@ -4,12 +4,12 @@ import { FrontendEngine, IFrontendEngineData } from "../../../../components/fron
 import {
 	ERROR_MESSAGE,
 	FRONTEND_ENGINE_ID,
+	TOverrideField,
+	TOverrideSchema,
 	getErrorMessage,
 	getField,
 	getSubmitButton,
 	getSubmitButtonProps,
-	TOverrideField,
-	TOverrideSchema,
 } from "../../../common";
 
 const submitFn = jest.fn();
@@ -110,7 +110,7 @@ describe(fieldType, () => {
 	});
 
 	it("should be able to support single selection", async () => {
-		renderComponent({ multi: false });
+		renderComponent({ validation: [{ max: 1 }] });
 		const apple = getChipA();
 		const berry = getChipB();
 

--- a/src/__tests__/components/fields/textarea/textarea.spec.tsx
+++ b/src/__tests__/components/fields/textarea/textarea.spec.tsx
@@ -5,12 +5,12 @@ import { IFrontendEngineData } from "../../../../components/types";
 import {
 	ERROR_MESSAGE,
 	FRONTEND_ENGINE_ID,
+	TOverrideField,
+	TOverrideSchema,
 	getErrorMessage,
 	getField,
 	getSubmitButton,
 	getSubmitButtonProps,
-	TOverrideField,
-	TOverrideSchema,
 } from "../../../common";
 
 const submitFn = jest.fn();
@@ -67,8 +67,20 @@ describe(fieldType, () => {
 		expect(submitFn).toBeCalledWith(expect.objectContaining({ [componentId]: defaultValue }));
 	});
 
-	it("should be able to show character counter if maxLength is defined", () => {
-		renderComponent({ maxLength: 100 });
+	it("should apply maxLength attribute if max validation is specified", () => {
+		renderComponent({ validation: [{ max: 100 }] });
+
+		expect(getTextarea()).toHaveAttribute("maxLength", "100");
+	});
+
+	it("should apply maxLength attribute if length validation is specified", () => {
+		renderComponent({ validation: [{ length: 100 }] });
+
+		expect(getTextarea()).toHaveAttribute("maxLength", "100");
+	});
+
+	it("should be able to show character counter if max validation is defined", () => {
+		renderComponent({ validation: [{ max: 100 }] });
 
 		expect(screen.getByText("100 characters left")).toBeInTheDocument();
 	});

--- a/src/__tests__/components/fields/textfield/textfield.spec.tsx
+++ b/src/__tests__/components/fields/textfield/textfield.spec.tsx
@@ -5,11 +5,11 @@ import { IFrontendEngineData } from "../../../../components/types";
 import {
 	ERROR_MESSAGE,
 	FRONTEND_ENGINE_ID,
+	TOverrideSchema,
 	getErrorMessage,
 	getField,
 	getSubmitButton,
 	getSubmitButtonProps,
-	TOverrideSchema,
 } from "../../../common";
 
 const submitFn = jest.fn();
@@ -68,6 +68,18 @@ describe("textfield", () => {
 			expect(getTextfield()).toHaveAttribute("inputMode", defaultFieldType);
 		});
 
+		it("should apply maxLength attribute if max validation is specified", () => {
+			renderComponent({ validation: [{ max: 5 }] });
+
+			expect(getTextfield()).toHaveAttribute("maxLength", "5");
+		});
+
+		it("should apply maxLength attribute if length validation is specified", () => {
+			renderComponent({ validation: [{ length: 5 }] });
+
+			expect(getTextfield()).toHaveAttribute("maxLength", "5");
+		});
+
 		it("should support default value", async () => {
 			const defaultValue = "hello";
 			renderComponent(undefined, { defaultValues: { [componentId]: defaultValue } });
@@ -80,13 +92,11 @@ describe("textfield", () => {
 
 		it("should pass other props into the field", () => {
 			renderComponent({
-				maxLength: 10,
 				placeholder: "placeholder",
 				readOnly: true,
 				disabled: true,
 			});
 
-			expect(getTextfield()).toHaveAttribute("maxLength", "10");
 			expect(getTextfield()).toHaveAttribute("placeholder", "placeholder");
 			expect(getTextfield()).toHaveAttribute("readonly");
 			expect(getTextfield()).toBeDisabled();
@@ -130,6 +140,18 @@ describe("textfield", () => {
 			expect(getTextfield()).toHaveAttribute("inputMode", emailFieldType);
 		});
 
+		it("should apply maxLength attribute if max validation is specified", () => {
+			renderComponent({ fieldType: emailFieldType, validation: [{ max: 5 }] });
+
+			expect(getTextfield()).toHaveAttribute("maxLength", "5");
+		});
+
+		it("should apply maxLength attribute if length validation is specified", () => {
+			renderComponent({ fieldType: emailFieldType, validation: [{ length: 5 }] });
+
+			expect(getTextfield()).toHaveAttribute("maxLength", "5");
+		});
+
 		it("should support default value", async () => {
 			const defaultValue = "john@doe.tld";
 			renderComponent({ fieldType: emailFieldType }, { defaultValues: { [componentId]: defaultValue } });
@@ -143,13 +165,11 @@ describe("textfield", () => {
 		it("should pass other props into the field", () => {
 			renderComponent({
 				fieldType: emailFieldType,
-				maxLength: 10,
 				placeholder: "placeholder",
 				readOnly: true,
 				disabled: true,
 			});
 
-			expect(getTextfield()).toHaveAttribute("maxLength", "10");
 			expect(getTextfield()).toHaveAttribute("placeholder", "placeholder");
 			expect(getTextfield()).toHaveAttribute("readOnly");
 			expect(getTextfield()).toBeDisabled();
@@ -182,6 +202,18 @@ describe("textfield", () => {
 			renderComponent({ fieldType: numberFieldType });
 
 			expect(getTextfield()).toHaveAttribute("inputMode", numberFieldType);
+		});
+
+		it("should apply min attribute if min validation is specified", () => {
+			renderComponent({ fieldType: numberFieldType, validation: [{ min: 5 }] });
+
+			expect(getTextfield()).toHaveAttribute("min", "5");
+		});
+
+		it("should apply max attribute if max validation is specified", () => {
+			renderComponent({ fieldType: numberFieldType, validation: [{ max: 5 }] });
+
+			expect(getTextfield()).toHaveAttribute("max", "5");
 		});
 
 		it("should support default value", async () => {

--- a/src/components/fields/chips/chips.tsx
+++ b/src/components/fields/chips/chips.tsx
@@ -1,4 +1,5 @@
 import { Form } from "@lifesg/react-design-system/form";
+import kebabCase from "lodash/kebabCase";
 import { useEffect, useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import * as Yup from "yup";
@@ -15,7 +16,7 @@ export const Chips = (props: IGenericFieldProps<IChipsSchema>) => {
 	// CONST, STATE, REFS
 	// =============================================================================
 	const {
-		schema: { label, validation, options, textarea, multi = true, ...otherSchema },
+		schema: { label, validation, options, textarea, ...otherSchema },
 		id,
 		value,
 		onChange,
@@ -25,6 +26,7 @@ export const Chips = (props: IGenericFieldProps<IChipsSchema>) => {
 
 	const [stateValue, setStateValue] = useState<string[]>(value || []);
 	const [showTextArea, setShowTextArea] = useState<boolean>(false);
+	const [multi, setMulti] = useState(true);
 	const { control } = useFormContext();
 	const { setFieldValidationConfig, removeFieldValidationConfig } = useValidationConfig();
 
@@ -33,6 +35,8 @@ export const Chips = (props: IGenericFieldProps<IChipsSchema>) => {
 	// =============================================================================
 	useEffect(() => {
 		const isRequiredRule = validation?.find((rule) => "required" in rule);
+		const maxRule = validation?.find((rule) => "max" in rule);
+		const lengthRule = validation?.find((rule) => "length" in rule);
 
 		setFieldValidationConfig(
 			id,
@@ -49,6 +53,11 @@ export const Chips = (props: IGenericFieldProps<IChipsSchema>) => {
 				),
 			validation
 		);
+
+		if (maxRule?.max === 1 || lengthRule?.length === 1) {
+			setMulti(false);
+		}
+
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [validation]);
 
@@ -64,7 +73,7 @@ export const Chips = (props: IGenericFieldProps<IChipsSchema>) => {
 	};
 
 	const getTextAreaId = () => {
-		return `chips-${textarea.label}`;
+		return `chips-${kebabCase(textarea.label)}`;
 	};
 
 	// =============================================================================

--- a/src/components/fields/chips/types.ts
+++ b/src/components/fields/chips/types.ts
@@ -14,9 +14,7 @@ export interface IChipsSchema<V = undefined>
 		label: string;
 		validation?: (V | IYupValidationRule)[];
 		resizable?: boolean;
-		maxLength?: number;
 		rows?: number;
 		placeholder?: string;
 	};
-	multi?: boolean;
 }

--- a/src/components/fields/textarea/textarea.tsx
+++ b/src/components/fields/textarea/textarea.tsx
@@ -14,7 +14,7 @@ export const TextArea = (props: IGenericFieldProps<ITextareaSchema>) => {
 	// CONST, STATE, REF
 	// =============================================================================
 	const {
-		schema: { chipTexts, chipPosition, maxLength, rows = 1, resizable, label, validation, ...otherSchema },
+		schema: { chipTexts, chipPosition, rows = 1, resizable, label, validation, ...otherSchema },
 		id,
 		name,
 		onChange,
@@ -23,12 +23,18 @@ export const TextArea = (props: IGenericFieldProps<ITextareaSchema>) => {
 		...otherProps
 	} = props;
 	const [stateValue, setStateValue] = useState<string | number | readonly string[]>(value || "");
+	const [maxLength, setMaxLength] = useState<number>();
 	const { setFieldValidationConfig } = useValidationConfig();
 
 	// =============================================================================
 	// EFFECTS
 	// =============================================================================
 	useEffect(() => {
+		const maxRule = validation?.find((rule) => "max" in rule);
+		const lengthRule = validation?.find((rule) => "length" in rule);
+		if (maxRule?.max > 0) setMaxLength(maxRule.max);
+		else if (lengthRule?.length > 0) setMaxLength(lengthRule.length);
+
 		setFieldValidationConfig(id, Yup.string(), validation);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [validation]);

--- a/src/components/fields/textarea/types.ts
+++ b/src/components/fields/textarea/types.ts
@@ -3,7 +3,7 @@ import { IFrontendEngineBaseFieldJsonSchema, TComponentOmitProps } from "../../f
 
 export interface ITextareaSchema<V = undefined>
 	extends IFrontendEngineBaseFieldJsonSchema<"textarea", V>,
-		TComponentOmitProps<FormTextareaProps> {
+		TComponentOmitProps<FormTextareaProps, "maxLength"> {
 	chipTexts?: string[] | undefined;
 	chipPosition?: "top" | "bottom" | undefined;
 	resizable?: boolean | undefined;

--- a/src/components/fields/textfield/textfield.tsx
+++ b/src/components/fields/textfield/textfield.tsx
@@ -35,28 +35,48 @@ export const TextField = (props: IGenericFieldProps<ITextfieldSchema | IEmailSch
 				const minRule = validation?.find((rule) => "min" in rule);
 				const maxRule = validation?.find((rule) => "max" in rule);
 				const attributes = { ...derivedAttributes };
-				if (minRule) {
+				if (minRule?.min > 0) {
 					attributes.min = minRule.min;
 				}
-				if (maxRule) {
+				if (maxRule?.max > 0) {
 					attributes.max = maxRule.max;
 				}
 				setDerivedAttributes(attributes);
 				break;
 			}
-			case "email":
-				{
-					const emailRule = validation?.find((rule) => rule.email);
-					setFieldValidationConfig(
-						id,
-						Yup.string().email(emailRule?.errorMessage || ERROR_MESSAGES.EMAIL.INVALID),
-						validation
-					);
+			case "email": {
+				const emailRule = validation?.find((rule) => rule.email);
+				setFieldValidationConfig(
+					id,
+					Yup.string().email(emailRule?.errorMessage || ERROR_MESSAGES.EMAIL.INVALID),
+					validation
+				);
+
+				const maxRule = validation?.find((rule) => "max" in rule);
+				const lengthRule = validation?.find((rule) => "length" in rule);
+				const attributes = { ...derivedAttributes };
+				if (maxRule?.max > 0) {
+					attributes.maxLength = maxRule.max;
+				} else if (lengthRule?.length > 0) {
+					attributes.maxLength = lengthRule.length;
 				}
+				setDerivedAttributes(attributes);
 				break;
-			case "text":
+			}
+			case "text": {
 				setFieldValidationConfig(id, Yup.string(), validation);
+
+				const maxRule = validation?.find((rule) => "max" in rule);
+				const lengthRule = validation?.find((rule) => "length" in rule);
+				const attributes = { ...derivedAttributes };
+				if (maxRule?.max > 0) {
+					attributes.maxLength = maxRule.max;
+				} else if (lengthRule?.length > 0) {
+					attributes.maxLength = lengthRule.length;
+				}
+				setDerivedAttributes(attributes);
 				break;
+			}
 			default:
 				break;
 		}

--- a/src/components/fields/textfield/types.ts
+++ b/src/components/fields/textfield/types.ts
@@ -3,11 +3,11 @@ import { IFrontendEngineBaseFieldJsonSchema, TComponentOmitProps } from "../../f
 
 export interface ITextfieldSchema<V = undefined>
 	extends IFrontendEngineBaseFieldJsonSchema<"text", V>,
-		TComponentOmitProps<FormInputProps, "type"> {}
+		TComponentOmitProps<FormInputProps, "type" | "maxLength"> {}
 
 export interface IEmailSchema<V = undefined>
 	extends IFrontendEngineBaseFieldJsonSchema<"email", V>,
-		TComponentOmitProps<FormInputProps, "type"> {}
+		TComponentOmitProps<FormInputProps, "type" | "maxLength"> {}
 
 export interface INumberSchema<V = undefined>
 	extends IFrontendEngineBaseFieldJsonSchema<"numeric", V>,

--- a/src/components/frontend-engine/yup/helper.ts
+++ b/src/components/frontend-engine/yup/helper.ts
@@ -122,22 +122,34 @@ export namespace YupHelper {
 				case !!rule.positive:
 				case !!rule.negative:
 				case !!rule.integer:
-					yupSchema = (yupSchema as unknown)[ruleKey](rule.errorMessage);
+					try {
+						yupSchema = (yupSchema as unknown)[ruleKey](rule.errorMessage);
+					} catch (error) {
+						console.warn(`error applying "${ruleKey}" condition to ${yupSchema.type} schema`);
+					}
 					break;
 				case rule.length > 0:
 				case rule.min > 0:
 				case rule.max > 0:
 				case !!rule.lessThan:
 				case !!rule.moreThan:
-					yupSchema = (yupSchema as unknown)[ruleKey](rule[ruleKey], rule.errorMessage);
+					try {
+						yupSchema = (yupSchema as unknown)[ruleKey](rule[ruleKey], rule.errorMessage);
+					} catch (error) {
+						console.warn(`error applying "${ruleKey}" condition to ${yupSchema.type} schema`);
+					}
 					break;
 				case !!rule.matches:
 					{
 						const matches = rule.matches.match(/\/(.*)\/([a-z]+)?/);
-						yupSchema = (yupSchema as Yup.StringSchema).matches(
-							new RegExp(matches[1], matches[2]),
-							rule.errorMessage
-						);
+						try {
+							yupSchema = (yupSchema as Yup.StringSchema).matches(
+								new RegExp(matches[1], matches[2]),
+								rule.errorMessage
+							);
+						} catch (error) {
+							console.warn(`error applying "${ruleKey}" condition to ${yupSchema.type} schema`);
+						}
 					}
 					break;
 				case !!rule.when:
@@ -202,7 +214,7 @@ export namespace YupHelper {
 		fn: (value: unknown, arg: unknown, context: Yup.TestContext) => boolean
 	) => {
 		if (customYupConditions.includes(name)) {
-			console.error(`the validation condition "${name}" is not added because it already exists!`);
+			console.warn(`the validation condition "${name}" is not added because it already exists!`);
 			return;
 		}
 		customYupConditions.push(name);

--- a/src/components/frontend-engine/yup/types.ts
+++ b/src/components/frontend-engine/yup/types.ts
@@ -56,6 +56,7 @@ export interface IYupValidationRule extends IYupRule {
 					is: string | number | boolean | string[] | number[] | boolean[] | IYupConditionalValidationRule[];
 					then: Omit<IYupValidationRule, "when">[];
 					otherwise?: Omit<IYupValidationRule, "when">[];
+					yupSchema?: Yup.AnySchema | undefined;
 				};
 		  }
 		| undefined;

--- a/src/stories/2-frontend-engine/validation/validation-component.tsx
+++ b/src/stories/2-frontend-engine/validation/validation-component.tsx
@@ -1,19 +1,26 @@
 import { Button } from "@lifesg/react-design-system/button";
 import styled from "styled-components";
 import * as Yup from "yup";
-import { IYupValidationRule, TYupSchemaType, YupHelper } from "../../../components/frontend-engine/yup";
+import {
+	IFieldYupConfig,
+	IYupValidationRule,
+	TYupSchemaType,
+	YupHelper,
+} from "../../../components/frontend-engine/yup";
 
 export interface IValidationComponentProps {
 	type: TYupSchemaType;
 	rule: IYupValidationRule;
 	value: Record<string, any>;
+	extraFields?: Record<string, IFieldYupConfig>;
 }
 
-export const ValidationComponent = ({ type, rule, value }: IValidationComponentProps) => {
+export const ValidationComponent = ({ type, rule, value, extraFields }: IValidationComponentProps) => {
 	const handleClick = () => {
 		try {
 			const hardSchema = YupHelper.buildSchema({
 				name: { schema: (Yup as any)[type](), validationRules: [rule] },
+				...(extraFields || {}),
 			});
 			hardSchema.validateSync(value);
 			alert("Validation passed");

--- a/src/stories/2-frontend-engine/validation/validation-conditional.stories.tsx
+++ b/src/stories/2-frontend-engine/validation/validation-conditional.stories.tsx
@@ -1,3 +1,4 @@
+import * as Yup from "yup";
 import { Description, Stories, Title } from "@storybook/addon-docs";
 import { Meta, Story } from "@storybook/react/types-6-0";
 import { IValidationComponentProps, ValidationComponent } from "./validation-component";
@@ -29,7 +30,7 @@ export default {
 } as Meta;
 
 const Template: Story<IValidationComponentProps> = (args) => (
-	<ValidationComponent type={args.type} rule={args.rule} value={args.value} />
+	<ValidationComponent type={args.type} rule={args.rule} value={args.value} extraFields={args.extraFields} />
 );
 
 export const IfExactValue = Template.bind({});
@@ -55,6 +56,7 @@ IfExactValue.args = {
 		},
 	},
 	value: { name: undefined, field2: "something" },
+	extraFields: { field2: { schema: Yup.string(), validationRules: [] } },
 };
 
 export const SchemaAsCondition = Template.bind({});
@@ -80,4 +82,5 @@ SchemaAsCondition.args = {
 		},
 	},
 	value: { field2: "something" },
+	extraFields: { field2: { schema: Yup.string(), validationRules: [] } },
 };

--- a/src/stories/3-fields/checkbox-group/checkbox-group.stories.tsx
+++ b/src/stories/3-fields/checkbox-group/checkbox-group.stories.tsx
@@ -28,12 +28,12 @@ export default {
 				type: {
 					summary: "boolean",
 				},
+				defaultValue: { summary: "default" },
 			},
 			options: ["default", "small"],
 			control: {
 				type: "select",
 			},
-			defaultValue: "default",
 		},
 		disabled: {
 			description: "Specifies if the checkbox should be disabled",
@@ -41,12 +41,12 @@ export default {
 				type: {
 					summary: "boolean",
 				},
+				defaultValue: { summary: false },
 			},
 			options: [true, false],
 			control: {
 				type: "boolean",
 			},
-			defaultValue: false,
 		},
 		options: {
 			description: "A list of options that a user can choose from",

--- a/src/stories/3-fields/chips/chips.stories.tsx
+++ b/src/stories/3-fields/chips/chips.stories.tsx
@@ -195,6 +195,20 @@ WithTextAreaCustomRows.args = {
 	},
 };
 
+export const WithTextAreaMaxLength = Template.bind({});
+WithTextAreaMaxLength.args = {
+	"chips-with-textarea-max-length": {
+		fieldType: "chips",
+		label: "Fruits",
+		options: [
+			{ label: "Apple", value: "Apple" },
+			{ label: "Berry", value: "Berry" },
+			{ label: "Cherry", value: "Cherry" },
+		],
+		textarea: { label: "Durian", rows: 1, validation: [{ max: 10 }] },
+	},
+};
+
 export const SingleSelection = Template.bind({});
 SingleSelection.args = {
 	"chips-single-selection": {
@@ -205,6 +219,6 @@ SingleSelection.args = {
 			{ label: "Berry", value: "Berry" },
 			{ label: "Cherry", value: "Cherry" },
 		],
-		multi: false,
+		validation: [{ max: 1 }],
 	},
 };

--- a/src/stories/3-fields/chips/chips.stories.tsx
+++ b/src/stories/3-fields/chips/chips.stories.tsx
@@ -54,12 +54,12 @@ export default {
 				type: {
 					summary: "boolean",
 				},
+				defaultValue: { summary: true },
 			},
 			options: [true, false],
 			control: {
 				type: "boolean",
 			},
-			defaultValue: true,
 		},
 	},
 } as Meta;

--- a/src/stories/3-fields/chips/chips.stories.tsx
+++ b/src/stories/3-fields/chips/chips.stories.tsx
@@ -48,19 +48,6 @@ export default {
 			},
 			type: { name: "object", value: {} },
 		},
-		multi: {
-			description: "Specifies if the component supports multiple selection",
-			table: {
-				type: {
-					summary: "boolean",
-				},
-				defaultValue: { summary: true },
-			},
-			options: [true, false],
-			control: {
-				type: "boolean",
-			},
-		},
 	},
 } as Meta;
 

--- a/src/stories/3-fields/contact-number/contact-number.stories.tsx
+++ b/src/stories/3-fields/contact-number/contact-number.stories.tsx
@@ -53,12 +53,12 @@ export default {
 				type: {
 					summary: "boolean",
 				},
+				defaultValue: { summary: false },
 			},
 			options: [true, false],
 			control: {
 				type: "boolean",
 			},
-			defaultValue: false,
 		},
 		disabled: {
 			description: "Specifies if the input should be disabled",
@@ -66,12 +66,12 @@ export default {
 				type: {
 					summary: "boolean",
 				},
+				defaultValue: { summary: false },
 			},
 			options: [true, false],
 			control: {
 				type: "boolean",
 			},
-			defaultValue: false,
 		},
 	},
 } as Meta;

--- a/src/stories/3-fields/date-input/date-input.stories.tsx
+++ b/src/stories/3-fields/date-input/date-input.stories.tsx
@@ -30,11 +30,11 @@ export default {
 				type: {
 					summary: "boolean",
 				},
+				defaultValue: { summary: false },
 			},
 			control: {
 				type: "boolean",
 			},
-			defaultValue: false,
 		},
 		dateFormat: {
 			description: `Date input and output format pattern string using <a href="https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html" target="_blank" rel="noopener noreferrer">Java SimpleDateFormat code</a><br>Note: This does not change the date format presented in the field.`,
@@ -42,11 +42,11 @@ export default {
 				type: {
 					summary: "string",
 				},
+				defaultValue: { summary: "uuuu-MM-dd" },
 			},
 			control: {
 				type: "text",
 			},
-			defaultValue: "uuuu-MM-dd",
 		},
 		validation: {
 			description:

--- a/src/stories/3-fields/email/email.stories.tsx
+++ b/src/stories/3-fields/email/email.stories.tsx
@@ -27,17 +27,6 @@ export default {
 	argTypes: {
 		...ExcludeReactFormHookProps,
 		...CommonFieldStoryProps("email"),
-		maxLength: {
-			description: "A specified maximum length for the value of the form element",
-			table: {
-				type: {
-					summary: "number",
-				},
-			},
-			control: {
-				type: "number",
-			},
-		},
 		placeholder: {
 			description: "Specifies the placeholder text",
 			table: {

--- a/src/stories/3-fields/email/email.stories.tsx
+++ b/src/stories/3-fields/email/email.stories.tsx
@@ -55,12 +55,12 @@ export default {
 				type: {
 					summary: "boolean",
 				},
+				defaultValue: { summary: false },
 			},
 			options: [true, false],
 			control: {
 				type: "boolean",
 			},
-			defaultValue: false,
 		},
 	},
 } as Meta;

--- a/src/stories/3-fields/email/email.stories.tsx
+++ b/src/stories/3-fields/email/email.stories.tsx
@@ -118,7 +118,7 @@ MaxLength.args = {
 	"textfield-maxlength": {
 		label: "Email",
 		fieldType: "email",
-		maxLength: 5,
+		validation: [{ max: 5 }],
 	},
 };
 

--- a/src/stories/3-fields/multi-select/multi-select.stories.tsx
+++ b/src/stories/3-fields/multi-select/multi-select.stories.tsx
@@ -29,12 +29,12 @@ export default {
 				type: {
 					summary: "boolean",
 				},
+				defaultValue: { summary: false },
 			},
 			options: [true, false],
 			control: {
 				type: "boolean",
 			},
-			defaultValue: false,
 		},
 		options: {
 			description: "A list of options that a user can choose from",

--- a/src/stories/3-fields/number/number.stories.tsx
+++ b/src/stories/3-fields/number/number.stories.tsx
@@ -44,12 +44,12 @@ export default {
 				type: {
 					summary: "boolean",
 				},
+				defaultValue: { summary: false },
 			},
 			options: [true, false],
 			control: {
 				type: "boolean",
 			},
-			defaultValue: false,
 		},
 	},
 } as Meta;

--- a/src/stories/3-fields/radio-button/radio-button.stories.tsx
+++ b/src/stories/3-fields/radio-button/radio-button.stories.tsx
@@ -28,12 +28,12 @@ export default {
 				type: {
 					summary: "boolean",
 				},
+				defaultValue: { summary: false },
 			},
 			options: [true, false],
 			control: {
 				type: "boolean",
 			},
-			defaultValue: false,
 		},
 		options: {
 			description: "A list of options that a user can choose from",

--- a/src/stories/3-fields/select/select.stories.tsx
+++ b/src/stories/3-fields/select/select.stories.tsx
@@ -27,12 +27,12 @@ export default {
 				type: {
 					summary: "boolean",
 				},
+				defaultValue: { summary: false },
 			},
 			options: [true, false],
 			control: {
 				type: "boolean",
 			},
-			defaultValue: false,
 		},
 		options: {
 			description: "A list of options that a user can choose from",

--- a/src/stories/3-fields/submit-button/submit-button.stories.tsx
+++ b/src/stories/3-fields/submit-button/submit-button.stories.tsx
@@ -45,12 +45,12 @@ export default {
 				type: {
 					summary: "boolean",
 				},
+				defaultValue: { summary: false },
 			},
 			options: [true, false],
 			control: {
 				type: "boolean",
 			},
-			defaultValue: false,
 		},
 	},
 } as Meta;

--- a/src/stories/3-fields/textarea/textarea.stories.tsx
+++ b/src/stories/3-fields/textarea/textarea.stories.tsx
@@ -49,7 +49,6 @@ export default {
 			control: {
 				type: "select",
 			},
-			defaultValue: "top",
 			options: ["top", "bottom"],
 		},
 		resizable: {
@@ -63,7 +62,6 @@ export default {
 			control: {
 				type: "boolean",
 			},
-			defaultValue: false,
 		},
 		maxLength: {
 			description:
@@ -83,7 +81,6 @@ export default {
 				},
 				defaultValue: { summary: 1 },
 			},
-			defaultValue: 1,
 			type: { name: "number" },
 		},
 		validation: {

--- a/src/stories/3-fields/textarea/textarea.stories.tsx
+++ b/src/stories/3-fields/textarea/textarea.stories.tsx
@@ -63,16 +63,6 @@ export default {
 				type: "boolean",
 			},
 		},
-		maxLength: {
-			description:
-				"Maximum number of characters that can go into the textarea. (Inherited from HTMLTextAreaElement). This brings up the character counter under the field.",
-			table: {
-				type: {
-					summary: "number",
-				},
-			},
-			type: { name: "number" },
-		},
 		rows: {
 			description: "Visible height of a text area, in lines (Inherited from HTMLTextAreaElement)",
 			table: {

--- a/src/stories/3-fields/textarea/textarea.stories.tsx
+++ b/src/stories/3-fields/textarea/textarea.stories.tsx
@@ -141,7 +141,7 @@ WithCounter.args = {
 	"textarea-with-counter": {
 		fieldType: "textarea",
 		label: "Textarea with counter",
-		maxLength: 5,
+		validation: [{ max: 5 }],
 	},
 };
 

--- a/src/stories/3-fields/textfield/textfield.stories.tsx
+++ b/src/stories/3-fields/textfield/textfield.stories.tsx
@@ -40,17 +40,6 @@ export default {
 				type: "select",
 			},
 		},
-		maxLength: {
-			description: "A specified maximum length for the value of the form element",
-			table: {
-				type: {
-					summary: "number",
-				},
-			},
-			control: {
-				type: "number",
-			},
-		},
 		placeholder: {
 			description: "Specifies the placeholder text",
 			table: {

--- a/src/stories/3-fields/textfield/textfield.stories.tsx
+++ b/src/stories/3-fields/textfield/textfield.stories.tsx
@@ -68,12 +68,12 @@ export default {
 				type: {
 					summary: "boolean",
 				},
+				defaultValue: { summary: false },
 			},
 			options: [true, false],
 			control: {
 				type: "boolean",
 			},
-			defaultValue: false,
 		},
 	},
 } as Meta;

--- a/src/stories/3-fields/textfield/textfield.stories.tsx
+++ b/src/stories/3-fields/textfield/textfield.stories.tsx
@@ -122,7 +122,7 @@ MaxLength.args = {
 	"text-maxlength": {
 		label: "Textfield",
 		fieldType: "text",
-		maxLength: 5,
+		validation: [{ max: 5 }],
 	},
 };
 

--- a/src/stories/3-fields/time-picker/time-picker.stories.tsx
+++ b/src/stories/3-fields/time-picker/time-picker.stories.tsx
@@ -39,12 +39,12 @@ export default {
 				type: {
 					summary: "boolean",
 				},
+				defaultValue: { summary: false },
 			},
 			options: [true, false],
 			control: {
 				type: "boolean",
 			},
-			defaultValue: false,
 		},
 		useCurrentTime: {
 			description: "Specifies if the form element should default to current time",
@@ -52,12 +52,12 @@ export default {
 				type: {
 					summary: "boolean",
 				},
+				defaultValue: { summary: false },
 			},
 			options: [true, false],
 			control: {
 				type: "boolean",
 			},
-			defaultValue: false,
 		},
 		is24HourFormat: {
 			description: "Specifies if the form element should use 24 hours time format",
@@ -65,12 +65,12 @@ export default {
 				type: {
 					summary: "boolean",
 				},
+				defaultValue: { summary: false },
 			},
 			options: [true, false],
 			control: {
 				type: "boolean",
 			},
-			defaultValue: false,
 		},
 	},
 } as Meta;

--- a/src/stories/4-elements/text/text.stories.tsx
+++ b/src/stories/4-elements/text/text.stories.tsx
@@ -80,7 +80,6 @@ export default {
 			control: {
 				type: "select",
 			},
-			defaultValue: "text-bodynbp",
 		},
 		weight: {
 			description: "The weight of the text component",
@@ -88,12 +87,12 @@ export default {
 				type: {
 					summary: '"regular" | "semibold" | "bold" | "light"',
 				},
+				defaultValue: { summary: "regular" },
 			},
 			options: ["regular", "semibold", "bold", "light"],
 			control: {
 				type: "select",
 			},
-			defaultValue: "regular",
 		},
 		inline: {
 			description: "Sets the text to an inline display to allow a combination of components in a single line",
@@ -101,12 +100,12 @@ export default {
 				type: {
 					summary: "boolean",
 				},
+				defaultValue: { summary: false },
 			},
 			options: [true, false],
 			control: {
 				type: "boolean",
 			},
-			defaultValue: false,
 		},
 		paragraph: {
 			description:
@@ -115,12 +114,12 @@ export default {
 				type: {
 					summary: "boolean",
 				},
+				defaultValue: { summary: false },
 			},
 			options: [true, false],
 			control: {
 				type: "boolean",
 			},
-			defaultValue: false,
 		},
 	},
 } as Meta;


### PR DESCRIPTION
- MOL-12158
- updated conditional rendering to infer the correct yup type of the source field
- added descriptive error on applying invalid yup rule and replace console.error with console.warn
- moved storybook `defaultValue` to under table, otherwise it will add unnecessary codes to code preview
- Applied text/email/textarea maxLength attribute according to max / length validation config
- Derive chips multi selection from validation config