### PR TITLE
Reset

### DIFF
--- a/src/__tests__/common/data.ts
+++ b/src/__tests__/common/data.ts
@@ -1,4 +1,6 @@
 export const SUBMIT_BUTTON_ID = "submit";
 export const SUBMIT_BUTTON_LABEL = "Submit";
+export const RESET_BUTTON_ID = "reset";
+export const RESET_BUTTON_LABEL = "Reset";
 export const ERROR_MESSAGE = "test error message";
 export const FRONTEND_ENGINE_ID = "test";

--- a/src/__tests__/common/helper.ts
+++ b/src/__tests__/common/helper.ts
@@ -1,6 +1,6 @@
 import { ByRoleOptions, screen } from "@testing-library/react";
 import { TFrontendEngineFieldSchema } from "../../components/frontend-engine";
-import { ERROR_MESSAGE, SUBMIT_BUTTON_ID, SUBMIT_BUTTON_LABEL } from "./data";
+import { ERROR_MESSAGE, RESET_BUTTON_ID, RESET_BUTTON_LABEL, SUBMIT_BUTTON_ID, SUBMIT_BUTTON_LABEL } from "./data";
 
 type TAriaRoles = "textbox" | "generic" | "button" | "spinbutton" | "radio" | "list";
 
@@ -8,11 +8,24 @@ export const getSubmitButton = (): HTMLElement => {
 	return screen.getByRole("button", { name: SUBMIT_BUTTON_LABEL });
 };
 
+export const getResetButton = (): HTMLElement => {
+	return screen.getByRole("button", { name: RESET_BUTTON_LABEL });
+};
+
 export const getSubmitButtonProps = (): Record<string, TFrontendEngineFieldSchema> => {
 	return {
 		[SUBMIT_BUTTON_ID]: {
 			label: SUBMIT_BUTTON_LABEL,
 			uiType: "submit",
+		},
+	};
+};
+
+export const getResetButtonProps = (): Record<string, TFrontendEngineFieldSchema> => {
+	return {
+		[RESET_BUTTON_ID]: {
+			label: RESET_BUTTON_LABEL,
+			uiType: "reset",
 		},
 	};
 };

--- a/src/__tests__/components/fields/checkbox-group/checkbox-group.spec.tsx
+++ b/src/__tests__/components/fields/checkbox-group/checkbox-group.spec.tsx
@@ -9,6 +9,8 @@ import {
 	TOverrideField,
 	TOverrideSchema,
 	getErrorMessage,
+	getResetButton,
+	getResetButtonProps,
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
@@ -34,6 +36,7 @@ const renderComponent = (overrideField?: TOverrideField<ICheckboxGroupSchema>, o
 						...overrideField,
 					},
 					...getSubmitButtonProps(),
+					...getResetButtonProps(),
 				},
 			},
 		},
@@ -228,5 +231,35 @@ describe(UI_TYPE, () => {
 				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
 			}
 		);
+	});
+
+	describe("reset", () => {
+		it("should clear selection on reset", async () => {
+			renderComponent();
+
+			const checkboxes = getCheckboxes();
+			fireEvent.click(checkboxes[0]);
+			fireEvent.click(checkboxes[1]);
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(checkboxes[0].nextElementSibling).not.toBeInTheDocument();
+			expect(checkboxes[1].nextElementSibling).not.toBeInTheDocument();
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		});
+
+		it("should revert to default value on reset", async () => {
+			const defaultValues = ["Apple"];
+			renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: defaultValues } });
+
+			const checkboxes = getCheckboxes();
+			fireEvent.click(checkboxes[1]);
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(checkboxes[0].nextElementSibling.tagName).toBe("svg");
+			expect(checkboxes[1].nextElementSibling).not.toBeInTheDocument();
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
+		});
 	});
 });

--- a/src/__tests__/components/fields/checkbox-group/checkbox-toggle-group.spec.tsx
+++ b/src/__tests__/components/fields/checkbox-group/checkbox-toggle-group.spec.tsx
@@ -9,6 +9,8 @@ import {
 	TOverrideField,
 	TOverrideSchema,
 	getErrorMessage,
+	getResetButton,
+	getResetButtonProps,
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
@@ -37,6 +39,7 @@ const renderComponent = (overrideField?: TOverrideField<ICheckboxGroupSchema>, o
 						...overrideField,
 					},
 					...getSubmitButtonProps(),
+					...getResetButtonProps(),
 				},
 			},
 		},
@@ -213,5 +216,35 @@ describe("checkbox toggle group", () => {
 				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
 			}
 		);
+	});
+
+	describe("reset", () => {
+		it("should clear selection on reset", async () => {
+			renderComponent();
+
+			const checkboxes = getToggles();
+			fireEvent.click(checkboxes[0]);
+			fireEvent.click(checkboxes[1]);
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(checkboxes[0]).not.toBeChecked();
+			expect(checkboxes[1]).not.toBeChecked();
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		});
+
+		it("should revert to default value on reset", async () => {
+			const defaultValues = ["Apple"];
+			renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: defaultValues } });
+
+			const checkboxes = getToggles();
+			fireEvent.click(checkboxes[1]);
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(checkboxes[0]).toBeChecked();
+			expect(checkboxes[1]).not.toBeChecked();
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
+		});
 	});
 });

--- a/src/__tests__/components/fields/contact-field/contact-field.spec.tsx
+++ b/src/__tests__/components/fields/contact-field/contact-field.spec.tsx
@@ -10,6 +10,8 @@ import {
 	TOverrideSchema,
 	getErrorMessage,
 	getField,
+	getResetButton,
+	getResetButtonProps,
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
@@ -34,6 +36,7 @@ const renderComponent = (overrideField?: TOverrideField<IContactFieldSchema>, ov
 						...overrideField,
 					},
 					...getSubmitButtonProps(),
+					...getResetButtonProps(),
 				},
 			},
 		},
@@ -260,6 +263,31 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			expect(screen.getByText(ERROR_MESSAGES.CONTACT.INVALID_INTERNATIONAL_NUMBER)).toBeInTheDocument();
+		});
+	});
+
+	describe("reset", () => {
+		it("should clear selection on reset", async () => {
+			renderComponent();
+
+			fireEvent.change(getContactField(), { target: { value: "91234567" } });
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(getContactField()).toHaveValue("");
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		});
+
+		it("should revert to default value on reset", async () => {
+			const defaultValues = "91234567";
+			renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: defaultValues } });
+
+			fireEvent.change(getContactField(), { target: { value: "987654321" } });
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(getContactField()).toHaveValue("9123 4567");
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
 		});
 	});
 });

--- a/src/__tests__/components/fields/multi-select/multi-select.spec.tsx
+++ b/src/__tests__/components/fields/multi-select/multi-select.spec.tsx
@@ -11,6 +11,8 @@ import {
 	TOverrideSchema,
 	getErrorMessage,
 	getField,
+	getResetButton,
+	getResetButtonProps,
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
@@ -36,6 +38,7 @@ const renderComponent = (overrideField?: TOverrideField<IMultiSelectSchema>, ove
 						...overrideField,
 					},
 					...getSubmitButtonProps(),
+					...getResetButtonProps(),
 				},
 			},
 		},
@@ -203,5 +206,43 @@ describe(UI_TYPE, () => {
 				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
 			}
 		);
+	});
+
+	describe("reset", () => {
+		it("should clear selection on reset", async () => {
+			renderComponent();
+
+			fireEvent.click(getComponent());
+			const apple = getCheckboxA();
+			const berry = getCheckboxB();
+
+			fireEvent.click(apple);
+			fireEvent.click(berry);
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(screen.getByText("Select")).toBeInTheDocument();
+			expect(apple.querySelector("svg")).not.toBeInTheDocument();
+			expect(berry.querySelector("svg")).not.toBeInTheDocument();
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		});
+
+		it("should revert to default value on reset", async () => {
+			const defaultValues = ["Apple"];
+			renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: defaultValues } });
+
+			fireEvent.click(getField("button", "1 selected"));
+			const apple = getCheckboxA();
+			const berry = getCheckboxB();
+
+			fireEvent.click(berry);
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(screen.getByText("1 selected")).toBeInTheDocument();
+			expect(apple.querySelector("svg")).toBeInTheDocument();
+			expect(berry.querySelector("svg")).not.toBeInTheDocument();
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
+		});
 	});
 });

--- a/src/__tests__/components/fields/radio-button/radio-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-button.spec.tsx
@@ -11,6 +11,8 @@ import {
 	TOverrideSchema,
 	getErrorMessage,
 	getField,
+	getResetButton,
+	getResetButtonProps,
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
@@ -44,6 +46,7 @@ const renderComponent = (overrideField?: TOverrideField<IRadioButtonGroupSchema>
 						...overrideField,
 					},
 					...getSubmitButtonProps(),
+					...getResetButtonProps(),
 				},
 			},
 		},
@@ -172,5 +175,35 @@ describe(UI_TYPE, () => {
 				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
 			}
 		);
+	});
+
+	describe("reset", () => {
+		it("should clear selection on reset", async () => {
+			renderComponent();
+			const apple = getRadioButtonA();
+
+			fireEvent.click(apple);
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(apple).not.toBeChecked();
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		});
+
+		it("should revert to default value on reset", async () => {
+			const defaultValue = "Apple";
+			renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: defaultValue } });
+
+			const apple = getRadioButtonA();
+			const berry = getRadioButtonB();
+
+			fireEvent.click(berry);
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(apple).toBeChecked();
+			expect(berry).not.toBeChecked();
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		});
 	});
 });

--- a/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
@@ -11,6 +11,8 @@ import {
 	TOverrideSchema,
 	getErrorMessage,
 	getField,
+	getResetButton,
+	getResetButtonProps,
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
@@ -47,6 +49,7 @@ const renderComponent = (overrideField?: TOverrideField<IRadioButtonGroupSchema>
 						...overrideField,
 					},
 					...getSubmitButtonProps(),
+					...getResetButtonProps(),
 				},
 			},
 		},
@@ -180,5 +183,35 @@ describe("radio toggle button", () => {
 				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
 			}
 		);
+	});
+
+	describe("reset", () => {
+		it("should clear selection on reset", async () => {
+			renderComponent();
+			const apple = getRadioButtonA();
+
+			fireEvent.click(apple);
+			await waitFor(() => fireEvent.click(getResetButton()));
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(apple).not.toBeChecked();
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		});
+
+		it("should revert to default value on reset", async () => {
+			const defaultValue = "Apple";
+			renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: defaultValue } });
+
+			const apple = getRadioButtonA();
+			const berry = getRadioButtonB();
+
+			fireEvent.click(berry);
+			await waitFor(() => fireEvent.click(getResetButton()));
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(apple).toBeChecked();
+			expect(berry).not.toBeChecked();
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		});
 	});
 });

--- a/src/__tests__/components/fields/select/select.spec.tsx
+++ b/src/__tests__/components/fields/select/select.spec.tsx
@@ -11,6 +11,8 @@ import {
 	TOverrideSchema,
 	getErrorMessage,
 	getField,
+	getResetButton,
+	getResetButtonProps,
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
@@ -36,6 +38,7 @@ const renderComponent = (overrideField?: TOverrideField<ICheckboxGroupSchema>, o
 						...overrideField,
 					},
 					...getSubmitButtonProps(),
+					...getResetButtonProps(),
 				},
 			},
 		},
@@ -150,5 +153,32 @@ describe(UI_TYPE, () => {
 				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
 			}
 		);
+	});
+
+	describe("reset", () => {
+		it("should clear selection on reset", async () => {
+			renderComponent();
+
+			fireEvent.click(getSelectToggle());
+			fireEvent.click(screen.getByRole("button", { name: "A" }));
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(screen.getByTestId(COMPONENT_ID)).toHaveTextContent("Select");
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		});
+
+		it("should revert to default value on reset", async () => {
+			const defaultValue = "Apple";
+			renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: defaultValue } });
+
+			fireEvent.click(getField("button", "A"));
+			fireEvent.click(screen.getByRole("button", { name: "B" }));
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(screen.getByTestId(COMPONENT_ID)).toHaveTextContent("A");
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		});
 	});
 });

--- a/src/__tests__/components/fields/text-field/text-field.spec.tsx
+++ b/src/__tests__/components/fields/text-field/text-field.spec.tsx
@@ -9,6 +9,8 @@ import {
 	TOverrideSchema,
 	getErrorMessage,
 	getField,
+	getResetButton,
+	getResetButtonProps,
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
@@ -36,6 +38,7 @@ const renderComponent = (
 						...overrideField,
 					},
 					...getSubmitButtonProps(),
+					...getResetButtonProps(),
 				},
 			},
 		},
@@ -155,6 +158,31 @@ describe(DEFAULT_FIELD_TYPE, () => {
 		const textField = getTextfield();
 		const event = fireEvent.drop(textField, { target: { value: EXPECTED_TEXT } });
 		expect(event).toBe(true);
+	});
+
+	describe("reset", () => {
+		it("should clear selection on reset", async () => {
+			renderComponent();
+
+			fireEvent.change(getTextfield(), { target: { value: "hello" } });
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(getTextfield()).toHaveValue("");
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		});
+
+		it("should revert to default value on reset", async () => {
+			const defaultValue = "hello";
+			renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: defaultValue } });
+
+			fireEvent.change(getTextfield(), { target: { value: "world" } });
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(getTextfield()).toHaveValue(defaultValue);
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		});
 	});
 });
 
@@ -281,6 +309,31 @@ describe(EMAIL_FIELD_TYPE, () => {
 		const event = fireEvent.drop(textField, { target: { value: EXPECTED_EMAIL } });
 		expect(event).toBe(true);
 	});
+
+	describe("reset", () => {
+		it("should clear selection on reset", async () => {
+			renderComponent({ uiType: EMAIL_FIELD_TYPE });
+
+			fireEvent.change(getTextfield(), { target: { value: "john@doe.com" } });
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(getTextfield()).toHaveValue("");
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		});
+
+		it("should revert to default value on reset", async () => {
+			const defaultValue = "john@doe.com";
+			renderComponent({ uiType: EMAIL_FIELD_TYPE }, { defaultValues: { [COMPONENT_ID]: defaultValue } });
+
+			fireEvent.change(getTextfield(), { target: { value: "lorem@ipsum.com" } });
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(getTextfield()).toHaveValue(defaultValue);
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		});
+	});
 });
 
 describe(NUMERIC_FIELD_TYPE, () => {
@@ -396,5 +449,30 @@ describe(NUMERIC_FIELD_TYPE, () => {
 		const textField = getTextfield();
 		const event = fireEvent.drop(textField, { target: { value: EXPECTED_NUMBER } });
 		expect(event).toBe(true);
+	});
+
+	describe("reset", () => {
+		it("should clear selection on reset", async () => {
+			renderComponent({ uiType: NUMERIC_FIELD_TYPE });
+
+			fireEvent.change(getTextfield("spinbutton"), { target: { value: 1 } });
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(getTextfield("spinbutton")).toHaveValue(null);
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		});
+
+		it("should revert to default value on reset", async () => {
+			const defaultValue = 1;
+			renderComponent({ uiType: NUMERIC_FIELD_TYPE }, { defaultValues: { [COMPONENT_ID]: defaultValue } });
+
+			fireEvent.change(getTextfield("spinbutton"), { target: { value: 2 } });
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(getTextfield("spinbutton")).toHaveValue(defaultValue);
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		});
 	});
 });

--- a/src/__tests__/components/fields/textarea/textarea.spec.tsx
+++ b/src/__tests__/components/fields/textarea/textarea.spec.tsx
@@ -9,6 +9,8 @@ import {
 	TOverrideSchema,
 	getErrorMessage,
 	getField,
+	getResetButton,
+	getResetButtonProps,
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
@@ -31,6 +33,7 @@ const renderComponent = (overrideField?: TOverrideField<ITextareaSchema>, overri
 						...overrideField,
 					},
 					...getSubmitButtonProps(),
+					...getResetButtonProps(),
 				},
 			},
 		},
@@ -121,5 +124,30 @@ describe(UI_TYPE, () => {
 		expect(getTextarea()).toHaveAttribute("placeholder", "placeholder");
 		expect(getTextarea()).toHaveAttribute("readonly");
 		expect(getTextarea()).toBeDisabled();
+	});
+
+	describe("reset", () => {
+		it("should clear selection on reset", async () => {
+			renderComponent();
+
+			fireEvent.change(getTextarea(), { target: { value: "hello" } });
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(getTextarea()).toHaveValue("");
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		});
+
+		it("should revert to default value on reset", async () => {
+			const defaultValue = "hello";
+			renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: defaultValue } });
+
+			fireEvent.change(getTextarea(), { target: { value: "world" } });
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(getTextarea()).toHaveValue(defaultValue);
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		});
 	});
 });

--- a/src/__tests__/components/fields/time-field/time-field.spec.tsx
+++ b/src/__tests__/components/fields/time-field/time-field.spec.tsx
@@ -144,11 +144,11 @@ describe(UI_TYPE, () => {
 		it("should clear selection on reset", async () => {
 			renderComponent();
 
-			fireEvent.click(getTimePicker());
-			fireEvent.click(getMinuteButton());
-			fireEvent.click(getHourButton());
-			fireEvent.click(getConfirmButton());
-			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getTimePicker()));
+			await waitFor(() => fireEvent.click(getMinuteButton()));
+			await waitFor(() => fireEvent.click(getHourButton()));
+			await waitFor(() => fireEvent.click(getConfirmButton()));
+			await waitFor(() => fireEvent.click(getResetButton()));
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			await waitFor(() => expect(getTimePicker()).toHaveValue(""));
@@ -159,11 +159,11 @@ describe(UI_TYPE, () => {
 			const defaultValue = "11:11am";
 			renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: defaultValue } });
 
-			fireEvent.click(getTimePicker());
-			fireEvent.click(getMinuteButton());
-			fireEvent.click(getHourButton());
-			fireEvent.click(getConfirmButton());
-			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getTimePicker()));
+			await waitFor(() => fireEvent.click(getMinuteButton()));
+			await waitFor(() => fireEvent.click(getHourButton()));
+			await waitFor(() => fireEvent.click(getConfirmButton()));
+			await waitFor(() => fireEvent.click(getResetButton()));
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			await waitFor(() => expect(getTimePicker()).toHaveValue(defaultValue));
@@ -175,11 +175,11 @@ describe(UI_TYPE, () => {
 			jest.spyOn(LocalTime, "now").mockReturnValue(LocalTime.parse(currentTime));
 			renderComponent({ useCurrentTime: true });
 
-			fireEvent.click(getTimePicker());
-			fireEvent.click(getMinuteButton());
-			fireEvent.click(getHourButton());
-			fireEvent.click(getConfirmButton());
-			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getTimePicker()));
+			await waitFor(() => fireEvent.click(getMinuteButton()));
+			await waitFor(() => fireEvent.click(getHourButton()));
+			await waitFor(() => fireEvent.click(getConfirmButton()));
+			await waitFor(() => fireEvent.click(getResetButton()));
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			await waitFor(() => expect(getTimePicker()).toHaveValue(`${currentTime}pm`));

--- a/src/__tests__/components/fields/unit-number-field/unit-number.spec.tsx
+++ b/src/__tests__/components/fields/unit-number-field/unit-number.spec.tsx
@@ -7,6 +7,8 @@ import {
 	TOverrideField,
 	TOverrideSchema,
 	getField,
+	getResetButton,
+	getResetButtonProps,
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
@@ -30,6 +32,7 @@ const renderComponent = (overrideField?: TOverrideField<IUnitNumberFieldSchema>,
 						...overrideField,
 					},
 					...getSubmitButtonProps(),
+					...getResetButtonProps(),
 				},
 			},
 		},
@@ -123,6 +126,39 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			expect(screen.getByText(customError)).toBeInTheDocument();
+		});
+	});
+
+	describe("reset", () => {
+		it("should clear selection on reset", async () => {
+			const floorNumber = "01";
+			const unitNumber = "20";
+			renderComponent();
+
+			fireEvent.change(getFloorInputField(), { target: { value: floorNumber } });
+			fireEvent.change(getUnitInputField(), { target: { value: unitNumber } });
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(getFloorInputField()).toHaveValue("");
+			expect(getUnitInputField()).toHaveValue("");
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		});
+
+		it("should revert to default value on reset", async () => {
+			const defaultFloor = "01";
+			const defaultUnit = "20";
+			const defaultValue = `${defaultFloor}-${defaultUnit}`;
+			renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: defaultValue } });
+
+			fireEvent.change(getFloorInputField(), { target: { value: "12" } });
+			fireEvent.change(getUnitInputField(), { target: { value: "34" } });
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(getFloorInputField()).toHaveValue(defaultFloor);
+			expect(getUnitInputField()).toHaveValue(defaultUnit);
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 		});
 	});
 });

--- a/src/components/fields/chips/chips.tsx
+++ b/src/components/fields/chips/chips.tsx
@@ -62,7 +62,8 @@ export const Chips = (props: IGenericFieldProps<IChipsSchema>) => {
 	}, [validation]);
 
 	useDeepCompareEffect(() => {
-		const updatedValues = value?.filter((v) => options.find((option) => option.value === v));
+		const optionValuesWithTextarea = [...options.map((option) => option.value), textarea?.label];
+		const updatedValues = value?.filter((v) => optionValuesWithTextarea.includes(v));
 		setValue(id, updatedValues);
 	}, [options]);
 
@@ -90,6 +91,7 @@ export const Chips = (props: IGenericFieldProps<IChipsSchema>) => {
 		setShowTextarea(show);
 		if (!show) {
 			removeFieldValidationConfig(getTextareaId());
+			setValue(getTextareaId(), undefined);
 		}
 	};
 
@@ -169,7 +171,7 @@ export const Chips = (props: IGenericFieldProps<IChipsSchema>) => {
 			<Controller
 				control={control}
 				name={textareaId}
-				shouldUnregister={true}
+				shouldUnregister={false}
 				render={({ field, fieldState }) => {
 					const fieldProps = { ...field, id: textareaId, ref: undefined };
 					return <Textarea schema={schema} {...fieldProps} {...fieldState} />;

--- a/src/components/fields/chips/chips.tsx
+++ b/src/components/fields/chips/chips.tsx
@@ -1,5 +1,4 @@
 import { Form } from "@lifesg/react-design-system/form";
-import kebabCase from "lodash/kebabCase";
 import { useEffect, useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import useDeepCompareEffect from "use-deep-compare-effect";
@@ -68,6 +67,11 @@ export const Chips = (props: IGenericFieldProps<IChipsSchema>) => {
 	}, [options]);
 
 	useEffect(() => {
+		if (value?.includes(textarea?.label)) {
+			toggleTextarea(true);
+		} else {
+			toggleTextarea();
+		}
 		setStateValue(value || []);
 	}, [value]);
 
@@ -80,6 +84,13 @@ export const Chips = (props: IGenericFieldProps<IChipsSchema>) => {
 
 	const getTextareaId = () => {
 		return `${id}-textarea`;
+	};
+
+	const toggleTextarea = (show = false) => {
+		setShowTextarea(show);
+		if (!show) {
+			removeFieldValidationConfig(getTextareaId());
+		}
 	};
 
 	// =============================================================================
@@ -107,12 +118,6 @@ export const Chips = (props: IGenericFieldProps<IChipsSchema>) => {
 
 	const handleTextareaChipClick = (name: string) => {
 		handleChange(name);
-		setShowTextarea((prevState) => {
-			if (prevState) {
-				removeFieldValidationConfig(getTextareaId());
-			}
-			return !prevState;
-		});
 	};
 
 	// =============================================================================

--- a/src/components/fields/contact-field/contact-field.tsx
+++ b/src/components/fields/contact-field/contact-field.tsx
@@ -107,6 +107,12 @@ export const ContactField = (props: IGenericFieldProps<IContactFieldSchema>) => 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [validation, defaultCountry]);
 
+	// handle changes in value through reset
+	useEffect(() => {
+		const { number } = PhoneHelper.getParsedPhoneNumber(value || "");
+		setStateValue(number);
+	}, [value]);
+
 	// =============================================================================
 	// EVENT HANDLERS
 	// =============================================================================

--- a/src/components/fields/date-field/date-field.tsx
+++ b/src/components/fields/date-field/date-field.tsx
@@ -7,6 +7,7 @@ import { useValidationConfig } from "../../../utils/hooks";
 import { IGenericFieldProps } from "../../frontend-engine/types";
 import { ERROR_MESSAGES } from "../../shared";
 import { IDateFieldSchema } from "./types";
+import { useFormContext } from "react-hook-form";
 
 const DEFAULT_DATE_FORMAT = "uuuu-MM-dd";
 export const DateField = (props: IGenericFieldProps<IDateFieldSchema>) => {
@@ -16,11 +17,13 @@ export const DateField = (props: IGenericFieldProps<IDateFieldSchema>) => {
 	const {
 		schema: { label, useCurrentDate, dateFormat = DEFAULT_DATE_FORMAT, validation, ...otherSchema },
 		id,
+		isDirty,
 		onChange,
 		value,
 		error,
 		...otherProps
 	} = props;
+	const { setValue } = useFormContext();
 	const [stateValue, setStateValue] = useState<string>(value || ""); // always uuuu-MM-dd because it is passed to Form.DateInput
 	const { setFieldValidationConfig } = useValidationConfig();
 
@@ -108,14 +111,24 @@ export const DateField = (props: IGenericFieldProps<IDateFieldSchema>) => {
 	useEffect(() => {
 		if (!dateFormat) return;
 
-		if (useCurrentDate && !value) {
-			const currentDate = DateTimeHelper.formatDateTime(LocalDate.now().toString(), dateFormat, "date");
-			// need delay to allow onChange event to fire properly
-			setTimeout(() => onChange({ target: { value: currentDate } }));
+		if (!value) {
+			if (!isDirty) {
+				// runs on mount and reset
+				if (useCurrentDate) {
+					const currentDate = DateTimeHelper.formatDateTime(LocalDate.now().toString(), dateFormat, "date");
+					setValue(id, currentDate, { shouldDirty: true });
 
-			const inputDate = DateTimeHelper.formatDateTime(LocalDate.now().toString(), DEFAULT_DATE_FORMAT, "date");
-			setStateValue(inputDate);
-		} else if (value && !isValidDate(value)) {
+					const inputDate = DateTimeHelper.formatDateTime(
+						LocalDate.now().toString(),
+						DEFAULT_DATE_FORMAT,
+						"date"
+					);
+					setStateValue(inputDate);
+				} else {
+					setStateValue(undefined);
+				}
+			}
+		} else if (!isValidDate(value)) {
 			setStateValue(ERROR_MESSAGES.DATE.INVALID);
 		} else {
 			const localDate = DateTimeHelper.toLocalDateOrTime(value, dateFormat, "date"); // convert to LocalDate first to parse defaultValue
@@ -129,7 +142,7 @@ export const DateField = (props: IGenericFieldProps<IDateFieldSchema>) => {
 			);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [useCurrentDate, value, dateFormat]);
+	}, [useCurrentDate, value, dateFormat, isDirty]);
 
 	// =============================================================================
 	// EVENT HANDLER
@@ -137,7 +150,7 @@ export const DateField = (props: IGenericFieldProps<IDateFieldSchema>) => {
 	const handleChange = ([day, month, year]: string[]) => {
 		if (!day && !month && !year) {
 			onChange({
-				target: { value: undefined },
+				target: { value: "" },
 			});
 		} else if (day.length < 2 || month.length < 2 || year.length < 4) {
 			onChange({

--- a/src/components/fields/date-field/date-field.tsx
+++ b/src/components/fields/date-field/date-field.tsx
@@ -110,7 +110,8 @@ export const DateField = (props: IGenericFieldProps<IDateFieldSchema>) => {
 
 		if (useCurrentDate && !value) {
 			const currentDate = DateTimeHelper.formatDateTime(LocalDate.now().toString(), dateFormat, "date");
-			onChange({ target: { value: currentDate } });
+			// need delay to allow onChange event to fire properly
+			setTimeout(() => onChange({ target: { value: currentDate } }));
 
 			const inputDate = DateTimeHelper.formatDateTime(LocalDate.now().toString(), DEFAULT_DATE_FORMAT, "date");
 			setStateValue(inputDate);

--- a/src/components/fields/textarea/textarea.tsx
+++ b/src/components/fields/textarea/textarea.tsx
@@ -40,7 +40,7 @@ export const Textarea = (props: IGenericFieldProps<ITextareaSchema>) => {
 	}, [validation]);
 
 	useEffect(() => {
-		setStateValue(value);
+		setStateValue(value || "");
 	}, [value]);
 
 	// =============================================================================

--- a/src/components/fields/textarea/textarea.tsx
+++ b/src/components/fields/textarea/textarea.tsx
@@ -8,6 +8,7 @@ import { IGenericFieldProps } from "../../frontend-engine/types";
 import { Chip } from "../../shared";
 import { ChipContainer, StyledTextarea, Wrapper } from "./textarea.styles";
 import { ITextareaSchema } from "./types";
+import { useFormContext } from "react-hook-form";
 
 export const Textarea = (props: IGenericFieldProps<ITextareaSchema>) => {
 	// =============================================================================
@@ -22,6 +23,7 @@ export const Textarea = (props: IGenericFieldProps<ITextareaSchema>) => {
 		error,
 		...otherProps
 	} = props;
+	const { setValue } = useFormContext();
 	const [stateValue, setStateValue] = useState<string | number | readonly string[]>(value || "");
 	const [maxLength, setMaxLength] = useState<number>();
 	const { setFieldValidationConfig } = useValidationConfig();
@@ -29,6 +31,12 @@ export const Textarea = (props: IGenericFieldProps<ITextareaSchema>) => {
 	// =============================================================================
 	// EFFECTS
 	// =============================================================================
+	useEffect(() => {
+		// ensure default value is passed to react-hook-form on mount
+		// this is used in conjunction with chips + textarea field
+		setValue(id, value);
+	}, []);
+
 	useEffect(() => {
 		const maxRule = validation?.find((rule) => "max" in rule);
 		const lengthRule = validation?.find((rule) => "length" in rule);

--- a/src/components/fields/time-field/time-field.tsx
+++ b/src/components/fields/time-field/time-field.tsx
@@ -46,14 +46,15 @@ export const TimeField = (props: IGenericFieldProps<ITimeFieldSchema>) => {
 	// EVENT HANDLERS
 	// =============================================================================
 	const handleChange = (value: string): void => {
-		onChange({ target: { value } });
+		// TODO: temporary fix to uppercase am/pm,to remove setting uppercase when design system is using uppercase
+		onChange({ target: { value: value.toUpperCase() } });
 	};
 
 	// =============================================================================
 	// HELPER FUNCTIONS
 	// =============================================================================
 	const handleCurrentTime = (format: string): void => {
-		const currentTime = DateTimeHelper.formatDateTime(LocalTime.now().toString(), format, "time");
+		const currentTime = DateTimeHelper.formatDateTime(LocalTime.now().toString().toUpperCase(), format, "time");
 
 		setStateValue(currentTime);
 		onChange({ target: { value: currentTime } });

--- a/src/components/fields/time-field/time-field.tsx
+++ b/src/components/fields/time-field/time-field.tsx
@@ -34,7 +34,7 @@ export const TimeField = (props: IGenericFieldProps<ITimeFieldSchema>) => {
 	useEffect(() => {
 		if (useCurrentTime && !value) {
 			const timeFormatPattern = is24HourFormat ? "H:mm" : "h:mma";
-			handleCurrentTime(timeFormatPattern);
+			setTimeout(() => handleCurrentTime(timeFormatPattern));
 		} else {
 			setStateValue(value);
 		}

--- a/src/stories/3-fields/checkbox-group/checkbox-group.stories.tsx
+++ b/src/stories/3-fields/checkbox-group/checkbox-group.stories.tsx
@@ -1,7 +1,7 @@
 import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
-import { Meta, Story } from "@storybook/react/types-6-0";
+import { Meta } from "@storybook/react/types-6-0";
 import { ICheckboxGroupSchema } from "../../../components/fields/checkbox-group";
-import { CommonFieldStoryProps, FrontendEngine, SUBMIT_BUTTON_SCHEMA } from "../../common";
+import { CommonFieldStoryProps, DefaultStoryTemplate, ResetStoryTemplate } from "../../common";
 
 export default {
 	title: "Field/Checkbox/Default",
@@ -59,29 +59,7 @@ export default {
 	},
 } as Meta;
 
-const Template = (id: string) =>
-	(({ defaultValues, ...args }) => (
-		<FrontendEngine
-			data={{
-				sections: {
-					section: {
-						uiType: "section",
-						children: {
-							[id]: args,
-							...SUBMIT_BUTTON_SCHEMA,
-						},
-					},
-				},
-				...(!!defaultValues && {
-					defaultValues: {
-						[id]: defaultValues,
-					},
-				}),
-			}}
-		/>
-	)) as Story<ICheckboxGroupSchema & { defaultValues?: string[] | undefined }>;
-
-export const Default = Template("checkbox-default").bind({});
+export const Default = DefaultStoryTemplate<ICheckboxGroupSchema>("checkbox-default").bind({});
 Default.args = {
 	uiType: "checkbox",
 	label: "Checkbox",
@@ -92,7 +70,7 @@ Default.args = {
 	],
 };
 
-export const DefaultValue = Template("checkbox-default-value").bind({});
+export const DefaultValue = DefaultStoryTemplate<ICheckboxGroupSchema, string[]>("checkbox-default-value").bind({});
 DefaultValue.args = {
 	uiType: "checkbox",
 	label: "Fruits",
@@ -115,7 +93,7 @@ DefaultValue.argTypes = {
 	},
 };
 
-export const DisabledOptions = Template("checkbox-disabled-options").bind({});
+export const DisabledOptions = DefaultStoryTemplate<ICheckboxGroupSchema>("checkbox-disabled-options").bind({});
 DisabledOptions.args = {
 	uiType: "checkbox",
 	label: "Fruits",
@@ -126,7 +104,7 @@ DisabledOptions.args = {
 	],
 };
 
-export const Disabled = Template("checkbox-disabled").bind({});
+export const Disabled = DefaultStoryTemplate<ICheckboxGroupSchema>("checkbox-disabled").bind({});
 Disabled.args = {
 	uiType: "checkbox",
 	label: "Fruits",
@@ -138,7 +116,7 @@ Disabled.args = {
 	disabled: true,
 };
 
-export const CustomSize = Template("checkbox-custom-size").bind({});
+export const CustomSize = DefaultStoryTemplate<ICheckboxGroupSchema>("checkbox-custom-size").bind({});
 CustomSize.args = {
 	uiType: "checkbox",
 	label: "Fruits",
@@ -150,7 +128,7 @@ CustomSize.args = {
 	displaySize: "small",
 };
 
-export const WithValidation = Template("checkbox-with-validation").bind({});
+export const WithValidation = DefaultStoryTemplate<ICheckboxGroupSchema>("checkbox-with-validation").bind({});
 WithValidation.args = {
 	uiType: "checkbox",
 	label: "Fruits",
@@ -160,4 +138,40 @@ WithValidation.args = {
 		{ label: "Cherry", value: "Cherry" },
 	],
 	validation: [{ required: true }],
+};
+
+export const Reset = ResetStoryTemplate<ICheckboxGroupSchema>("checkbox-reset").bind({});
+Reset.args = {
+	uiType: "checkbox",
+	label: "Checkbox",
+	options: [
+		{ label: "Apple", value: "Apple" },
+		{ label: "Berry", value: "Berry" },
+		{ label: "Cherry", value: "Cherry" },
+	],
+};
+
+export const ResetWithDefaultValues = ResetStoryTemplate<ICheckboxGroupSchema, string[]>(
+	"checkbox-reset-default-values"
+).bind({});
+ResetWithDefaultValues.args = {
+	uiType: "checkbox",
+	label: "Checkbox",
+	options: [
+		{ label: "Apple", value: "Apple" },
+		{ label: "Berry", value: "Berry" },
+		{ label: "Cherry", value: "Cherry" },
+	],
+	defaultValues: ["Apple", "Berry"],
+};
+ResetWithDefaultValues.argTypes = {
+	defaultValues: {
+		description: "Default value for the field, this is declared outside `sections`",
+		table: {
+			type: {
+				summary: "string[]",
+			},
+		},
+		type: { name: "object", value: {} },
+	},
 };

--- a/src/stories/3-fields/checkbox-group/checkbox-toggle-group.stories.tsx
+++ b/src/stories/3-fields/checkbox-group/checkbox-toggle-group.stories.tsx
@@ -1,7 +1,7 @@
 import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
-import { Meta, Story } from "@storybook/react/types-6-0";
+import { Meta } from "@storybook/react/types-6-0";
 import { ICheckboxGroupSchema } from "../../../components/fields/checkbox-group";
-import { CommonFieldStoryProps, FrontendEngine, SUBMIT_BUTTON_SCHEMA } from "../../common";
+import { CommonFieldStoryProps, DefaultStoryTemplate, ResetStoryTemplate } from "../../common";
 
 export default {
 	title: "Field/Checkbox/Toggle",
@@ -56,29 +56,7 @@ export default {
 	},
 } as Meta;
 
-const Template = (id: string) =>
-	(({ defaultValues, ...args }) => (
-		<FrontendEngine
-			data={{
-				sections: {
-					section: {
-						uiType: "section",
-						children: {
-							[id]: args,
-							...SUBMIT_BUTTON_SCHEMA,
-						},
-					},
-				},
-				...(!!defaultValues && {
-					defaultValues: {
-						[id]: defaultValues,
-					},
-				}),
-			}}
-		/>
-	)) as Story<ICheckboxGroupSchema & { defaultValues?: string[] | undefined }>;
-
-export const Default = Template("checkbox-default").bind({});
+export const Default = DefaultStoryTemplate<ICheckboxGroupSchema>("checkbox-default").bind({});
 Default.args = {
 	uiType: "checkbox",
 	label: "Toggle",
@@ -92,7 +70,7 @@ Default.args = {
 	],
 };
 
-export const DefaultValue = Template("checkbox-default-value").bind({});
+export const DefaultValue = DefaultStoryTemplate<ICheckboxGroupSchema, string[]>("checkbox-default-value").bind({});
 DefaultValue.args = {
 	uiType: "checkbox",
 	label: "Fruits",
@@ -118,7 +96,7 @@ DefaultValue.argTypes = {
 	},
 };
 
-export const DisabledOptions = Template("checkbox-disabled-options").bind({});
+export const DisabledOptions = DefaultStoryTemplate<ICheckboxGroupSchema>("checkbox-disabled-options").bind({});
 DisabledOptions.args = {
 	uiType: "checkbox",
 	label: "Fruits",
@@ -132,7 +110,7 @@ DisabledOptions.args = {
 	],
 };
 
-export const Disabled = Template("checkbox-disabled").bind({});
+export const Disabled = DefaultStoryTemplate<ICheckboxGroupSchema>("checkbox-disabled").bind({});
 Disabled.args = {
 	uiType: "checkbox",
 	label: "Fruits",
@@ -147,7 +125,7 @@ Disabled.args = {
 	disabled: true,
 };
 
-export const WithValidation = Template("checkbox-with-validation").bind({});
+export const WithValidation = DefaultStoryTemplate<ICheckboxGroupSchema>("checkbox-with-validation").bind({});
 WithValidation.args = {
 	uiType: "checkbox",
 	label: "Fruits",
@@ -162,7 +140,7 @@ WithValidation.args = {
 	validation: [{ required: true }],
 };
 
-export const NoneOption = Template("checkbox-default").bind({});
+export const NoneOption = DefaultStoryTemplate<ICheckboxGroupSchema>("checkbox-default").bind({});
 NoneOption.args = {
 	uiType: "checkbox",
 	label: "Fruits",
@@ -177,7 +155,7 @@ NoneOption.args = {
 	],
 };
 
-export const WithIndicator = Template("checkbox-default").bind({});
+export const WithIndicator = DefaultStoryTemplate<ICheckboxGroupSchema>("checkbox-default").bind({});
 WithIndicator.args = {
 	uiType: "checkbox",
 	label: "Fruits",
@@ -192,7 +170,7 @@ WithIndicator.args = {
 	],
 };
 
-export const WithoutBorder = Template("checkbox-default").bind({});
+export const WithoutBorder = DefaultStoryTemplate<ICheckboxGroupSchema>("checkbox-default").bind({});
 WithoutBorder.args = {
 	uiType: "checkbox",
 	label: "Fruits",
@@ -205,4 +183,46 @@ WithoutBorder.args = {
 		{ label: "Berry", value: "Berry" },
 		{ label: "Cherry", value: "Cherry" },
 	],
+};
+
+export const Reset = ResetStoryTemplate<ICheckboxGroupSchema>("checkbox-reset").bind({});
+Reset.args = {
+	uiType: "checkbox",
+	label: "Checkbox",
+	customOptions: {
+		styleType: "toggle",
+	},
+	options: [
+		{ label: "Apple", value: "Apple" },
+		{ label: "Berry", value: "Berry" },
+		{ label: "Cherry", value: "Cherry" },
+	],
+};
+
+export const ResetWithDefaultValues = ResetStoryTemplate<ICheckboxGroupSchema, string[]>(
+	"checkbox-reset-default-values"
+).bind({});
+ResetWithDefaultValues.args = {
+	uiType: "checkbox",
+	label: "Checkbox",
+	customOptions: {
+		styleType: "toggle",
+	},
+	options: [
+		{ label: "Apple", value: "Apple" },
+		{ label: "Berry", value: "Berry" },
+		{ label: "Cherry", value: "Cherry" },
+	],
+	defaultValues: ["Apple", "Berry"],
+};
+ResetWithDefaultValues.argTypes = {
+	defaultValues: {
+		description: "Default value for the field, this is declared outside `sections`",
+		table: {
+			type: {
+				summary: "string[]",
+			},
+		},
+		type: { name: "object", value: {} },
+	},
 };

--- a/src/stories/3-fields/chips/chips.stories.tsx
+++ b/src/stories/3-fields/chips/chips.stories.tsx
@@ -1,7 +1,16 @@
 import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
-import { Meta } from "@storybook/react/types-6-0";
+import { Meta, Story } from "@storybook/react/types-6-0";
 import { IChipsSchema } from "../../../components/fields/chips";
-import { CommonFieldStoryProps, DefaultStoryTemplate, ResetStoryTemplate } from "../../common";
+import {
+	CommonFieldStoryProps,
+	DefaultStoryTemplate,
+	FrontendEngine,
+	RESET_BUTTON_SCHEMA,
+	ResetStoryTemplate,
+	SUBMIT_BUTTON_SCHEMA,
+} from "../../common";
+import { IFrontendEngineRef } from "../../../components";
+import { useRef } from "react";
 
 export default {
 	title: "Field/Chips",
@@ -96,6 +105,42 @@ DefaultValue.argTypes = {
 		},
 		type: { name: "object", value: {} },
 	},
+};
+
+export const DefaultTextareaValue: Story<IChipsSchema> = (args) => (
+	<FrontendEngine
+		data={{
+			sections: {
+				section: {
+					uiType: "section",
+					children: {
+						"chips-textarea-default": args,
+						buttons: {
+							uiType: "div",
+							style: { display: "flex", gap: "1rem" },
+							children: {
+								...SUBMIT_BUTTON_SCHEMA,
+							},
+						},
+					},
+				},
+			},
+			defaultValues: {
+				"chips-textarea-default": ["Durian"],
+				"chips-textarea-default-textarea": "Hello world",
+			},
+		}}
+	/>
+);
+DefaultTextareaValue.args = {
+	uiType: "chips",
+	label: "Fruits",
+	options: [
+		{ label: "Apple", value: "Apple" },
+		{ label: "Berry", value: "Berry" },
+		{ label: "Cherry", value: "Cherry" },
+	],
+	textarea: { label: "Durian", rows: 1 },
 };
 
 export const DisabledOptions = DefaultStoryTemplate<IChipsSchema>("chips-disabled-options").bind({});
@@ -237,4 +282,41 @@ ResetWithDefaultValues.argTypes = {
 		},
 		type: { name: "object", value: {} },
 	},
+};
+
+export const ResetWithTextarea: Story<IChipsSchema> = (args) => (
+	<FrontendEngine
+		data={{
+			sections: {
+				section: {
+					uiType: "section",
+					children: {
+						"chips-textarea-reset": args,
+						buttons: {
+							uiType: "div",
+							style: { display: "flex", gap: "1rem" },
+							children: {
+								...RESET_BUTTON_SCHEMA,
+								...SUBMIT_BUTTON_SCHEMA,
+							},
+						},
+					},
+				},
+			},
+			defaultValues: {
+				"chips-textarea-reset": ["Durian"],
+				"chips-textarea-reset-textarea": "Hello world",
+			},
+		}}
+	/>
+);
+ResetWithTextarea.args = {
+	uiType: "chips",
+	label: "Fruits",
+	options: [
+		{ label: "Apple", value: "Apple" },
+		{ label: "Berry", value: "Berry" },
+		{ label: "Cherry", value: "Cherry" },
+	],
+	textarea: { label: "Durian", rows: 1 },
 };

--- a/src/stories/3-fields/chips/chips.stories.tsx
+++ b/src/stories/3-fields/chips/chips.stories.tsx
@@ -1,7 +1,7 @@
 import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
-import { Meta, Story } from "@storybook/react/types-6-0";
+import { Meta } from "@storybook/react/types-6-0";
 import { IChipsSchema } from "../../../components/fields/chips";
-import { CommonFieldStoryProps, FrontendEngine, SUBMIT_BUTTON_SCHEMA } from "../../common";
+import { CommonFieldStoryProps, DefaultStoryTemplate, ResetStoryTemplate } from "../../common";
 
 export default {
 	title: "Field/Chips",
@@ -64,29 +64,7 @@ export default {
 	},
 } as Meta;
 
-const Template = (id: string) =>
-	(({ defaultValues, ...args }) => (
-		<FrontendEngine
-			data={{
-				sections: {
-					section: {
-						uiType: "section",
-						children: {
-							[id]: args,
-							...SUBMIT_BUTTON_SCHEMA,
-						},
-					},
-				},
-				...(!!defaultValues && {
-					defaultValues: {
-						[id]: defaultValues,
-					},
-				}),
-			}}
-		/>
-	)) as Story<IChipsSchema & { defaultValues?: string[] | undefined }>;
-
-export const Default = Template("chips-default").bind({});
+export const Default = DefaultStoryTemplate<IChipsSchema>("chips-default").bind({});
 Default.args = {
 	uiType: "chips",
 	label: "Fruits",
@@ -97,7 +75,7 @@ Default.args = {
 	],
 };
 
-export const DefaultValue = Template("chips-default-value").bind({});
+export const DefaultValue = DefaultStoryTemplate<IChipsSchema, string[]>("chips-default-value").bind({});
 DefaultValue.args = {
 	uiType: "chips",
 	label: "Fruits",
@@ -120,7 +98,7 @@ DefaultValue.argTypes = {
 	},
 };
 
-export const DisabledOptions = Template("chips-disabled-options").bind({});
+export const DisabledOptions = DefaultStoryTemplate<IChipsSchema>("chips-disabled-options").bind({});
 DisabledOptions.args = {
 	uiType: "chips",
 	label: "Fruits",
@@ -131,7 +109,7 @@ DisabledOptions.args = {
 	],
 };
 
-export const Disabled = Template("chips-disabled").bind({});
+export const Disabled = DefaultStoryTemplate<IChipsSchema>("chips-disabled").bind({});
 Disabled.args = {
 	uiType: "chips",
 	label: "Fruits",
@@ -143,7 +121,7 @@ Disabled.args = {
 	disabled: true,
 };
 
-export const WithValidation = Template("chips-with-validation").bind({});
+export const WithValidation = DefaultStoryTemplate<IChipsSchema>("chips-with-validation").bind({});
 WithValidation.args = {
 	uiType: "chips",
 	label: "Fruits",
@@ -155,7 +133,7 @@ WithValidation.args = {
 	validation: [{ required: true }],
 };
 
-export const WithTextarea = Template("chips-with-textarea").bind({});
+export const WithTextarea = DefaultStoryTemplate<IChipsSchema>("chips-with-textarea").bind({});
 WithTextarea.args = {
 	uiType: "chips",
 	label: "Fruits",
@@ -167,7 +145,7 @@ WithTextarea.args = {
 	textarea: { label: "Durian" },
 };
 
-export const WithTextareaValidation = Template("chips-with-textarea-validation").bind({});
+export const WithTextareaValidation = DefaultStoryTemplate<IChipsSchema>("chips-with-textarea-validation").bind({});
 WithTextareaValidation.args = {
 	uiType: "chips",
 	label: "Fruits",
@@ -179,7 +157,7 @@ WithTextareaValidation.args = {
 	textarea: { label: "Durian", validation: [{ required: true }, { min: 3, errorMessage: "Min. 3 characters" }] },
 };
 
-export const WithResizableTextarea = Template("chips-with-textarea-resizable").bind({});
+export const WithResizableTextarea = DefaultStoryTemplate<IChipsSchema>("chips-with-textarea-resizable").bind({});
 WithResizableTextarea.args = {
 	uiType: "chips",
 	label: "Fruits",
@@ -191,7 +169,7 @@ WithResizableTextarea.args = {
 	textarea: { label: "Durian", resizable: true },
 };
 
-export const WithTextareaCustomRows = Template("chips-with-textarea-custom-rows").bind({});
+export const WithTextareaCustomRows = DefaultStoryTemplate<IChipsSchema>("chips-with-textarea-custom-rows").bind({});
 WithTextareaCustomRows.args = {
 	uiType: "chips",
 	label: "Fruits",
@@ -203,7 +181,7 @@ WithTextareaCustomRows.args = {
 	textarea: { label: "Durian", rows: 1 },
 };
 
-export const WithTextareaMaxLength = Template("chips-with-textarea-max-length").bind({});
+export const WithTextareaMaxLength = DefaultStoryTemplate<IChipsSchema>("chips-with-textarea-max-length").bind({});
 WithTextareaMaxLength.args = {
 	uiType: "chips",
 	label: "Fruits",
@@ -215,7 +193,7 @@ WithTextareaMaxLength.args = {
 	textarea: { label: "Durian", rows: 1, validation: [{ max: 10 }] },
 };
 
-export const SingleSelection = Template("chips-single-selection").bind({});
+export const SingleSelection = DefaultStoryTemplate<IChipsSchema>("chips-single-selection").bind({});
 SingleSelection.args = {
 	uiType: "chips",
 	label: "Fruits",
@@ -225,4 +203,38 @@ SingleSelection.args = {
 		{ label: "Cherry", value: "Cherry" },
 	],
 	validation: [{ max: 1 }],
+};
+
+export const Reset = ResetStoryTemplate<IChipsSchema>("chips-reset").bind({});
+Reset.args = {
+	uiType: "chips",
+	label: "Fruits",
+	options: [
+		{ label: "Apple", value: "Apple" },
+		{ label: "Berry", value: "Berry" },
+		{ label: "Cherry", value: "Cherry" },
+	],
+};
+
+export const ResetWithDefaultValues = ResetStoryTemplate<IChipsSchema, string[]>("chips-reset-default-values").bind({});
+ResetWithDefaultValues.args = {
+	uiType: "chips",
+	label: "Fruits",
+	options: [
+		{ label: "Apple", value: "Apple" },
+		{ label: "Berry", value: "Berry" },
+		{ label: "Cherry", value: "Cherry" },
+	],
+	defaultValues: ["Apple", "Berry"],
+};
+ResetWithDefaultValues.argTypes = {
+	defaultValues: {
+		description: "Default value for the field, this is declared outside `sections`",
+		table: {
+			type: {
+				summary: "string[]",
+			},
+		},
+		type: { name: "object", value: {} },
+	},
 };

--- a/src/stories/3-fields/contact-field/contact-field.stories.tsx
+++ b/src/stories/3-fields/contact-field/contact-field.stories.tsx
@@ -30,9 +30,6 @@ export default {
 					summary: "string",
 				},
 			},
-			control: {
-				type: "text",
-			},
 		},
 		defaultCountry: {
 			description:
@@ -103,9 +100,6 @@ DefaultValue.argTypes = {
 			type: {
 				summary: "string",
 			},
-		},
-		control: {
-			type: "text",
 		},
 	},
 };
@@ -222,6 +216,5 @@ ResetWithDefaultValues.argTypes = {
 				summary: "string",
 			},
 		},
-		type: { name: "object", value: {} },
 	},
 };

--- a/src/stories/3-fields/contact-field/contact-field.stories.tsx
+++ b/src/stories/3-fields/contact-field/contact-field.stories.tsx
@@ -1,8 +1,8 @@
 import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
-import { Meta, Story } from "@storybook/react/types-6-0";
+import { Meta } from "@storybook/react/types-6-0";
 import { IContactFieldSchema } from "../../../components/fields";
 import { getCountries } from "../../../components/fields/contact-field/data";
-import { CommonFieldStoryProps, FrontendEngine, SUBMIT_BUTTON_SCHEMA } from "../../common";
+import { CommonFieldStoryProps, DefaultStoryTemplate, ResetStoryTemplate } from "../../common";
 
 export default {
 	title: "Field/ContactField",
@@ -77,44 +77,20 @@ export default {
 	},
 } as Meta;
 
-const Template = (id: string) =>
-	(({ defaultValues, ...args }) => {
-		return (
-			<FrontendEngine
-				data={{
-					sections: {
-						section: {
-							uiType: "section",
-							children: {
-								[id]: args,
-								...SUBMIT_BUTTON_SCHEMA,
-							},
-						},
-					},
-					...(!!defaultValues && {
-						defaultValues: {
-							[id]: defaultValues,
-						},
-					}),
-				}}
-			/>
-		);
-	}) as Story<IContactFieldSchema & { defaultValues?: string | undefined }>;
-
-export const Default = Template("contact-default").bind({});
+export const Default = DefaultStoryTemplate<IContactFieldSchema>("contact-default").bind({});
 Default.args = {
 	uiType: "contact-field",
 	label: "Contact Number",
 };
 
-export const DefaultCountry = Template("contact-default-country").bind({});
+export const DefaultCountry = DefaultStoryTemplate<IContactFieldSchema>("contact-default-country").bind({});
 DefaultCountry.args = {
 	uiType: "contact-field",
 	label: "Contact Number",
 	defaultCountry: "Japan",
 };
 
-export const DefaultValue = Template("contact-default-value").bind({});
+export const DefaultValue = DefaultStoryTemplate<IContactFieldSchema>("contact-default-value").bind({});
 DefaultValue.args = {
 	uiType: "contact-field",
 	label: "Contact Number",
@@ -134,28 +110,28 @@ DefaultValue.argTypes = {
 	},
 };
 
-export const Disabled = Template("contact-disabled").bind({});
+export const Disabled = DefaultStoryTemplate<IContactFieldSchema>("contact-disabled").bind({});
 Disabled.args = {
 	uiType: "contact-field",
 	label: "Contact Number",
 	disabled: true,
 };
 
-export const Placeholder = Template("contact-placeholder").bind({});
+export const Placeholder = DefaultStoryTemplate<IContactFieldSchema>("contact-placeholder").bind({});
 Placeholder.args = {
 	uiType: "contact-field",
 	label: "Contact Number",
 	placeholder: "Enter your contact number",
 };
 
-export const WithSearch = Template("contact-with-search").bind({});
+export const WithSearch = DefaultStoryTemplate<IContactFieldSchema>("contact-with-search").bind({});
 WithSearch.args = {
 	uiType: "contact-field",
 	label: "Contact Number",
 	enableSearch: true,
 };
 
-export const FixedCountry = Template("contact-fixed-country").bind({});
+export const FixedCountry = DefaultStoryTemplate<IContactFieldSchema>("contact-fixed-country").bind({});
 FixedCountry.args = {
 	uiType: "contact-field",
 	label: "Contact Number",
@@ -168,7 +144,7 @@ FixedCountry.args = {
 	],
 };
 
-export const SGNumberValidation = Template("contact-singapore-number").bind({});
+export const SGNumberValidation = DefaultStoryTemplate<IContactFieldSchema>("contact-singapore-number").bind({});
 SGNumberValidation.args = {
 	uiType: "contact-field",
 	label: "Contact Number",
@@ -181,7 +157,9 @@ SGNumberValidation.args = {
 	],
 };
 
-export const SGHouseNumberValidation = Template("contact-singapore-house-number").bind({});
+export const SGHouseNumberValidation = DefaultStoryTemplate<IContactFieldSchema>("contact-singapore-house-number").bind(
+	{}
+);
 SGHouseNumberValidation.args = {
 	uiType: "contact-field",
 	label: "Contact Number",
@@ -194,7 +172,9 @@ SGHouseNumberValidation.args = {
 	],
 };
 
-export const SGPhoneNumberValidation = Template("contact-singapore-mobile-number").bind({});
+export const SGPhoneNumberValidation = DefaultStoryTemplate<IContactFieldSchema>(
+	"contact-singapore-mobile-number"
+).bind({});
 SGPhoneNumberValidation.args = {
 	uiType: "contact-field",
 	label: "Contact Number",
@@ -207,7 +187,9 @@ SGPhoneNumberValidation.args = {
 	],
 };
 
-export const InternationalNumberValidation = Template("contact-international-number").bind({});
+export const InternationalNumberValidation = DefaultStoryTemplate<IContactFieldSchema>(
+	"contact-international-number"
+).bind({});
 InternationalNumberValidation.args = {
 	uiType: "contact-field",
 	label: "Contact Number",
@@ -218,4 +200,28 @@ InternationalNumberValidation.args = {
 			},
 		},
 	],
+};
+
+export const Reset = ResetStoryTemplate<IContactFieldSchema>("contact-reset").bind({});
+Reset.args = {
+	uiType: "contact-field",
+	label: "Contact Number",
+};
+
+export const ResetWithDefaultValues = ResetStoryTemplate<IContactFieldSchema>("contact-reset-default-values").bind({});
+ResetWithDefaultValues.args = {
+	uiType: "contact-field",
+	label: "Contact Number",
+	defaultValues: "91234567",
+};
+ResetWithDefaultValues.argTypes = {
+	defaultValues: {
+		description: "Default value for the field, this is declared outside `sections`",
+		table: {
+			type: {
+				summary: "string",
+			},
+		},
+		type: { name: "object", value: {} },
+	},
 };

--- a/src/stories/3-fields/date-field/date-field.stories.tsx
+++ b/src/stories/3-fields/date-field/date-field.stories.tsx
@@ -43,9 +43,6 @@ export default {
 				},
 				defaultValue: { summary: "uuuu-MM-dd" },
 			},
-			control: {
-				type: "text",
-			},
 		},
 	},
 } as Meta;
@@ -76,9 +73,6 @@ DefaultValue.argTypes = {
 			type: {
 				summary: "string",
 			},
-		},
-		control: {
-			type: "text",
 		},
 	},
 };
@@ -169,7 +163,6 @@ ResetWithDefaultValues.argTypes = {
 				summary: "string",
 			},
 		},
-		type: { name: "object", value: {} },
 	},
 };
 

--- a/src/stories/3-fields/date-field/date-field.stories.tsx
+++ b/src/stories/3-fields/date-field/date-field.stories.tsx
@@ -172,3 +172,10 @@ ResetWithDefaultValues.argTypes = {
 		type: { name: "object", value: {} },
 	},
 };
+
+export const ResetToCurrentDate = ResetStoryTemplate<IDateFieldSchema>("date-reset-current-date").bind({});
+ResetToCurrentDate.args = {
+	uiType: "date-field",
+	label: "Date",
+	useCurrentDate: true,
+};

--- a/src/stories/3-fields/date-field/date-field.stories.tsx
+++ b/src/stories/3-fields/date-field/date-field.stories.tsx
@@ -1,7 +1,7 @@
 import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
-import { Meta, Story } from "@storybook/react/types-6-0";
+import { Meta } from "@storybook/react/types-6-0";
 import { IDateFieldSchema } from "src/components/fields/date-field/types";
-import { CommonFieldStoryProps, FrontendEngine, SUBMIT_BUTTON_SCHEMA } from "../../common";
+import { CommonFieldStoryProps, DefaultStoryTemplate, ResetStoryTemplate } from "../../common";
 
 export default {
 	title: "Field/DateField",
@@ -50,44 +50,20 @@ export default {
 	},
 } as Meta;
 
-const Template = (id: string) =>
-	(({ defaultValues, ...args }) => {
-		return (
-			<FrontendEngine
-				data={{
-					sections: {
-						section: {
-							uiType: "section",
-							children: {
-								[id]: args,
-								...SUBMIT_BUTTON_SCHEMA,
-							},
-						},
-					},
-					...(!!defaultValues && {
-						defaultValues: {
-							[id]: defaultValues,
-						},
-					}),
-				}}
-			/>
-		);
-	}) as Story<IDateFieldSchema & { defaultValues?: string | undefined }>;
-
-export const Default = Template("date-default").bind({});
+export const Default = DefaultStoryTemplate<IDateFieldSchema>("date-default").bind({});
 Default.args = {
 	uiType: "date-field",
 	label: "Date",
 };
 
-export const UseCurrentDate = Template("date-use-current-date").bind({});
+export const UseCurrentDate = DefaultStoryTemplate<IDateFieldSchema>("date-use-current-date").bind({});
 UseCurrentDate.args = {
 	uiType: "date-field",
 	label: "Date",
 	useCurrentDate: true,
 };
 
-export const DefaultValue = Template("date-default-value").bind({});
+export const DefaultValue = DefaultStoryTemplate<IDateFieldSchema>("date-default-value").bind({});
 DefaultValue.args = {
 	uiType: "date-field",
 	label: "Date with default value",
@@ -107,14 +83,14 @@ DefaultValue.argTypes = {
 	},
 };
 
-export const DateFormat = Template("date-format").bind({});
+export const DateFormat = DefaultStoryTemplate<IDateFieldSchema>("date-format").bind({});
 DateFormat.args = {
 	uiType: "date-field",
 	label: "Date",
 	dateFormat: "d MMMM uuuu",
 };
 
-export const DateFormatDefaultValues = Template("date-format-default").bind({});
+export const DateFormatDefaultValues = DefaultStoryTemplate<IDateFieldSchema>("date-format-default").bind({});
 DateFormatDefaultValues.storyName = "Date Format with Default Value";
 DateFormatDefaultValues.args = {
 	uiType: "date-field",
@@ -124,51 +100,75 @@ DateFormatDefaultValues.args = {
 };
 DateFormatDefaultValues.argTypes = DefaultValue.argTypes;
 
-export const WithValidation = Template("date-with-validation").bind({});
+export const WithValidation = DefaultStoryTemplate<IDateFieldSchema>("date-with-validation").bind({});
 WithValidation.args = {
 	uiType: "date-field",
 	label: "Date",
 	validation: [{ required: true }],
 };
 
-export const FutureDateOnly = Template("date-future").bind({});
+export const FutureDateOnly = DefaultStoryTemplate<IDateFieldSchema>("date-future").bind({});
 FutureDateOnly.args = {
 	uiType: "date-field",
 	label: "Date",
 	validation: [{ required: true }, { future: true, errorMessage: "Only future dates allowed" }],
 };
 
-export const PastDateOnly = Template("date-past").bind({});
+export const PastDateOnly = DefaultStoryTemplate<IDateFieldSchema>("date-past").bind({});
 PastDateOnly.args = {
 	uiType: "date-field",
 	label: "Date",
 	validation: [{ required: true }, { past: true, errorMessage: "Only past dates allowed" }],
 };
 
-export const NotFutureDate = Template("date-now-or-past").bind({});
+export const NotFutureDate = DefaultStoryTemplate<IDateFieldSchema>("date-now-or-past").bind({});
 NotFutureDate.args = {
 	uiType: "date-field",
 	label: "Date",
 	validation: [{ required: true }, { notFuture: true, errorMessage: "No future dates" }],
 };
 
-export const NotPastDate = Template("date-now-or-future").bind({});
+export const NotPastDate = DefaultStoryTemplate<IDateFieldSchema>("date-now-or-future").bind({});
 NotPastDate.args = {
 	uiType: "date-field",
 	label: "Date",
 	validation: [{ required: true }, { notPast: true, errorMessage: "No past dates" }],
 };
 
-export const MinDate = Template("min-date").bind({});
+export const MinDate = DefaultStoryTemplate<IDateFieldSchema>("min-date").bind({});
 MinDate.args = {
 	uiType: "date-field",
 	label: "Date",
 	validation: [{ required: true }, { minDate: "2023-01-01", errorMessage: "Min date 01/01/2023" }],
 };
 
-export const MaxDate = Template("max-date").bind({});
+export const MaxDate = DefaultStoryTemplate<IDateFieldSchema>("max-date").bind({});
 MaxDate.args = {
 	uiType: "date-field",
 	label: "Date",
 	validation: [{ required: true }, { maxDate: "2023-01-01", errorMessage: "Max date 01/01/2023" }],
+};
+
+export const Reset = ResetStoryTemplate<IDateFieldSchema>("date-reset").bind({});
+Reset.args = {
+	uiType: "date-field",
+	label: "Date",
+};
+
+export const ResetWithDefaultValues = ResetStoryTemplate<IDateFieldSchema>("date-reset-default-values").bind({});
+ResetWithDefaultValues.args = {
+	uiType: "date-field",
+	label: "Date",
+	defaultValues: "2022-02-01",
+};
+ResetWithDefaultValues.argTypes = {
+	defaultValues: {
+		description: "Default value for the field, this is declared outside `sections`",
+		table: {
+			type: {
+				summary: "string",
+			},
+		},
+		type: { name: "object", value: {} },
+	},
 };

--- a/src/stories/3-fields/email-field/email-field.stories.tsx
+++ b/src/stories/3-fields/email-field/email-field.stories.tsx
@@ -1,7 +1,7 @@
 import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
-import { Meta, Story } from "@storybook/react/types-6-0";
+import { Meta } from "@storybook/react/types-6-0";
 import { IEmailFieldSchema } from "../../../components/fields";
-import { CommonFieldStoryProps, FrontendEngine, SUBMIT_BUTTON_SCHEMA } from "../../common";
+import { CommonFieldStoryProps, DefaultStoryTemplate, ResetStoryTemplate } from "../../common";
 
 export default {
 	title: "Field/EmailField",
@@ -63,35 +63,13 @@ export default {
 	},
 } as Meta;
 
-const Template = (id: string) =>
-	(({ defaultValues, ...args }) => (
-		<FrontendEngine
-			data={{
-				sections: {
-					section: {
-						uiType: "section",
-						children: {
-							[id]: args,
-							...SUBMIT_BUTTON_SCHEMA,
-						},
-					},
-				},
-				...(!!defaultValues && {
-					defaultValues: {
-						[id]: defaultValues,
-					},
-				}),
-			}}
-		/>
-	)) as Story<IEmailFieldSchema & { defaultValues?: string | undefined }>;
-
-export const Default = Template("email-default").bind({});
+export const Default = DefaultStoryTemplate<IEmailFieldSchema>("email-default").bind({});
 Default.args = {
 	label: "Email",
 	uiType: "email-field",
 };
 
-export const DefaultValue = Template("email-default-value").bind({});
+export const DefaultValue = DefaultStoryTemplate<IEmailFieldSchema>("email-default-value").bind({});
 DefaultValue.args = {
 	label: "Email",
 	uiType: "email-field",
@@ -111,42 +89,42 @@ DefaultValue.argTypes = {
 	},
 };
 
-export const Disabled = Template("email-disabled").bind({});
+export const Disabled = DefaultStoryTemplate<IEmailFieldSchema>("email-disabled").bind({});
 Disabled.args = {
 	label: "Email",
 	uiType: "email-field",
 	disabled: true,
 };
 
-export const CustomErrorMessage = Template("email-email-error").bind({});
+export const CustomErrorMessage = DefaultStoryTemplate<IEmailFieldSchema>("email-email-error").bind({});
 CustomErrorMessage.args = {
 	label: "Email",
 	uiType: "email-field",
 	validation: [{ email: true, errorMessage: "Please use a valid email" }],
 };
 
-export const MaxLength = Template("textfield-maxlength").bind({});
+export const MaxLength = DefaultStoryTemplate<IEmailFieldSchema>("textfield-maxlength").bind({});
 MaxLength.args = {
 	label: "Email",
 	uiType: "email-field",
 	validation: [{ max: 5 }],
 };
 
-export const Placeholder = Template("email-placeholder").bind({});
+export const Placeholder = DefaultStoryTemplate<IEmailFieldSchema>("email-placeholder").bind({});
 Placeholder.args = {
 	label: "Email",
 	uiType: "email-field",
 	placeholder: "Enter an email",
 };
 
-export const WithValidation = Template("email-with-validation").bind({});
+export const WithValidation = DefaultStoryTemplate<IEmailFieldSchema>("email-with-validation").bind({});
 WithValidation.args = {
 	label: "Email",
 	uiType: "email-field",
 	validation: [{ required: true }],
 };
 
-export const PreventCopyAndPaste = Template("prevent-copy-and-paste").bind({});
+export const PreventCopyAndPaste = DefaultStoryTemplate<IEmailFieldSchema>("prevent-copy-and-paste").bind({});
 PreventCopyAndPaste.args = {
 	label: "Email",
 	uiType: "email-field",
@@ -155,11 +133,34 @@ PreventCopyAndPaste.args = {
 	},
 };
 
-export const PreventDragAndDrop = Template("prevent-drag-and-drop").bind({});
+export const PreventDragAndDrop = DefaultStoryTemplate<IEmailFieldSchema>("prevent-drag-and-drop").bind({});
 PreventDragAndDrop.args = {
 	label: "Textfield",
 	uiType: "email-field",
 	customOptions: {
 		preventDragAndDrop: true,
+	},
+};
+export const Reset = ResetStoryTemplate<IEmailFieldSchema>("email-reset").bind({});
+Reset.args = {
+	uiType: "email-field",
+	label: "Email",
+};
+
+export const ResetWithDefaultValues = ResetStoryTemplate<IEmailFieldSchema>("email-reset-default-values").bind({});
+ResetWithDefaultValues.args = {
+	uiType: "email-field",
+	label: "Email",
+	defaultValues: "default@domain.tld",
+};
+ResetWithDefaultValues.argTypes = {
+	defaultValues: {
+		description: "Default value for the field, this is declared outside `sections`",
+		table: {
+			type: {
+				summary: "string",
+			},
+		},
+		type: { name: "object", value: {} },
 	},
 };

--- a/src/stories/3-fields/email-field/email-field.stories.tsx
+++ b/src/stories/3-fields/email-field/email-field.stories.tsx
@@ -32,9 +32,6 @@ export default {
 					summary: "string",
 				},
 			},
-			control: {
-				type: "text",
-			},
 		},
 		disabled: {
 			description: "Specifies if the textfield is interactable",
@@ -82,9 +79,6 @@ DefaultValue.argTypes = {
 			type: {
 				summary: "string",
 			},
-		},
-		control: {
-			type: "text",
 		},
 	},
 };
@@ -161,6 +155,5 @@ ResetWithDefaultValues.argTypes = {
 				summary: "string",
 			},
 		},
-		type: { name: "object", value: {} },
 	},
 };

--- a/src/stories/3-fields/multi-select/multi-select.stories.tsx
+++ b/src/stories/3-fields/multi-select/multi-select.stories.tsx
@@ -51,9 +51,6 @@ export default {
 					summary: "string",
 				},
 			},
-			control: {
-				type: "text",
-			},
 		},
 		listStyleWidth: {
 			description: "Style option: The width of the options. You can specify e.g. 100% or 12rem",
@@ -61,9 +58,6 @@ export default {
 				type: {
 					summary: "string",
 				},
-			},
-			control: {
-				type: "text",
 			},
 		},
 	},

--- a/src/stories/3-fields/multi-select/multi-select.stories.tsx
+++ b/src/stories/3-fields/multi-select/multi-select.stories.tsx
@@ -1,7 +1,7 @@
 import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
-import { Meta, Story } from "@storybook/react/types-6-0";
+import { Meta } from "@storybook/react/types-6-0";
 import { IMultiSelectSchema } from "../../../components/fields";
-import { CommonFieldStoryProps, FrontendEngine, SUBMIT_BUTTON_SCHEMA } from "../../common";
+import { CommonFieldStoryProps, DefaultStoryTemplate, ResetStoryTemplate } from "../../common";
 
 export default {
 	title: "Field/MultiSelect",
@@ -69,29 +69,7 @@ export default {
 	},
 } as Meta;
 
-const Template = (id: string) =>
-	(({ defaultValues, ...args }) => (
-		<FrontendEngine
-			data={{
-				sections: {
-					section: {
-						uiType: "section",
-						children: {
-							[id]: args,
-							...SUBMIT_BUTTON_SCHEMA,
-						},
-					},
-				},
-				...(!!defaultValues && {
-					defaultValues: {
-						[id]: defaultValues,
-					},
-				}),
-			}}
-		/>
-	)) as Story<IMultiSelectSchema & { defaultValues?: string[] | undefined }>;
-
-export const Default = Template("multi-select-default").bind({});
+export const Default = DefaultStoryTemplate<IMultiSelectSchema>("multi-select-default").bind({});
 Default.args = {
 	uiType: "multi-select",
 	label: "Fruits",
@@ -102,7 +80,7 @@ Default.args = {
 	],
 };
 
-export const DefaultValue = Template("multi-select-default-value").bind({});
+export const DefaultValue = DefaultStoryTemplate<IMultiSelectSchema, string[]>("multi-select-default-value").bind({});
 DefaultValue.args = {
 	uiType: "multi-select",
 	label: "Fruits",
@@ -125,7 +103,7 @@ DefaultValue.argTypes = {
 	},
 };
 
-export const Disabled = Template("multi-select-disabled").bind({});
+export const Disabled = DefaultStoryTemplate<IMultiSelectSchema>("multi-select-disabled").bind({});
 Disabled.args = {
 	uiType: "multi-select",
 	label: "Fruits",
@@ -137,7 +115,7 @@ Disabled.args = {
 	disabled: true,
 };
 
-export const CustomWidth = Template("multi-select-custom-width").bind({});
+export const CustomWidth = DefaultStoryTemplate<IMultiSelectSchema>("multi-select-custom-width").bind({});
 CustomWidth.args = {
 	uiType: "multi-select",
 	label: "Fruits",
@@ -149,7 +127,7 @@ CustomWidth.args = {
 	listStyleWidth: "12rem",
 };
 
-export const Placeholder = Template("multi-select-placeholder").bind({});
+export const Placeholder = DefaultStoryTemplate<IMultiSelectSchema>("multi-select-placeholder").bind({});
 Placeholder.args = {
 	uiType: "multi-select",
 	label: "Fruits",
@@ -161,7 +139,7 @@ Placeholder.args = {
 	placeholder: "Select your fruit",
 };
 
-export const WithValidation = Template("multi-select-with-validation").bind({});
+export const WithValidation = DefaultStoryTemplate<IMultiSelectSchema>("multi-select-with-validation").bind({});
 WithValidation.args = {
 	uiType: "multi-select",
 	label: "Fruits",
@@ -171,4 +149,40 @@ WithValidation.args = {
 		{ value: "Cherry", label: "Cherry" },
 	],
 	validation: [{ required: true }],
+};
+
+export const Reset = ResetStoryTemplate<IMultiSelectSchema>("multi-select-reset").bind({});
+Reset.args = {
+	uiType: "multi-select",
+	label: "Fruits",
+	options: [
+		{ value: "Apple", label: "Apple" },
+		{ value: "Berry", label: "Berry" },
+		{ value: "Cherry", label: "Cherry" },
+	],
+};
+
+export const ResetWithDefaultValues = ResetStoryTemplate<IMultiSelectSchema, string[]>(
+	"multi-select-reset-default-value"
+).bind({});
+ResetWithDefaultValues.args = {
+	uiType: "multi-select",
+	label: "Fruits",
+	options: [
+		{ value: "Apple", label: "Apple" },
+		{ value: "Berry", label: "Berry" },
+		{ value: "Cherry", label: "Cherry" },
+	],
+	defaultValues: ["Apple", "Berry"],
+};
+ResetWithDefaultValues.argTypes = {
+	defaultValues: {
+		description: "Default value for the field, this is declared outside `sections`",
+		table: {
+			type: {
+				summary: "string[]",
+			},
+		},
+		type: { name: "object", value: {} },
+	},
 };

--- a/src/stories/3-fields/numeric-field/numeric-field.stories.tsx
+++ b/src/stories/3-fields/numeric-field/numeric-field.stories.tsx
@@ -32,9 +32,6 @@ export default {
 					summary: "string",
 				},
 			},
-			control: {
-				type: "text",
-			},
 		},
 		disabled: {
 			description: "Specifies if the textfield is interactable",
@@ -83,7 +80,6 @@ DefaultValue.argTypes = {
 				summary: "number",
 			},
 		},
-		type: { name: "object", value: {} },
 	},
 };
 
@@ -154,6 +150,5 @@ ResetWithDefaultValues.argTypes = {
 				summary: "number",
 			},
 		},
-		type: { name: "object", value: {} },
 	},
 };

--- a/src/stories/3-fields/numeric-field/numeric-field.stories.tsx
+++ b/src/stories/3-fields/numeric-field/numeric-field.stories.tsx
@@ -1,7 +1,7 @@
 import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
-import { Meta, Story } from "@storybook/react/types-6-0";
+import { Meta } from "@storybook/react/types-6-0";
 import { INumericFieldSchema } from "../../../components/fields";
-import { CommonFieldStoryProps, FrontendEngine, SUBMIT_BUTTON_SCHEMA } from "../../common";
+import { CommonFieldStoryProps, DefaultStoryTemplate, ResetStoryTemplate } from "../../common";
 
 export default {
 	title: "Field/NumericField",
@@ -63,35 +63,13 @@ export default {
 	},
 } as Meta;
 
-const Template = (id: string) =>
-	(({ defaultValues, ...args }) => (
-		<FrontendEngine
-			data={{
-				sections: {
-					section: {
-						uiType: "section",
-						children: {
-							[id]: args,
-							...SUBMIT_BUTTON_SCHEMA,
-						},
-					},
-				},
-				...(!!defaultValues && {
-					defaultValues: {
-						[id]: defaultValues,
-					},
-				}),
-			}}
-		/>
-	)) as Story<INumericFieldSchema & { defaultValues?: number | undefined }>;
-
-export const Default = Template("numeric-default").bind({});
+export const Default = DefaultStoryTemplate<INumericFieldSchema>("numeric-default").bind({});
 Default.args = {
 	label: "Number",
 	uiType: "numeric-field",
 };
 
-export const DefaultValue = Template("numeric-default-value").bind({});
+export const DefaultValue = DefaultStoryTemplate<INumericFieldSchema, number>("numeric-default-value").bind({});
 DefaultValue.args = {
 	label: "Number",
 	uiType: "numeric-field",
@@ -109,35 +87,35 @@ DefaultValue.argTypes = {
 	},
 };
 
-export const Disabled = Template("numeric-disabled").bind({});
+export const Disabled = DefaultStoryTemplate<INumericFieldSchema>("numeric-disabled").bind({});
 Disabled.args = {
 	label: "Number",
 	uiType: "numeric-field",
 	disabled: true,
 };
 
-export const MaxLength = Template("numeric-maxlength").bind({});
+export const MaxLength = DefaultStoryTemplate<INumericFieldSchema>("numeric-maxlength").bind({});
 MaxLength.args = {
 	label: "Number",
 	uiType: "numeric-field",
 	maxLength: 2,
 };
 
-export const Placeholder = Template("numeric-placeholder").bind({});
+export const Placeholder = DefaultStoryTemplate<INumericFieldSchema>("numeric-placeholder").bind({});
 Placeholder.args = {
 	label: "Number",
 	uiType: "numeric-field",
 	placeholder: "Enter a number",
 };
 
-export const WithValidation = Template("numeric-with-validation").bind({});
+export const WithValidation = DefaultStoryTemplate<INumericFieldSchema>("numeric-with-validation").bind({});
 WithValidation.args = {
 	label: "Number",
 	uiType: "numeric-field",
 	validation: [{ required: true }],
 };
 
-export const PreventCopyAndPaste = Template("prevent-copy-and-paste").bind({});
+export const PreventCopyAndPaste = DefaultStoryTemplate<INumericFieldSchema>("prevent-copy-and-paste").bind({});
 PreventCopyAndPaste.args = {
 	label: "Number",
 	uiType: "numeric-field",
@@ -146,11 +124,36 @@ PreventCopyAndPaste.args = {
 	},
 };
 
-export const PreventDragAndDrop = Template("prevent-drag-and-drop").bind({});
+export const PreventDragAndDrop = DefaultStoryTemplate<INumericFieldSchema>("prevent-drag-and-drop").bind({});
 PreventDragAndDrop.args = {
 	label: "Number",
 	uiType: "numeric-field",
 	customOptions: {
 		preventDragAndDrop: true,
+	},
+};
+export const Reset = ResetStoryTemplate<INumericFieldSchema>("numeric-reset").bind({});
+Reset.args = {
+	label: "Number",
+	uiType: "numeric-field",
+};
+
+export const ResetWithDefaultValues = ResetStoryTemplate<INumericFieldSchema, number>(
+	"numeric-reset-default-values"
+).bind({});
+ResetWithDefaultValues.args = {
+	label: "Number",
+	uiType: "numeric-field",
+	defaultValues: 1,
+};
+ResetWithDefaultValues.argTypes = {
+	defaultValues: {
+		description: "Default value for the field, this is declared outside `sections`",
+		table: {
+			type: {
+				summary: "number",
+			},
+		},
+		type: { name: "object", value: {} },
 	},
 };

--- a/src/stories/3-fields/radio-button/radio-button.stories.tsx
+++ b/src/stories/3-fields/radio-button/radio-button.stories.tsx
@@ -1,7 +1,7 @@
 import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
-import { Meta, Story } from "@storybook/react/types-6-0";
+import { Meta } from "@storybook/react/types-6-0";
 import { IRadioButtonGroupSchema } from "../../../components/fields/radio-button/types";
-import { CommonFieldStoryProps, FrontendEngine, SUBMIT_BUTTON_SCHEMA } from "../../common";
+import { CommonFieldStoryProps, DefaultStoryTemplate, ResetStoryTemplate } from "../../common";
 
 export default {
 	title: "Field/RadioButton/Default",
@@ -46,29 +46,7 @@ export default {
 	},
 } as Meta;
 
-const Template = (id: string) =>
-	(({ defaultValues, ...args }) => (
-		<FrontendEngine
-			data={{
-				sections: {
-					section: {
-						uiType: "section",
-						children: {
-							[id]: args,
-							...SUBMIT_BUTTON_SCHEMA,
-						},
-					},
-				},
-				...(!!defaultValues && {
-					defaultValues: {
-						[id]: defaultValues,
-					},
-				}),
-			}}
-		/>
-	)) as Story<IRadioButtonGroupSchema & { defaultValues?: string | undefined }>;
-
-export const Default = Template("radio-default").bind({});
+export const Default = DefaultStoryTemplate<IRadioButtonGroupSchema>("radio-default").bind({});
 Default.args = {
 	uiType: "radio",
 	label: "Radio Button",
@@ -79,7 +57,7 @@ Default.args = {
 	],
 };
 
-export const DefaultValue = Template("radio-default-value").bind({});
+export const DefaultValue = DefaultStoryTemplate<IRadioButtonGroupSchema>("radio-default-value").bind({});
 DefaultValue.args = {
 	uiType: "radio",
 	label: "Fruits",
@@ -104,7 +82,7 @@ DefaultValue.argTypes = {
 	},
 };
 
-export const DisabledOptions = Template("radio-disabled-options").bind({});
+export const DisabledOptions = DefaultStoryTemplate<IRadioButtonGroupSchema>("radio-disabled-options").bind({});
 DisabledOptions.args = {
 	uiType: "radio",
 	label: "Radio Button",
@@ -115,7 +93,7 @@ DisabledOptions.args = {
 	],
 };
 
-export const Disabled = Template("radio-disabled").bind({});
+export const Disabled = DefaultStoryTemplate<IRadioButtonGroupSchema>("radio-disabled").bind({});
 Disabled.args = {
 	uiType: "radio",
 	label: "Radio Button",
@@ -127,7 +105,7 @@ Disabled.args = {
 	disabled: true,
 };
 
-export const WithValidation = Template("radio-with-validation").bind({});
+export const WithValidation = DefaultStoryTemplate<IRadioButtonGroupSchema>("radio-with-validation").bind({});
 WithValidation.args = {
 	uiType: "radio",
 	label: "Radio Button",
@@ -137,4 +115,40 @@ WithValidation.args = {
 		{ label: "Cherry", value: "Cherry" },
 	],
 	validation: [{ required: true }],
+};
+
+export const Reset = ResetStoryTemplate<IRadioButtonGroupSchema>("radio-reset").bind({});
+Reset.args = {
+	uiType: "radio",
+	label: "Radio Button",
+	options: [
+		{ label: "Apple", value: "Apple" },
+		{ label: "Berry", value: "Berry" },
+		{ label: "Cherry", value: "Cherry" },
+	],
+};
+
+export const ResetWithDefaultValues = ResetStoryTemplate<IRadioButtonGroupSchema>("radio-reset-default-values").bind(
+	{}
+);
+ResetWithDefaultValues.args = {
+	uiType: "radio",
+	label: "Radio Button",
+	options: [
+		{ label: "Apple", value: "Apple" },
+		{ label: "Berry", value: "Berry" },
+		{ label: "Cherry", value: "Cherry" },
+	],
+	defaultValues: "Apple",
+};
+ResetWithDefaultValues.argTypes = {
+	defaultValues: {
+		description: "Default value for the field, this is declared outside `sections`",
+		table: {
+			type: {
+				summary: "string",
+			},
+		},
+		type: { name: "object", value: {} },
+	},
 };

--- a/src/stories/3-fields/radio-button/radio-button.stories.tsx
+++ b/src/stories/3-fields/radio-button/radio-button.stories.tsx
@@ -76,9 +76,6 @@ DefaultValue.argTypes = {
 				summary: "string",
 			},
 		},
-		control: {
-			type: "text",
-		},
 	},
 };
 
@@ -149,6 +146,5 @@ ResetWithDefaultValues.argTypes = {
 				summary: "string",
 			},
 		},
-		type: { name: "object", value: {} },
 	},
 };

--- a/src/stories/3-fields/radio-button/radio-toggle-button.stories.tsx
+++ b/src/stories/3-fields/radio-button/radio-toggle-button.stories.tsx
@@ -92,9 +92,6 @@ DefaultValue.argTypes = {
 				summary: "string",
 			},
 		},
-		control: {
-			type: "text",
-		},
 	},
 };
 
@@ -212,6 +209,5 @@ ResetWithDefaultValues.argTypes = {
 				summary: "string",
 			},
 		},
-		type: { name: "object", value: {} },
 	},
 };

--- a/src/stories/3-fields/radio-button/radio-toggle-button.stories.tsx
+++ b/src/stories/3-fields/radio-button/radio-toggle-button.stories.tsx
@@ -1,7 +1,7 @@
 import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
-import { Meta, Story } from "@storybook/react/types-6-0";
+import { Meta } from "@storybook/react/types-6-0";
 import { IRadioButtonGroupSchema } from "../../../components/fields/radio-button/types";
-import { CommonFieldStoryProps, FrontendEngine, SUBMIT_BUTTON_SCHEMA } from "../../common";
+import { CommonFieldStoryProps, DefaultStoryTemplate, ResetStoryTemplate } from "../../common";
 
 export default {
 	title: "Field/RadioButton/Toggle",
@@ -56,29 +56,7 @@ export default {
 	},
 } as Meta;
 
-const Template = (id: string) =>
-	(({ defaultValues, ...args }) => (
-		<FrontendEngine
-			data={{
-				sections: {
-					section: {
-						uiType: "section",
-						children: {
-							[id]: args,
-							...SUBMIT_BUTTON_SCHEMA,
-						},
-					},
-				},
-				...(!!defaultValues && {
-					defaultValues: {
-						[id]: defaultValues,
-					},
-				}),
-			}}
-		/>
-	)) as Story<IRadioButtonGroupSchema & { defaultValues?: string | undefined }>;
-
-export const Default = Template("radio-default").bind({});
+export const Default = DefaultStoryTemplate<IRadioButtonGroupSchema>("radio-default").bind({});
 Default.args = {
 	uiType: "radio",
 	label: "Radio Button",
@@ -92,7 +70,7 @@ Default.args = {
 	],
 };
 
-export const DefaultValue = Template("radio-default-value").bind({});
+export const DefaultValue = DefaultStoryTemplate<IRadioButtonGroupSchema>("radio-default-value").bind({});
 DefaultValue.args = {
 	uiType: "radio",
 	label: "Fruits",
@@ -120,7 +98,7 @@ DefaultValue.argTypes = {
 	},
 };
 
-export const DisabledOptions = Template("radio-disabled-options").bind({});
+export const DisabledOptions = DefaultStoryTemplate<IRadioButtonGroupSchema>("radio-disabled-options").bind({});
 DisabledOptions.args = {
 	uiType: "radio",
 	label: "Radio Button",
@@ -134,7 +112,7 @@ DisabledOptions.args = {
 	],
 };
 
-export const Disabled = Template("radio-disabled").bind({});
+export const Disabled = DefaultStoryTemplate<IRadioButtonGroupSchema>("radio-disabled").bind({});
 Disabled.args = {
 	uiType: "radio",
 	label: "Radio Button",
@@ -149,7 +127,7 @@ Disabled.args = {
 	disabled: true,
 };
 
-export const WithValidation = Template("radio-with-validation").bind({});
+export const WithValidation = DefaultStoryTemplate<IRadioButtonGroupSchema>("radio-with-validation").bind({});
 WithValidation.args = {
 	uiType: "radio",
 	label: "Radio Button",
@@ -164,7 +142,7 @@ WithValidation.args = {
 	validation: [{ required: true }],
 };
 
-export const WithIndicator = Template("radio-with-validation").bind({});
+export const WithIndicator = DefaultStoryTemplate<IRadioButtonGroupSchema>("radio-with-validation").bind({});
 WithIndicator.args = {
 	uiType: "radio",
 	label: "Radio Button",
@@ -180,7 +158,7 @@ WithIndicator.args = {
 	validation: [{ required: true }],
 };
 
-export const WithoutBorder = Template("radio-with-validation").bind({});
+export const WithoutBorder = DefaultStoryTemplate<IRadioButtonGroupSchema>("radio-with-validation").bind({});
 WithoutBorder.args = {
 	uiType: "radio",
 	label: "Radio Button",
@@ -194,4 +172,46 @@ WithoutBorder.args = {
 		{ label: "Cherry", value: "Cherry" },
 	],
 	validation: [{ required: true }],
+};
+
+export const Reset = ResetStoryTemplate<IRadioButtonGroupSchema>("radio-reset").bind({});
+Reset.args = {
+	uiType: "radio",
+	label: "Radio Button",
+	customOptions: {
+		styleType: "toggle",
+	},
+	options: [
+		{ label: "Apple", value: "Apple" },
+		{ label: "Berry", value: "Berry" },
+		{ label: "Cherry", value: "Cherry" },
+	],
+};
+
+export const ResetWithDefaultValues = ResetStoryTemplate<IRadioButtonGroupSchema>("radio-reset-default-values").bind(
+	{}
+);
+ResetWithDefaultValues.args = {
+	uiType: "radio",
+	label: "Radio Button",
+	customOptions: {
+		styleType: "toggle",
+	},
+	options: [
+		{ label: "Apple", value: "Apple" },
+		{ label: "Berry", value: "Berry" },
+		{ label: "Cherry", value: "Cherry" },
+	],
+	defaultValues: "Apple",
+};
+ResetWithDefaultValues.argTypes = {
+	defaultValues: {
+		description: "Default value for the field, this is declared outside `sections`",
+		table: {
+			type: {
+				summary: "string",
+			},
+		},
+		type: { name: "object", value: {} },
+	},
 };

--- a/src/stories/3-fields/select/select.stories.tsx
+++ b/src/stories/3-fields/select/select.stories.tsx
@@ -1,7 +1,7 @@
 import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
-import { Meta, Story } from "@storybook/react/types-6-0";
+import { Meta } from "@storybook/react/types-6-0";
 import { ISelectSchema } from "../../../components/fields";
-import { CommonFieldStoryProps, FrontendEngine, SUBMIT_BUTTON_SCHEMA } from "../../common";
+import { CommonFieldStoryProps, DefaultStoryTemplate, ResetStoryTemplate } from "../../common";
 
 export default {
 	title: "Field/Select",
@@ -67,40 +67,18 @@ export default {
 	},
 } as Meta;
 
-const Template = (id: string) =>
-	(({ defaultValues, ...args }) => (
-		<FrontendEngine
-			data={{
-				sections: {
-					section: {
-						uiType: "section",
-						children: {
-							[id]: args,
-							...SUBMIT_BUTTON_SCHEMA,
-						},
-					},
-				},
-				...(!!defaultValues && {
-					defaultValues: {
-						[id]: defaultValues,
-					},
-				}),
-			}}
-		/>
-	)) as Story<ISelectSchema & { defaultValues?: string | undefined }>;
-
-export const Default = Template("select-default").bind({});
+export const Default = DefaultStoryTemplate<ISelectSchema>("select-default").bind({});
 Default.args = {
 	uiType: "select",
 	label: "Fruits",
 	options: [
-		{ label: "1", value: "1" },
-		{ label: "2", value: "2" },
-		{ label: "3", value: "3" },
+		{ label: "Apple", value: "apple" },
+		{ label: "Berry", value: "berry" },
+		{ label: "Cherry", value: "cherry" },
 	],
 };
 
-export const DefaultValue = Template("select-default-value").bind({});
+export const DefaultValue = DefaultStoryTemplate<ISelectSchema>("select-default-value").bind({});
 DefaultValue.args = {
 	uiType: "select",
 	label: "Fruits",
@@ -125,7 +103,7 @@ DefaultValue.argTypes = {
 	},
 };
 
-export const Disabled = Template("select-disabled").bind({});
+export const Disabled = DefaultStoryTemplate<ISelectSchema>("select-disabled").bind({});
 Disabled.args = {
 	uiType: "select",
 	label: "Fruits",
@@ -137,7 +115,7 @@ Disabled.args = {
 	disabled: true,
 };
 
-export const CustomWidth = Template("select-custom-width").bind({});
+export const CustomWidth = DefaultStoryTemplate<ISelectSchema>("select-custom-width").bind({});
 CustomWidth.args = {
 	uiType: "select",
 	label: "Fruits",
@@ -149,7 +127,7 @@ CustomWidth.args = {
 	listStyleWidth: "12rem",
 };
 
-export const Placeholder = Template("select-placeholder").bind({});
+export const Placeholder = DefaultStoryTemplate<ISelectSchema>("select-placeholder").bind({});
 Placeholder.args = {
 	uiType: "select",
 	label: "Fruits",
@@ -161,7 +139,7 @@ Placeholder.args = {
 	placeholder: "Select your fruit",
 };
 
-export const WithValidation = Template("select-with-validation").bind({});
+export const WithValidation = DefaultStoryTemplate<ISelectSchema>("select-with-validation").bind({});
 WithValidation.args = {
 	uiType: "select",
 	label: "Fruits",
@@ -171,4 +149,38 @@ WithValidation.args = {
 		{ label: "Cherry", value: "cherry" },
 	],
 	validation: [{ required: true }],
+};
+
+export const Reset = ResetStoryTemplate<ISelectSchema>("select-reset").bind({});
+Reset.args = {
+	uiType: "select",
+	label: "Fruits",
+	options: [
+		{ label: "Apple", value: "Apple" },
+		{ label: "Berry", value: "Berry" },
+		{ label: "Cherry", value: "Cherry" },
+	],
+};
+
+export const ResetWithDefaultValues = ResetStoryTemplate<ISelectSchema>("select-reset-default-values").bind({});
+ResetWithDefaultValues.args = {
+	uiType: "select",
+	label: "Fruits",
+	options: [
+		{ label: "Apple", value: "Apple" },
+		{ label: "Berry", value: "Berry" },
+		{ label: "Cherry", value: "Cherry" },
+	],
+	defaultValues: "Apple",
+};
+ResetWithDefaultValues.argTypes = {
+	defaultValues: {
+		description: "Default value for the field, this is declared outside `sections`",
+		table: {
+			type: {
+				summary: "string",
+			},
+		},
+		type: { name: "object", value: {} },
+	},
 };

--- a/src/stories/3-fields/select/select.stories.tsx
+++ b/src/stories/3-fields/select/select.stories.tsx
@@ -49,9 +49,6 @@ export default {
 					summary: "string",
 				},
 			},
-			control: {
-				type: "text",
-			},
 		},
 		listStyleWidth: {
 			description: "Style option: The width of the options. You can specify e.g. 100% or 12rem",
@@ -59,9 +56,6 @@ export default {
 				type: {
 					summary: "string",
 				},
-			},
-			control: {
-				type: "text",
 			},
 		},
 	},
@@ -96,9 +90,6 @@ DefaultValue.argTypes = {
 			type: {
 				summary: "string",
 			},
-		},
-		control: {
-			type: "text",
 		},
 	},
 };
@@ -181,6 +172,5 @@ ResetWithDefaultValues.argTypes = {
 				summary: "string",
 			},
 		},
-		type: { name: "object", value: {} },
 	},
 };

--- a/src/stories/3-fields/text-field/text-field.stories.tsx
+++ b/src/stories/3-fields/text-field/text-field.stories.tsx
@@ -1,7 +1,7 @@
 import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
-import { Meta, Story } from "@storybook/react/types-6-0";
+import { Meta } from "@storybook/react/types-6-0";
 import { ITextFieldSchema } from "../../../components/fields";
-import { CommonFieldStoryProps, FrontendEngine, SUBMIT_BUTTON_SCHEMA } from "../../common";
+import { CommonFieldStoryProps, DefaultStoryTemplate, ResetStoryTemplate } from "../../common";
 
 export default {
 	title: "Field/TextField",
@@ -63,35 +63,13 @@ export default {
 	},
 } as Meta;
 
-const Template = (id: string) =>
-	(({ defaultValues, ...args }) => (
-		<FrontendEngine
-			data={{
-				sections: {
-					section: {
-						uiType: "section",
-						children: {
-							[id]: args,
-							...SUBMIT_BUTTON_SCHEMA,
-						},
-					},
-				},
-				...(!!defaultValues && {
-					defaultValues: {
-						[id]: defaultValues,
-					},
-				}),
-			}}
-		/>
-	)) as Story<ITextFieldSchema & { defaultValues?: string | undefined }>;
-
-export const Default = Template("text-default").bind({});
+export const Default = DefaultStoryTemplate<ITextFieldSchema>("text-default").bind({});
 Default.args = {
 	label: "Textfield",
 	uiType: "text-field",
 };
 
-export const DefaultValue = Template("text-default-value").bind({});
+export const DefaultValue = DefaultStoryTemplate<ITextFieldSchema>("text-default-value").bind({});
 DefaultValue.args = {
 	label: "Textfield",
 	uiType: "text-field",
@@ -111,35 +89,35 @@ DefaultValue.argTypes = {
 	},
 };
 
-export const Disabled = Template("text-disabled").bind({});
+export const Disabled = DefaultStoryTemplate<ITextFieldSchema>("text-disabled").bind({});
 Disabled.args = {
 	label: "Textfield",
 	uiType: "text-field",
 	disabled: true,
 };
 
-export const MaxLength = Template("text-maxlength").bind({});
+export const MaxLength = DefaultStoryTemplate<ITextFieldSchema>("text-maxlength").bind({});
 MaxLength.args = {
 	label: "Textfield",
 	uiType: "text-field",
 	validation: [{ max: 5 }],
 };
 
-export const Placeholder = Template("text-placeholder").bind({});
+export const Placeholder = DefaultStoryTemplate<ITextFieldSchema>("text-placeholder").bind({});
 Placeholder.args = {
 	label: "Textfield",
 	uiType: "text-field",
 	placeholder: "Enter text here",
 };
 
-export const WithValidation = Template("text-with-validation").bind({});
+export const WithValidation = DefaultStoryTemplate<ITextFieldSchema>("text-with-validation").bind({});
 WithValidation.args = {
 	label: "Textfield",
 	uiType: "text-field",
 	validation: [{ required: true }],
 };
 
-export const PreventCopyAndPaste = Template("prevent-copy-and-paste").bind({});
+export const PreventCopyAndPaste = DefaultStoryTemplate<ITextFieldSchema>("prevent-copy-and-paste").bind({});
 PreventCopyAndPaste.args = {
 	label: "Textfield",
 	uiType: "text-field",
@@ -148,11 +126,35 @@ PreventCopyAndPaste.args = {
 	},
 };
 
-export const PreventDragAndDrop = Template("prevent-drag-and-drop").bind({});
+export const PreventDragAndDrop = DefaultStoryTemplate<ITextFieldSchema>("prevent-drag-and-drop").bind({});
 PreventDragAndDrop.args = {
 	label: "Textfield",
 	uiType: "text-field",
 	customOptions: {
 		preventDragAndDrop: true,
+	},
+};
+
+export const Reset = ResetStoryTemplate<ITextFieldSchema>("text-reset").bind({});
+Reset.args = {
+	label: "Textfield",
+	uiType: "text-field",
+};
+
+export const ResetWithDefaultValues = ResetStoryTemplate<ITextFieldSchema>("text-reset-default-values").bind({});
+ResetWithDefaultValues.args = {
+	label: "Textfield",
+	uiType: "text-field",
+	defaultValues: "This is the default value",
+};
+ResetWithDefaultValues.argTypes = {
+	defaultValues: {
+		description: "Default value for the field, this is declared outside `sections`",
+		table: {
+			type: {
+				summary: "string",
+			},
+		},
+		type: { name: "object", value: {} },
 	},
 };

--- a/src/stories/3-fields/text-field/text-field.stories.tsx
+++ b/src/stories/3-fields/text-field/text-field.stories.tsx
@@ -32,9 +32,6 @@ export default {
 					summary: "string",
 				},
 			},
-			control: {
-				type: "text",
-			},
 		},
 		disabled: {
 			description: "Specifies if the textfield is interactable",
@@ -82,9 +79,6 @@ DefaultValue.argTypes = {
 			type: {
 				summary: "string",
 			},
-		},
-		control: {
-			type: "text",
 		},
 	},
 };
@@ -155,6 +149,5 @@ ResetWithDefaultValues.argTypes = {
 				summary: "string",
 			},
 		},
-		type: { name: "object", value: {} },
 	},
 };

--- a/src/stories/3-fields/textarea/textarea.stories.tsx
+++ b/src/stories/3-fields/textarea/textarea.stories.tsx
@@ -94,9 +94,6 @@ DefaultValue.argTypes = {
 				summary: "string",
 			},
 		},
-		control: {
-			type: "text",
-		},
 	},
 };
 
@@ -165,6 +162,5 @@ ResetWithDefaultValues.argTypes = {
 				summary: "string",
 			},
 		},
-		type: { name: "object", value: {} },
 	},
 };

--- a/src/stories/3-fields/textarea/textarea.stories.tsx
+++ b/src/stories/3-fields/textarea/textarea.stories.tsx
@@ -1,7 +1,7 @@
 import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
-import { Meta, Story } from "@storybook/react/types-6-0";
+import { Meta } from "@storybook/react/types-6-0";
 import { ITextareaSchema } from "../../../components/fields";
-import { CommonFieldStoryProps, FrontendEngine, SUBMIT_BUTTON_SCHEMA } from "../../common";
+import { CommonFieldStoryProps, DefaultStoryTemplate, ResetStoryTemplate } from "../../common";
 
 export default {
 	title: "Field/Textarea",
@@ -74,35 +74,13 @@ export default {
 	},
 } as Meta;
 
-const Template = (id: string) =>
-	(({ defaultValues, ...args }) => (
-		<FrontendEngine
-			data={{
-				sections: {
-					section: {
-						uiType: "section",
-						children: {
-							[id]: args,
-							...SUBMIT_BUTTON_SCHEMA,
-						},
-					},
-				},
-				...(!!defaultValues && {
-					defaultValues: {
-						[id]: defaultValues,
-					},
-				}),
-			}}
-		/>
-	)) as Story<ITextareaSchema & { defaultValues?: string | undefined }>;
-
-export const Default = Template("textarea-default").bind({});
+export const Default = DefaultStoryTemplate<ITextareaSchema>("textarea-default").bind({});
 Default.args = {
 	uiType: "textarea",
 	label: "Textarea",
 };
 
-export const DefaultValue = Template("textarea-default-value").bind({});
+export const DefaultValue = DefaultStoryTemplate<ITextareaSchema>("textarea-default-value").bind({});
 DefaultValue.args = {
 	uiType: "textarea",
 	label: "Textarea",
@@ -122,7 +100,7 @@ DefaultValue.argTypes = {
 	},
 };
 
-export const AllowResize = Template("textarea-allow-resize").bind({});
+export const AllowResize = DefaultStoryTemplate<ITextareaSchema>("textarea-allow-resize").bind({});
 AllowResize.args = {
 	uiType: "textarea",
 	label: "Resizable textarea",
@@ -130,21 +108,21 @@ AllowResize.args = {
 	rows: 3,
 };
 
-export const WithCounter = Template.bind({});
-WithCounter("textarea-with-counter").args = {
+export const WithCounter = DefaultStoryTemplate<ITextareaSchema>("textarea-with-counter").bind({});
+WithCounter.args = {
 	uiType: "textarea",
 	label: "Textarea with counter",
 	validation: [{ max: 5 }],
 };
 
-export const WithPills = Template("textarea-with-pills").bind({});
+export const WithPills = DefaultStoryTemplate<ITextareaSchema>("textarea-with-pills").bind({});
 WithPills.args = {
 	uiType: "textarea",
 	label: "Textarea with pills",
 	chipTexts: ["Pill 1", "Pill 2", "Pill 3"],
 };
 
-export const WithPillsBottom = Template("textarea-with-pills-bottom").bind({});
+export const WithPillsBottom = DefaultStoryTemplate<ITextareaSchema>("textarea-with-pills-bottom").bind({});
 WithPillsBottom.storyName = "With Pills (Bottom)";
 WithPillsBottom.args = {
 	uiType: "textarea",
@@ -153,16 +131,40 @@ WithPillsBottom.args = {
 	chipPosition: "bottom",
 };
 
-export const WithValidation = Template("textarea-with-validation").bind({});
+export const WithValidation = DefaultStoryTemplate<ITextareaSchema>("textarea-with-validation").bind({});
 WithValidation.args = {
 	uiType: "textarea",
 	label: "Textarea with validation",
 	validation: [{ required: true }, { min: 3, errorMessage: "Min. 3 characters" }],
 };
 
-export const WithPlaceholder = Template("textarea-with-placeholder").bind({});
+export const WithPlaceholder = DefaultStoryTemplate<ITextareaSchema>("textarea-with-placeholder").bind({});
 WithPlaceholder.args = {
 	uiType: "textarea",
 	label: "Textarea with placeholder",
 	placeholder: "Enter something...",
+};
+
+export const Reset = ResetStoryTemplate<ITextareaSchema>("textarea-reset").bind({});
+Reset.args = {
+	uiType: "textarea",
+	label: "Textarea",
+};
+
+export const ResetWithDefaultValues = ResetStoryTemplate<ITextareaSchema>("textarea-reset-default-values").bind({});
+ResetWithDefaultValues.args = {
+	uiType: "textarea",
+	label: "Textarea",
+	defaultValues: "This is the default value",
+};
+ResetWithDefaultValues.argTypes = {
+	defaultValues: {
+		description: "Default value for the field, this is declared outside `sections`",
+		table: {
+			type: {
+				summary: "string",
+			},
+		},
+		type: { name: "object", value: {} },
+	},
 };

--- a/src/stories/3-fields/time-field/time-field.stories.tsx
+++ b/src/stories/3-fields/time-field/time-field.stories.tsx
@@ -1,7 +1,7 @@
 import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
-import { Meta, Story } from "@storybook/react/types-6-0";
+import { Meta } from "@storybook/react/types-6-0";
 import { ITimeFieldSchema } from "src/components/fields";
-import { CommonFieldStoryProps, FrontendEngine, SUBMIT_BUTTON_SCHEMA } from "../../common";
+import { CommonFieldStoryProps, DefaultStoryTemplate, ResetStoryTemplate } from "../../common";
 
 export default {
 	title: "Field/TimeField",
@@ -73,65 +73,78 @@ export default {
 	},
 } as Meta;
 
-const Template = (id: string) =>
-	(({ defaultValues, ...args }) => (
-		<FrontendEngine
-			data={{
-				sections: {
-					section: {
-						uiType: "section",
-						children: {
-							[id]: args,
-							...SUBMIT_BUTTON_SCHEMA,
-						},
-					},
-				},
-				...(!!defaultValues && {
-					defaultValues: {
-						[id]: defaultValues,
-					},
-				}),
-			}}
-		/>
-	)) as Story<ITimeFieldSchema & { defaultValues?: string | undefined }>;
-
-export const Default = Template("time-default").bind({});
+export const Default = DefaultStoryTemplate<ITimeFieldSchema>("time-default").bind({});
 Default.args = {
 	label: "Time",
 	uiType: "time-field",
 };
 
-export const Disabled = Template("time-disabled").bind({});
+export const Disabled = DefaultStoryTemplate<ITimeFieldSchema>("time-disabled").bind({});
 Disabled.args = {
 	label: "Time",
 	uiType: "time-field",
 	disabled: true,
 };
 
-export const DefaultValue = Template("time-default-value").bind({});
+export const DefaultValue = DefaultStoryTemplate<ITimeFieldSchema>("time-default-value").bind({});
 DefaultValue.args = {
 	label: "Time",
 	uiType: "time-field",
 	defaultValues: "11:11am",
 };
+DefaultValue.argTypes = {
+	defaultValues: {
+		description: "Default value for the field, this is declared outside `sections`",
+		table: {
+			type: {
+				summary: "string",
+			},
+		},
+		type: { name: "object", value: {} },
+	},
+};
 
-export const UseCurrentTime = Template("time-use-current-time").bind({});
+export const UseCurrentTime = DefaultStoryTemplate<ITimeFieldSchema>("time-use-current-time").bind({});
 UseCurrentTime.args = {
 	label: "Time",
 	uiType: "time-field",
 	useCurrentTime: true,
 };
 
-export const Placeholder = Template("time-placeholder").bind({});
+export const Placeholder = DefaultStoryTemplate<ITimeFieldSchema>("time-placeholder").bind({});
 Placeholder.args = {
 	label: "Time",
 	uiType: "time-field",
 	placeholder: "Select a preferred time",
 };
 
-export const Use24HoursFormat = Template("time-24hr-format").bind({});
+export const Use24HoursFormat = DefaultStoryTemplate<ITimeFieldSchema>("time-24hr-format").bind({});
 Use24HoursFormat.args = {
 	label: "Time",
 	uiType: "time-field",
 	is24HourFormat: true,
+};
+
+export const Reset = ResetStoryTemplate<ITimeFieldSchema>("time-reset").bind({});
+Reset.args = {
+	label: "Time",
+	uiType: "time-field",
+};
+
+export const ResetWithDefaultValues = ResetStoryTemplate<ITimeFieldSchema>("time-reset-default-values").bind({});
+ResetWithDefaultValues.args = {
+	label: "Time",
+	uiType: "time-field",
+	defaultValues: "11:11am",
+};
+ResetWithDefaultValues.argTypes = {
+	defaultValues: {
+		description: "Default value for the field, this is declared outside `sections`",
+		table: {
+			type: {
+				summary: "string",
+			},
+		},
+		type: { name: "object", value: {} },
+	},
 };

--- a/src/stories/3-fields/time-field/time-field.stories.tsx
+++ b/src/stories/3-fields/time-field/time-field.stories.tsx
@@ -27,9 +27,6 @@ export default {
 					summary: "string",
 				},
 			},
-			control: {
-				type: "text",
-			},
 		},
 		disabled: {
 			description: "Specifies if the form element is interactable",
@@ -100,7 +97,6 @@ DefaultValue.argTypes = {
 				summary: "string",
 			},
 		},
-		type: { name: "object", value: {} },
 	},
 };
 
@@ -145,6 +141,5 @@ ResetWithDefaultValues.argTypes = {
 				summary: "string",
 			},
 		},
-		type: { name: "object", value: {} },
 	},
 };

--- a/src/stories/3-fields/time-field/time-field.stories.tsx
+++ b/src/stories/3-fields/time-field/time-field.stories.tsx
@@ -143,3 +143,10 @@ ResetWithDefaultValues.argTypes = {
 		},
 	},
 };
+
+export const ResetToCurrentTime = ResetStoryTemplate<ITimeFieldSchema>("date-reset-current-date").bind({});
+ResetToCurrentTime.args = {
+	label: "Time",
+	uiType: "time-field",
+	useCurrentTime: true,
+};

--- a/src/stories/3-fields/unit-number-field/unit-number-field.stories.tsx
+++ b/src/stories/3-fields/unit-number-field/unit-number-field.stories.tsx
@@ -1,7 +1,7 @@
 import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
-import { Meta, Story } from "@storybook/react/types-6-0";
+import { Meta } from "@storybook/react/types-6-0";
 import { IUnitNumberFieldSchema } from "src/components/fields";
-import { CommonFieldStoryProps, FrontendEngine, SUBMIT_BUTTON_SCHEMA } from "../../common";
+import { CommonFieldStoryProps, DefaultStoryTemplate, ResetStoryTemplate } from "../../common";
 
 export default {
 	title: "Field/UnitNumberField",
@@ -47,42 +47,20 @@ export default {
 	},
 } as Meta;
 
-const Template = (id: string) =>
-	(({ defaultValues, ...args }) => (
-		<FrontendEngine
-			data={{
-				sections: {
-					section: {
-						uiType: "section",
-						children: {
-							[id]: args,
-							...SUBMIT_BUTTON_SCHEMA,
-						},
-					},
-				},
-				...(!!defaultValues && {
-					defaultValues: {
-						[id]: defaultValues,
-					},
-				}),
-			}}
-		/>
-	)) as Story<IUnitNumberFieldSchema & { defaultValues?: string | undefined }>;
-
-export const Default = Template("unit-number-default").bind({});
+export const Default = DefaultStoryTemplate<IUnitNumberFieldSchema>("unit-number-default").bind({});
 Default.args = {
 	label: "Unit Number",
 	uiType: "unit-number-field",
 };
 
-export const Disabled = Template("unit-number-disabled").bind({});
+export const Disabled = DefaultStoryTemplate<IUnitNumberFieldSchema>("unit-number-disabled").bind({});
 Disabled.args = {
 	label: "Unit Number",
 	uiType: "unit-number-field",
 	disabled: true,
 };
 
-export const DefaultValue = Template("unit-number-default-value").bind({});
+export const DefaultValue = DefaultStoryTemplate<IUnitNumberFieldSchema>("unit-number-default-value").bind({});
 DefaultValue.args = {
 	uiType: "unit-number-field",
 	label: "Unit number with default value",
@@ -102,23 +80,49 @@ DefaultValue.argTypes = {
 	},
 };
 
-export const Placeholder = Template("unit-number-placeholder").bind({});
+export const Placeholder = DefaultStoryTemplate<IUnitNumberFieldSchema>("unit-number-placeholder").bind({});
 Placeholder.args = {
 	label: "Unit number with placeholder",
 	uiType: "unit-number-field",
 	placeholder: "03-045",
 };
 
-export const CustomErrorMessage = Template("unit-number-custom-error").bind({});
+export const CustomErrorMessage = DefaultStoryTemplate<IUnitNumberFieldSchema>("unit-number-custom-error").bind({});
 CustomErrorMessage.args = {
 	label: "Unit number with custom error",
 	uiType: "unit-number-field",
 	validation: [{ unitNumberFormat: true, errorMessage: "Please enter a valid unit number" }],
 };
 
-export const WithValidation = Template("unit-number-with-validation").bind({});
+export const WithValidation = DefaultStoryTemplate<IUnitNumberFieldSchema>("unit-number-with-validation").bind({});
 WithValidation.args = {
 	label: "Unit number with validation",
 	uiType: "unit-number-field",
 	validation: [{ required: true }],
+};
+
+export const Reset = ResetStoryTemplate<IUnitNumberFieldSchema>("unit-number-reset").bind({});
+Reset.args = {
+	label: "Unit Number",
+	uiType: "unit-number-field",
+};
+
+export const ResetWithDefaultValues = ResetStoryTemplate<IUnitNumberFieldSchema>(
+	"unit-number-reset-default-values"
+).bind({});
+ResetWithDefaultValues.args = {
+	label: "Unit Number",
+	uiType: "unit-number-field",
+	defaultValues: "01-019",
+};
+ResetWithDefaultValues.argTypes = {
+	defaultValues: {
+		description: "Default value for the field, this is declared outside `sections`",
+		table: {
+			type: {
+				summary: "string",
+			},
+		},
+		type: { name: "object", value: {} },
+	},
 };

--- a/src/stories/3-fields/unit-number-field/unit-number-field.stories.tsx
+++ b/src/stories/3-fields/unit-number-field/unit-number-field.stories.tsx
@@ -27,9 +27,6 @@ export default {
 					summary: "string",
 				},
 			},
-			control: {
-				type: "text",
-			},
 		},
 		disabled: {
 			description: "Specifies if the form element is interactable",
@@ -73,9 +70,6 @@ DefaultValue.argTypes = {
 			type: {
 				summary: "string",
 			},
-		},
-		control: {
-			type: "text",
 		},
 	},
 };
@@ -123,6 +117,5 @@ ResetWithDefaultValues.argTypes = {
 				summary: "string",
 			},
 		},
-		type: { name: "object", value: {} },
 	},
 };

--- a/src/stories/5-custom/filter/filter.stories.tsx
+++ b/src/stories/5-custom/filter/filter.stories.tsx
@@ -29,15 +29,9 @@ export default {
 					summary: "string",
 				},
 			},
-			control: {
-				type: "text",
-			},
 		},
 		toggleFilterButtonLabel: {
 			description: "Filter button label used in mobile view.",
-			control: {
-				type: "text",
-			},
 			defaultValue: "Filters Mobile",
 		},
 		clearButtonDisabled: {

--- a/src/stories/common.tsx
+++ b/src/stories/common.tsx
@@ -1,10 +1,11 @@
-import styled from "styled-components";
+import { MediaQuery, MediaWidths } from "@lifesg/react-design-system";
 import { action } from "@storybook/addon-actions";
+import { Story } from "@storybook/react/types-6-0";
+import { ReactElement, Ref, forwardRef } from "react";
+import styled from "styled-components";
 import { IFrontendEngineProps, IYupValidationRule, FrontendEngine as OriginalFrontendEngine } from "../components";
 import { ISubmitButtonSchema } from "../components/fields";
-import { IFrontendEngineRef, TNoInfer } from "../components/frontend-engine";
-import { ReactElement, Ref, forwardRef } from "react";
-import { MediaQuery, MediaWidths } from "@lifesg/react-design-system";
+import { IFrontendEngineRef, TFrontendEngineFieldSchema, TNoInfer } from "../components/frontend-engine";
 
 const EXCLUDED_STORY_PROPS = {
 	invalid: { table: { disable: true } },
@@ -166,3 +167,68 @@ export const LOREM_IPSUM = (prefix: string) => {
 
 	return `${prefix && codePrefix + " : "}Lorem ipsum dolor sit`;
 };
+
+/**
+ * Default story template that contains the component and a submit button
+ *
+ * &lt;T&gt; generic: component schema definition
+ *
+ * &lt;U&gt; generic: default value typing
+ */
+export const DefaultStoryTemplate = <T, U = string>(id: string) =>
+	(({ defaultValues, ...args }) => (
+		<FrontendEngine
+			data={{
+				sections: {
+					section: {
+						uiType: "section",
+						children: {
+							[id]: args as unknown as TFrontendEngineFieldSchema,
+							...SUBMIT_BUTTON_SCHEMA,
+						},
+					},
+				},
+				...(!!defaultValues && {
+					defaultValues: {
+						[id]: defaultValues,
+					},
+				}),
+			}}
+		/>
+	)) as Story<T & { defaultValues?: U | undefined }>;
+
+/**
+ * Story template that contains the component, a reset button and a submit button
+ *
+ * &lt;T&gt; generic: component schema definition
+ *
+ * &lt;U&gt; generic: default value typing
+ */
+export const ResetStoryTemplate = <T, U = string>(id: string) =>
+	(({ defaultValues, ...args }) => (
+		<FrontendEngine
+			data={{
+				sections: {
+					section: {
+						uiType: "section",
+						children: {
+							[id]: args as unknown as TFrontendEngineFieldSchema,
+							buttons: {
+								uiType: "div",
+								style: { display: "flex", gap: "1rem" },
+								children: {
+									"reset-button": { uiType: "reset", label: "Reset" },
+									...SUBMIT_BUTTON_SCHEMA,
+								},
+							},
+						},
+					},
+				},
+				...(!!defaultValues && {
+					defaultValues: {
+						[id]: defaultValues,
+					},
+				}),
+			}}
+		/>
+	)) as Story<T & { defaultValues?: U | undefined }>;

--- a/src/stories/common.tsx
+++ b/src/stories/common.tsx
@@ -4,7 +4,7 @@ import { Story } from "@storybook/react/types-6-0";
 import { ReactElement, Ref, forwardRef } from "react";
 import styled from "styled-components";
 import { IFrontendEngineProps, IYupValidationRule, FrontendEngine as OriginalFrontendEngine } from "../components";
-import { ISubmitButtonSchema } from "../components/fields";
+import { IResetButtonSchema, ISubmitButtonSchema } from "../components/fields";
 import { IFrontendEngineRef, TFrontendEngineFieldSchema, TNoInfer } from "../components/frontend-engine";
 
 const EXCLUDED_STORY_PROPS = {
@@ -122,6 +122,9 @@ export const CommonCustomStoryProps = (referenceKey: string) => {
 export const SUBMIT_BUTTON_SCHEMA: Record<string, ISubmitButtonSchema> = {
 	"submit-button": { uiType: "submit", label: "Submit" },
 };
+export const RESET_BUTTON_SCHEMA: Record<string, IResetButtonSchema> = {
+	"reset-button": { uiType: "reset", label: "Reset" },
+};
 
 const MINIMUM_SIDE_PADDING = 48;
 const SIDEBAR_WIDTH = 210;
@@ -217,7 +220,7 @@ export const ResetStoryTemplate = <T, U = string>(id: string) =>
 								uiType: "div",
 								style: { display: "flex", gap: "1rem" },
 								children: {
-									"reset-button": { uiType: "reset", label: "Reset" },
+									...RESET_BUTTON_SCHEMA,
 									...SUBMIT_BUTTON_SCHEMA,
 								},
 							},

--- a/src/stories/common.tsx
+++ b/src/stories/common.tsx
@@ -60,9 +60,6 @@ export const CommonFieldStoryProps = (uiType: string, onlyFieldType = false) => 
 					summary: "string",
 				},
 			},
-			control: {
-				type: "text",
-			},
 		},
 		validation: {
 			description:
@@ -100,9 +97,6 @@ export const CommonCustomStoryProps = (referenceKey: string) => {
 			},
 			type: { name: "string", required: true },
 			options: [referenceKey],
-			control: {
-				type: "text",
-			},
 			defaultValue: referenceKey,
 		},
 		label: {
@@ -111,9 +105,6 @@ export const CommonCustomStoryProps = (referenceKey: string) => {
 				type: {
 					summary: "string",
 				},
-			},
-			control: {
-				type: "text",
 			},
 		},
 	};


### PR DESCRIPTION
**Changes**
- Fixed reset behaviours in:
  - chips
  - contact-field
  - date-field
  - textarea
  - time-field
- converted time-field am/pm to uppercase
- fixed handling of default values in chips with textarea
- created reset stories and tests for each field
- created common story templates for fields to use

**Additional information**
- This fixes a number of bugs reported
  - Bugs with `useCurrentDate` in date-field (https://github.com/LifeSG/web-frontend-engine/issues/65)
  - Bug with reset chips with textarea (CCUBE-219)
  - Unable to reset textarea (CCUBE-220)
