### PR TITLE
[VAL][WL] change default validationMode to onTouched

### DIFF
--- a/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
+++ b/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
@@ -384,6 +384,21 @@ describe("frontend-engine", () => {
 			await waitFor(() => fireEvent.change(getFieldOne(), { target: { value: "h" } }));
 			expect(getErrorMessage()).toBeInTheDocument();
 		});
+
+		it("should support onTouched validationMode", async () => {
+			renderComponent(undefined, { validationMode: "onTouched" });
+
+			expect(getErrorMessage(true)).not.toBeInTheDocument();
+
+			await waitFor(() => fireEvent.change(getFieldOne(), { target: { value: "h" } }));
+			expect(getErrorMessage(true)).not.toBeInTheDocument();
+
+			await waitFor(() => fireEvent.blur(getFieldOne()));
+			expect(getErrorMessage()).toBeInTheDocument();
+
+			await waitFor(() => fireEvent.change(getFieldOne(), { target: { value: "he" } }));
+			expect(getErrorMessage(true)).not.toBeInTheDocument();
+		});
 	});
 
 	describe("revalidationMode", () => {

--- a/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
+++ b/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
@@ -356,14 +356,19 @@ describe("frontend-engine", () => {
 	});
 
 	describe("validationMode", () => {
-		it("should validate on submit by default", async () => {
+		it("should support validate on touched by default", async () => {
 			renderComponent();
 
-			fireEvent.change(getFieldOne(), { target: { value: "h" } });
 			expect(getErrorMessage(true)).not.toBeInTheDocument();
 
-			await waitFor(() => fireEvent.click(getSubmitButton()));
+			await waitFor(() => fireEvent.change(getFieldOne(), { target: { value: "h" } }));
+			expect(getErrorMessage(true)).not.toBeInTheDocument();
+
+			await waitFor(() => fireEvent.blur(getFieldOne()));
 			expect(getErrorMessage()).toBeInTheDocument();
+
+			await waitFor(() => fireEvent.change(getFieldOne(), { target: { value: "he" } }));
+			expect(getErrorMessage(true)).not.toBeInTheDocument();
 		});
 
 		it("should support onBlur validationMode", async () => {
@@ -385,19 +390,17 @@ describe("frontend-engine", () => {
 			expect(getErrorMessage()).toBeInTheDocument();
 		});
 
-		it("should support onTouched validationMode", async () => {
-			renderComponent(undefined, { validationMode: "onTouched" });
+		it("should support onSubmit validationMode", async () => {
+			renderComponent();
 
+			fireEvent.change(getFieldOne(), { target: { value: "h" } });
 			expect(getErrorMessage(true)).not.toBeInTheDocument();
 
-			await waitFor(() => fireEvent.change(getFieldOne(), { target: { value: "h" } }));
+			fireEvent.blur(getFieldOne());
 			expect(getErrorMessage(true)).not.toBeInTheDocument();
 
-			await waitFor(() => fireEvent.blur(getFieldOne()));
+			await waitFor(() => fireEvent.click(getSubmitButton()));
 			expect(getErrorMessage()).toBeInTheDocument();
-
-			await waitFor(() => fireEvent.change(getFieldOne(), { target: { value: "he" } }));
-			expect(getErrorMessage(true)).not.toBeInTheDocument();
 		});
 
 		it("should support all validationMode", async () => {

--- a/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
+++ b/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
@@ -399,6 +399,16 @@ describe("frontend-engine", () => {
 			await waitFor(() => fireEvent.change(getFieldOne(), { target: { value: "he" } }));
 			expect(getErrorMessage(true)).not.toBeInTheDocument();
 		});
+
+		it("should support all validationMode", async () => {
+			renderComponent(undefined, { validationMode: "all" });
+
+			await waitFor(() => fireEvent.blur(getFieldOne()));
+			expect(getErrorMessage()).toBeInTheDocument();
+
+			await waitFor(() => fireEvent.change(getFieldOne(), { target: { value: "h" } }));
+			expect(getErrorMessage(true)).toBeInTheDocument();
+		});
 	});
 
 	describe("revalidationMode", () => {

--- a/src/components/frontend-engine/frontend-engine.tsx
+++ b/src/components/frontend-engine/frontend-engine.tsx
@@ -20,7 +20,7 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 			sections,
 			id,
 			revalidationMode = "onChange",
-			validationMode = "onSubmit",
+			validationMode = "onTouched",
 		},
 		className = null,
 		onChange,

--- a/src/stories/2-frontend-engine/frontend-engine.stories.tsx
+++ b/src/stories/2-frontend-engine/frontend-engine.stories.tsx
@@ -197,7 +197,7 @@ const Template: Story<IFrontendEngineProps> = (args) => <FrontendEngine {...args
 export const Default = Template.bind({});
 Default.args = {
 	data: {
-		validationMode: "onSubmit",
+		validationMode: "onTouched",
 		revalidationMode: "onChange",
 		...DATA,
 	},
@@ -221,10 +221,10 @@ ValidateOnBlur.args = {
 	},
 };
 
-export const ValidateOnTouched = Template.bind({});
-ValidateOnTouched.args = {
+export const ValidateOnSubmit = Template.bind({});
+ValidateOnSubmit.args = {
 	data: {
-		validationMode: "onTouched",
+		validationMode: "onSubmit",
 		revalidationMode: "onChange",
 		...DATA,
 	},

--- a/src/stories/2-frontend-engine/frontend-engine.stories.tsx
+++ b/src/stories/2-frontend-engine/frontend-engine.stories.tsx
@@ -141,7 +141,7 @@ export default {
 		},
 		"data.revalidationMode": {
 			description:
-				" Validation strategy when inputs with errors get re-validated after a user submits the form (onSubmit event).",
+				"Validation strategy when inputs with errors get re-validated after a user submits the form (onSubmit event). Refer to React Hook Form's <a href='https://react-hook-form.com/api/useform/#props' target='_blank' rel='noopener noreferrer'>documentation</a> for more info.",
 			table: {
 				type: {
 					summary: "TRevalidationMode",
@@ -153,14 +153,15 @@ export default {
 			},
 		},
 		"data.validationMode": {
-			description: "Validation strategy before a user submits the form (onSubmit event)",
+			description:
+				"Validation strategy before a user submits the form (onSubmit event). RRefer to React Hook Form's <a href='https://react-hook-form.com/api/useform/#props' target='_blank' rel='noopener noreferrer'>documentation</a> for more info.",
 			table: {
 				type: {
 					summary: "TValidationMode",
-					detail: "onBlur | onChange | onSubmit",
+					detail: "onBlur | onChange | onSubmit | onTouched",
 				},
 				defaultValue: {
-					summary: "onSubmit",
+					summary: "onTouched",
 				},
 			},
 		},
@@ -215,6 +216,15 @@ export const ValidateOnBlur = Template.bind({});
 ValidateOnBlur.args = {
 	data: {
 		validationMode: "onBlur",
+		revalidationMode: "onChange",
+		...DATA,
+	},
+};
+
+export const ValidateOnTouched = Template.bind({});
+ValidateOnTouched.args = {
+	data: {
+		validationMode: "onTouched",
 		revalidationMode: "onChange",
 		...DATA,
 	},

--- a/src/stories/2-frontend-engine/frontend-engine.stories.tsx
+++ b/src/stories/2-frontend-engine/frontend-engine.stories.tsx
@@ -158,7 +158,7 @@ export default {
 			table: {
 				type: {
 					summary: "TValidationMode",
-					detail: "onBlur | onChange | onSubmit | onTouched",
+					detail: "onBlur | onChange | onSubmit | onTouched | all",
 				},
 				defaultValue: {
 					summary: "onTouched",
@@ -230,8 +230,16 @@ ValidateOnTouched.args = {
 	},
 };
 
-export const OnChange: Story<IFrontendEngineProps> = (args: IFrontendEngineProps) => <FrontendEngine {...args} />;
+export const ValidateOnAll = Template.bind({});
+ValidateOnAll.args = {
+	data: {
+		validationMode: "all",
+		revalidationMode: "onChange",
+		...DATA,
+	},
+};
 
+export const OnChange: Story<IFrontendEngineProps> = (args: IFrontendEngineProps) => <FrontendEngine {...args} />;
 OnChange.args = {
 	data: DATA,
 	onChange: (values, isValid) => action("change")(values, isValid),


### PR DESCRIPTION
**Changes**
- Changed default `validationMode` from `onSubmit` to `onTouched`
- Delete branch

**Changelog entry**
-   Changed default `validationMode` to `onTouched`

**Additional information**
- Reference of `onTouched` behaviour: https://react-hook-form.com/api/useform/#props
- Context: The `onTouched` behaviour is the behaviour that all our forms are using, have checked with UX and various teams regarding this
