### PR TITLE
Fix event listener initialisation (again)

### DIFF
--- a/src/components/frontend-engine/event/context-provider.tsx
+++ b/src/components/frontend-engine/event/context-provider.tsx
@@ -1,11 +1,11 @@
-import { ReactElement, createContext, useEffect, useState } from "react";
+import { ReactElement, createContext, useEffect, useRef } from "react";
 
 /**
  * events are added / removed / dispatched via the eventManager
  * the eventManager is just a div, the handling of events is purely through native event handlers
  */
 interface IEventContext {
-	eventManager: Element;
+	eventManagerRef: React.RefObject<Element>;
 }
 
 interface IProps {
@@ -13,15 +13,15 @@ interface IProps {
 }
 
 export const EventContext = createContext<IEventContext>({
-	eventManager: null,
+	eventManagerRef: { current: null },
 });
 
 export const EventProvider = ({ children }: IProps) => {
-	const [eventManager, setEventManager] = useState<Element>();
+	const eventManagerRef = useRef<Element>();
 
 	useEffect(() => {
-		setEventManager(document.createElement("div"));
+		eventManagerRef.current = document.createElement("div");
 	}, []);
 
-	return <EventContext.Provider value={{ eventManager }}>{children}</EventContext.Provider>;
+	return <EventContext.Provider value={{ eventManagerRef }}>{children}</EventContext.Provider>;
 };

--- a/src/utils/hooks/use-field-event.ts
+++ b/src/utils/hooks/use-field-event.ts
@@ -6,7 +6,7 @@ import { EventContext } from "../../components/frontend-engine/event";
  * use this hook to add/dispatch/remove event listeners
  */
 export const useFieldEvent = () => {
-	const { eventManager } = useContext(EventContext);
+	const { eventManagerRef } = useContext(EventContext);
 
 	const addFieldEventListener = (
 		type: string,
@@ -14,7 +14,7 @@ export const useFieldEvent = () => {
 		listener: (ev: Event) => unknown,
 		options?: boolean | AddEventListenerOptions
 	) => {
-		eventManager?.addEventListener(`${id}:${type}`, listener, options);
+		eventManagerRef.current?.addEventListener(`${id}:${type}`, listener, options);
 	};
 
 	const removeFieldEventListener = (
@@ -23,11 +23,11 @@ export const useFieldEvent = () => {
 		listener: (ev: Event) => unknown,
 		options?: boolean | EventListenerOptions
 	) => {
-		eventManager?.removeEventListener(`${id}:${type}`, listener, options);
+		eventManagerRef.current?.removeEventListener(`${id}:${type}`, listener, options);
 	};
 
 	const dispatchFieldEvent = (type: string, id: string, detail?: any): boolean => {
-		return eventManager?.dispatchEvent(
+		return eventManagerRef.current?.dispatchEvent(
 			new CustomEvent(`${id}:${type}`, { cancelable: true, detail: { id, ...detail } })
 		);
 	};


### PR DESCRIPTION
**Changes**
- The previous change fixed SSR errors, but caused another issue. The useEffects run in the same render cycle, but the setState update to initialise the event manager only takes effect in the next render
- Instead of using state, a ref ensures the event manager reference is immediately updated
- [delete] branch
