### PR TITLE
Event listeners

### DIFF
--- a/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
+++ b/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@lifesg/react-design-system/button";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useEffect, useRef } from "react";
 import { FrontendEngine } from "../../../components";
@@ -454,5 +455,48 @@ describe("frontend-engine", () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 			expect(getErrorMessage()).toBeInTheDocument();
 		});
+	});
+
+	it("should allow adding, dispatching and removing of field event listener", () => {
+		const testFn = jest.fn();
+		const eventName = "my-event";
+
+		const FrontendEngineWithEvent = () => {
+			const ref = useRef<IFrontendEngineRef>();
+			const handleAddFieldEventListener = () => {
+				ref.current?.addFieldEventListener(eventName, FIELD_ONE_ID, testFn);
+			};
+			const handleDispatchFieldEventListener = () => {
+				ref.current?.dispatchFieldEvent(eventName, FIELD_ONE_ID);
+			};
+			const handleRemoveFieldEventListener = () => {
+				ref.current?.removeFieldEventListener(eventName, FIELD_ONE_ID, testFn);
+			};
+
+			return (
+				<>
+					<FrontendEngine ref={ref} data={JSON_SCHEMA} />
+					<Button.Default onClick={handleAddFieldEventListener}>Add field event listener</Button.Default>
+					<Button.Default onClick={handleDispatchFieldEventListener}>
+						Dispatch field event listener
+					</Button.Default>
+					<Button.Default onClick={handleRemoveFieldEventListener}>
+						Remove field event listener
+					</Button.Default>
+				</>
+			);
+		};
+		render(<FrontendEngineWithEvent />);
+
+		fireEvent.click(screen.getByRole("button", { name: "Dispatch field event listener" }));
+		expect(testFn).not.toBeCalled();
+
+		fireEvent.click(screen.getByRole("button", { name: "Add field event listener" }));
+		fireEvent.click(screen.getByRole("button", { name: "Dispatch field event listener" }));
+		expect(testFn).toBeCalledTimes(1);
+
+		fireEvent.click(screen.getByRole("button", { name: "Remove field event listener" }));
+		fireEvent.click(screen.getByRole("button", { name: "Dispatch field event listener" }));
+		expect(testFn).toBeCalledTimes(1);
 	});
 });

--- a/src/components/frontend-engine/event/context-provider.tsx
+++ b/src/components/frontend-engine/event/context-provider.tsx
@@ -1,0 +1,23 @@
+import { createContext, ReactElement, useRef } from "react";
+
+/**
+ * events are added / removed / dispatched via the eventManager
+ * the eventManager is just a div, the handling of events is purely through native event handlers
+ */
+interface IEventContext {
+	eventManager: Element;
+}
+
+interface IProps {
+	children: ReactElement;
+}
+
+export const EventContext = createContext<IEventContext>({
+	eventManager: null,
+});
+
+export const EventProvider = ({ children }: IProps) => {
+	const eventManager = useRef<Element>(document?.createElement("div"));
+
+	return <EventContext.Provider value={{ eventManager: eventManager.current }}>{children}</EventContext.Provider>;
+};

--- a/src/components/frontend-engine/event/context-provider.tsx
+++ b/src/components/frontend-engine/event/context-provider.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactElement, useRef } from "react";
+import { ReactElement, createContext, useRef } from "react";
 
 /**
  * events are added / removed / dispatched via the eventManager

--- a/src/components/frontend-engine/event/index.ts
+++ b/src/components/frontend-engine/event/index.ts
@@ -1,0 +1,1 @@
+export * from "./context-provider";

--- a/src/components/frontend-engine/frontend-engine.tsx
+++ b/src/components/frontend-engine/frontend-engine.tsx
@@ -4,8 +4,9 @@ import { ReactElement, Ref, forwardRef, useCallback, useEffect, useImperativeHan
 import { FormProvider, useForm } from "react-hook-form";
 import { useDeepCompareEffectNoCheck } from "use-deep-compare-effect";
 import { ObjectHelper, TestHelper } from "../../utils";
-import { useValidationSchema } from "../../utils/hooks";
+import { useFieldEvent, useValidationSchema } from "../../utils/hooks";
 import { Sections } from "../elements/sections";
+import { EventProvider } from "./event";
 import { IFrontendEngineProps, IFrontendEngineRef, TErrorPayload, TFrontendEngineValues, TNoInfer } from "./types";
 import { IYupValidationRule, YupHelper, YupProvider } from "./yup";
 
@@ -27,6 +28,7 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 		onSubmit,
 	} = props;
 
+	const { addFieldEventListener, dispatchFieldEvent, removeFieldEventListener } = useFieldEvent();
 	const { warnings, performSoftValidation, softValidationSchema, hardValidationSchema } = useValidationSchema();
 	const formMethods = useForm({
 		mode: validationMode,
@@ -56,13 +58,16 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 	// HELPER FUNCTIONS
 	// =============================================================================
 	useImperativeHandle<Partial<IFrontendEngineRef>, Partial<IFrontendEngineRef>>(ref, () => ({
-		getValues,
-		setValue,
-		isValid: checkIsFormValid,
-		submit: reactFormHookSubmit(handleSubmit),
+		addFieldEventListener,
 		addCustomValidation: YupHelper.addCondition,
-		setErrors,
+		dispatchFieldEvent,
+		getValues,
+		isValid: checkIsFormValid,
+		removeFieldEventListener,
 		reset,
+		setErrors,
+		setValue,
+		submit: reactFormHookSubmit(handleSubmit),
 	}));
 
 	const checkIsFormValid = useCallback(() => {
@@ -179,7 +184,9 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 export const FrontendEngine = forwardRef<IFrontendEngineRef, IFrontendEngineProps>((props, ref) => {
 	return (
 		<YupProvider>
-			<FrontendEngineInner {...props} ref={ref} />
+			<EventProvider>
+				<FrontendEngineInner {...props} ref={ref} />
+			</EventProvider>
 		</YupProvider>
 	);
 }) as <V = undefined>(

--- a/src/components/frontend-engine/types.ts
+++ b/src/components/frontend-engine/types.ts
@@ -98,25 +98,37 @@ export type TValidationMode = keyof ValidationMode;
 export type TErrorMessage = string | string[] | Record<string, string | string[]>;
 export type TErrorPayload = Record<string, TErrorMessage>;
 export interface IFrontendEngineRef extends HTMLFormElement {
-	/** gets form values */
-	getValues: () => TFrontendEngineValues;
-	/** sets field value by id */
-	setValue: UseFormSetValue<TFrontendEngineValues>;
-	/** checks if form is valid */
-	isValid: () => boolean;
-	/** triggers form submission */
-	submit: () => void;
-	/** adds custom validation rule */
 	addCustomValidation: (
 		type: TYupSchemaType | "mixed",
 		name: string,
 		fn: (value: unknown, arg: unknown) => boolean
 	) => void;
-
-	/** allows setting of custom errors thrown by endpoints */
-	setErrors: (errors: TErrorPayload) => void;
+	addFieldEventListener: (
+		type: string,
+		id: string,
+		listener: (this: Element, ev: Event) => any,
+		options?: boolean | AddEventListenerOptions
+	) => void;
+	dispatchFieldEvent: (type: string, id: string, detail?: any) => boolean;
+	/** gets form values */
+	getValues: () => TFrontendEngineValues;
+	/** checks if form is valid */
+	isValid: () => boolean;
+	/** adds custom validation rule */
+	removeFieldEventListener: (
+		type: string,
+		id: string,
+		listener: (this: Element, ev: Event) => any,
+		options?: boolean | EventListenerOptions
+	) => void;
 	/** resets the form to the default state */
 	reset: UseFormReset<TFrontendEngineValues>;
+	/** allows setting of custom errors thrown by endpoints */
+	setErrors: (errors: TErrorPayload) => void;
+	/** sets field value by id */
+	setValue: UseFormSetValue<TFrontendEngineValues>;
+	/** triggers form submission */
+	submit: () => void;
 }
 
 // =============================================================================

--- a/src/components/frontend-engine/types.ts
+++ b/src/components/frontend-engine/types.ts
@@ -106,7 +106,7 @@ export interface IFrontendEngineRef extends HTMLFormElement {
 	addFieldEventListener: (
 		type: string,
 		id: string,
-		listener: (this: Element, ev: Event) => any,
+		listener: (ev: Event) => any,
 		options?: boolean | AddEventListenerOptions
 	) => void;
 	dispatchFieldEvent: (type: string, id: string, detail?: any) => boolean;
@@ -118,7 +118,7 @@ export interface IFrontendEngineRef extends HTMLFormElement {
 	removeFieldEventListener: (
 		type: string,
 		id: string,
-		listener: (this: Element, ev: Event) => any,
+		listener: (ev: Event) => any,
 		options?: boolean | EventListenerOptions
 	) => void;
 	/** resets the form to the default state */

--- a/src/utils/hooks/index.ts
+++ b/src/utils/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from "./use-field-event";
 export * from "./use-previous";
 export * from "./use-validation-config";
 export * from "./use-validation-schema";

--- a/src/utils/hooks/use-field-event.ts
+++ b/src/utils/hooks/use-field-event.ts
@@ -1,0 +1,36 @@
+import { useContext } from "react";
+import { EventContext } from "../../components/frontend-engine/event";
+
+/**
+ * Hook that interacts with the event context provider
+ * use this hook to add/dispatch/remove event listeners
+ */
+export const useFieldEvent = () => {
+	const { eventManager } = useContext(EventContext);
+
+	const addFieldEventListener = (
+		type: string,
+		id: string,
+		listener: (this: Element, ev: Event) => unknown,
+		options?: boolean | AddEventListenerOptions
+	) => {
+		eventManager?.addEventListener(`${id}:${type}`, listener, options);
+	};
+
+	const removeFieldEventListener = (
+		type: string,
+		id: string,
+		listener: (this: Element, ev: Event) => unknown,
+		options?: boolean | AddEventListenerOptions
+	) => {
+		eventManager?.removeEventListener(`${id}:${type}`, listener, options);
+	};
+
+	const dispatchFieldEvent = (type: string, id: string, detail?: any): boolean => {
+		return eventManager?.dispatchEvent(
+			new CustomEvent(`${id}:${type}`, { cancelable: true, detail: { id, ...detail } })
+		);
+	};
+
+	return { addFieldEventListener, dispatchFieldEvent, removeFieldEventListener };
+};

--- a/src/utils/hooks/use-field-event.ts
+++ b/src/utils/hooks/use-field-event.ts
@@ -21,7 +21,7 @@ export const useFieldEvent = () => {
 		type: string,
 		id: string,
 		listener: (ev: Event) => unknown,
-		options?: boolean | AddEventListenerOptions
+		options?: boolean | EventListenerOptions
 	) => {
 		eventManager?.removeEventListener(`${id}:${type}`, listener, options);
 	};

--- a/src/utils/hooks/use-field-event.ts
+++ b/src/utils/hooks/use-field-event.ts
@@ -11,7 +11,7 @@ export const useFieldEvent = () => {
 	const addFieldEventListener = (
 		type: string,
 		id: string,
-		listener: (this: Element, ev: Event) => unknown,
+		listener: (ev: Event) => unknown,
 		options?: boolean | AddEventListenerOptions
 	) => {
 		eventManager?.addEventListener(`${id}:${type}`, listener, options);
@@ -20,7 +20,7 @@ export const useFieldEvent = () => {
 	const removeFieldEventListener = (
 		type: string,
 		id: string,
-		listener: (this: Element, ev: Event) => unknown,
+		listener: (ev: Event) => unknown,
 		options?: boolean | AddEventListenerOptions
 	) => {
 		eventManager?.removeEventListener(`${id}:${type}`, listener, options);


### PR DESCRIPTION
**Changes**
- Implement event listeners to frontend engine
- Delete branch

**Additional information**
- Implementation is from `image-upload` branch
- This is to be used by `image-upload` and `location-input` to fire LifeSG-specific events
- No stories added; they will be added for fields using events instead
