### PR TITLE
new ignoreDefaultValues prop for reset button

### DIFF
--- a/src/__tests__/components/fields/reset/reset.spec.tsx
+++ b/src/__tests__/components/fields/reset/reset.spec.tsx
@@ -5,8 +5,8 @@ import { IResetButtonSchema } from "../../../../components/fields";
 import { IFrontendEngineData, TFrontendEngineValues } from "../../../../components/types";
 import { FRONTEND_ENGINE_ID, getField, getSubmitButton, getSubmitButtonProps } from "../../../common";
 
-const COMPONENT_ID = "field";
-const COMPONENT_LABEL = "Textfield";
+const TEXT_ID = "field";
+const TEXT_LABEL = "Textfield";
 
 const CHECKBOX_ID = "checkbox";
 const CHECKBOX_LABEL = "Checkbox";
@@ -26,10 +26,9 @@ const renderComponent = (
 			section: {
 				uiType: "section",
 				children: {
-					[COMPONENT_ID]: {
-						label: COMPONENT_LABEL,
+					[TEXT_ID]: {
+						label: TEXT_LABEL,
 						uiType: "text-field",
-						validation: [{ required: true }],
 					},
 					[CHECKBOX_ID]: {
 						label: CHECKBOX_LABEL,
@@ -51,7 +50,7 @@ const renderComponent = (
 };
 
 const getTextfield = (): HTMLElement => {
-	return getField("textbox", COMPONENT_LABEL);
+	return getField("textbox", TEXT_LABEL);
 };
 
 const getResetButton = (): HTMLElement => {
@@ -68,7 +67,7 @@ describe("reset", () => {
 		${"hello"} | ${"is set"}
 		${""}      | ${"is not set"}
 	`("reset the form on press to $description when default value is not set", async ({ result }) => {
-		renderComponent(undefined, _.isEmpty(result) ? undefined : { [COMPONENT_ID]: "hello" });
+		renderComponent(undefined, _.isEmpty(result) ? undefined : { [TEXT_ID]: "hello" });
 
 		const textfield = getTextfield();
 
@@ -80,30 +79,12 @@ describe("reset", () => {
 		expect(textfield).toHaveValue(result);
 	});
 
-	// it.each`
-	// 	defaultValue | expected | type
-	// 	${"hello"}   | ${""}    | ${"string"}
-	// 	${123}       | ${""}    | ${"number"}
-	// 	${["Apple"]} | ${[]}    | ${"array"}
-	// `(
-	// 	"reset the form on press to '' when default value is $type, ignoreDefaultValue:true",
-	// 	async ({ defaultValue, expected }) => {
-	// 		renderComponent({ ignoreDefaultValues: true }, { [COMPONENT_ID]: defaultValue });
-
-	// 		const textfield = getTextfield();
-	// 		const
-
-	// 		await waitFor(() => fireEvent.click(getResetButton()));
-	// 		expect(textfield).toHaveValue(expected);
-	// 	}
-	// );
-
 	it("reset the form on press when default value is set, ignoreDefaultValue:true", async () => {
-		renderComponent({ ignoreDefaultValues: true }, { [CHECKBOX_ID]: ["Apple"], [COMPONENT_ID]: "hello" });
+		renderComponent({ ignoreDefaultValues: true }, { [CHECKBOX_ID]: ["Apple"], [TEXT_ID]: "hello" });
 
 		await waitFor(() => fireEvent.click(getResetButton()));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [CHECKBOX_ID]: [], [COMPONENT_ID]: "" }));
+		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [CHECKBOX_ID]: [], [TEXT_ID]: "" }));
 	});
 
 	it("should be disabled if configured", async () => {

--- a/src/__tests__/components/fields/reset/reset.spec.tsx
+++ b/src/__tests__/components/fields/reset/reset.spec.tsx
@@ -3,13 +3,18 @@ import _ from "lodash";
 import { FrontendEngine } from "../../../../components";
 import { IResetButtonSchema } from "../../../../components/fields";
 import { IFrontendEngineData, TFrontendEngineValues } from "../../../../components/types";
-import { FRONTEND_ENGINE_ID, getField } from "../../../common";
+import { FRONTEND_ENGINE_ID, getField, getSubmitButton, getSubmitButtonProps } from "../../../common";
 
 const COMPONENT_ID = "field";
 const COMPONENT_LABEL = "Textfield";
 
+const CHECKBOX_ID = "checkbox";
+const CHECKBOX_LABEL = "Checkbox";
+
 const RESET_BUTTON_ID = "reset";
 const RESET_BUTTON_LABEL = "Reset";
+
+const SUBMIT_FN = jest.fn();
 
 const renderComponent = (
 	overrideReset?: Partial<IResetButtonSchema> | undefined,
@@ -26,17 +31,23 @@ const renderComponent = (
 						uiType: "text-field",
 						validation: [{ required: true }],
 					},
+					[CHECKBOX_ID]: {
+						label: CHECKBOX_LABEL,
+						uiType: "checkbox",
+						options: [{ label: "A", value: "Apple" }],
+					},
 					[RESET_BUTTON_ID]: {
 						label: RESET_BUTTON_LABEL,
 						uiType: "reset",
 						...overrideReset,
 					},
+					...getSubmitButtonProps(),
 				},
 			},
 		},
 		defaultValues: overrideDefaultValue,
 	};
-	return render(<FrontendEngine data={json} />);
+	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
 };
 
 const getTextfield = (): HTMLElement => {
@@ -48,11 +59,15 @@ const getResetButton = (): HTMLElement => {
 };
 
 describe("reset", () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
 	it.each`
 		result     | description
 		${"hello"} | ${"is set"}
 		${""}      | ${"is not set"}
-	`("reset the form to on press to $description when default value is not set", async ({ result }) => {
+	`("reset the form on press to $description when default value is not set", async ({ result }) => {
 		renderComponent(undefined, _.isEmpty(result) ? undefined : { [COMPONENT_ID]: "hello" });
 
 		const textfield = getTextfield();
@@ -63,6 +78,32 @@ describe("reset", () => {
 
 		await waitFor(() => fireEvent.click(getResetButton()));
 		expect(textfield).toHaveValue(result);
+	});
+
+	// it.each`
+	// 	defaultValue | expected | type
+	// 	${"hello"}   | ${""}    | ${"string"}
+	// 	${123}       | ${""}    | ${"number"}
+	// 	${["Apple"]} | ${[]}    | ${"array"}
+	// `(
+	// 	"reset the form on press to '' when default value is $type, ignoreDefaultValue:true",
+	// 	async ({ defaultValue, expected }) => {
+	// 		renderComponent({ ignoreDefaultValues: true }, { [COMPONENT_ID]: defaultValue });
+
+	// 		const textfield = getTextfield();
+	// 		const
+
+	// 		await waitFor(() => fireEvent.click(getResetButton()));
+	// 		expect(textfield).toHaveValue(expected);
+	// 	}
+	// );
+
+	it("reset the form on press when default value is set, ignoreDefaultValue:true", async () => {
+		renderComponent({ ignoreDefaultValues: true }, { [CHECKBOX_ID]: ["Apple"], [COMPONENT_ID]: "hello" });
+
+		await waitFor(() => fireEvent.click(getResetButton()));
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [CHECKBOX_ID]: [], [COMPONENT_ID]: "" }));
 	});
 
 	it("should be disabled if configured", async () => {

--- a/src/components/fields/reset-button/reset-button.tsx
+++ b/src/components/fields/reset-button/reset-button.tsx
@@ -8,19 +8,28 @@ export const ResetButton = (props: IGenericFieldProps<IResetButtonSchema>) => {
 	// CONST, STATE, REF
 	// =============================================================================
 	const {
-		schema: { label, disabled, ...otherSchema },
+		schema: { label, disabled, ignoreDefaultValues, ...otherSchema },
 		id,
 		...otherProps
 	} = props;
 
-	const { reset } = useFormContext();
+	const { reset, getValues } = useFormContext();
 
 	// =============================================================================
 	// EFFECTS
 	// =============================================================================
-
 	const onClick = () => {
-		reset();
+		if (ignoreDefaultValues) {
+			const values = getValues();
+			Object.entries(values).forEach(([key, value]) => {
+				if (Array.isArray(value)) {
+					values[key] = [];
+				} else {
+					values[key] = "";
+				}
+			});
+			reset(values);
+		} else reset();
 	};
 
 	// =============================================================================

--- a/src/components/fields/reset-button/types.ts
+++ b/src/components/fields/reset-button/types.ts
@@ -5,4 +5,5 @@ export interface IResetButtonSchema
 	extends Omit<IFrontendEngineBaseFieldJsonSchema<"reset">, "validation">,
 		TComponentOmitProps<ButtonProps, "disabled"> {
 	disabled?: boolean | undefined;
+	ignoreDefaultValues?: boolean | undefined;
 }

--- a/src/stories/3-fields/reset-button/reset-button.stories.tsx
+++ b/src/stories/3-fields/reset-button/reset-button.stories.tsx
@@ -51,6 +51,19 @@ export default {
 				type: "select",
 			},
 		},
+		ignoreDefaultValues: {
+			description: "Specifies if button should reset all fields and default values to blank",
+			table: {
+				type: {
+					summary: "boolean",
+				},
+				defaultValue: { summary: false },
+			},
+			options: [true, false],
+			control: {
+				type: "select",
+			},
+		},
 	},
 } as Meta;
 
@@ -100,4 +113,11 @@ export const DefaultValue = Template("reset-default-value", "default").bind({});
 DefaultValue.args = {
 	uiType: "reset",
 	label: "Reset",
+};
+
+export const IgnoreDefaultValue = Template("reset-ignore-default-value", "default").bind({});
+IgnoreDefaultValue.args = {
+	uiType: "reset",
+	label: "Reset",
+	ignoreDefaultValues: true,
 };


### PR DESCRIPTION
**Changes**
Added an optional prop `ignoreDefaultValues` for reset-button component that allows users to clear form fields while bypassing any defined default values

-   [delete] branch


**Changelog entry**

-   Added optional ignoreDefaultValues prop for reset button
