### PR TITLE
Fix conditional rendering behaviour when pre-filled

### DIFF
--- a/src/__tests__/components/elements/wrapper/conditional-renderer.spec.tsx
+++ b/src/__tests__/components/elements/wrapper/conditional-renderer.spec.tsx
@@ -14,7 +14,10 @@ const FIELD_ONE_LABEL = "Field one";
 const FIELD_TWO_LABEL = "Field two";
 const FIELD_THREE_LABEL = "Field three";
 
-const renderComponent = (fields: Record<string, TFrontendEngineFieldSchema>) => {
+const renderComponent = (
+	fields: Record<string, TFrontendEngineFieldSchema>,
+	defaultValues?: Record<string, unknown> | undefined
+) => {
 	const json: IFrontendEngineData = {
 		id: FRONTEND_ENGINE_ID,
 		sections: {
@@ -26,6 +29,7 @@ const renderComponent = (fields: Record<string, TFrontendEngineFieldSchema>) => 
 				},
 			},
 		},
+		defaultValues,
 	};
 
 	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
@@ -222,6 +226,28 @@ describe("conditional-renderer", () => {
 		fireEvent.change(getFieldOne(), { target: { value: null } });
 		fireEvent.change(getFieldTwo(), { target: { value: "hello" } });
 		expect(getFieldThree()).toBeInTheDocument();
+	});
+
+	it("should render conditional field if form is prefilled with matching value", () => {
+		const fields: Record<string, TFrontendEngineFieldSchema> = {
+			[FIELD_ONE_ID]: {
+				label: FIELD_ONE_LABEL,
+				uiType: "text-field",
+			},
+			wrapper: {
+				uiType: "div",
+				children: {
+					[FIELD_TWO_ID]: {
+						label: FIELD_TWO_LABEL,
+						uiType: "text-field",
+					},
+				},
+				showIf: [{ [FIELD_ONE_ID]: [{ filled: true }] }],
+			},
+		};
+		renderComponent(fields, { [FIELD_ONE_ID]: "hello" });
+
+		expect(getFieldTwo()).toBeInTheDocument();
 	});
 
 	it("should remove validation schema for fields that are conditionally hidden", async () => {

--- a/src/components/elements/wrapper/conditional-renderer.tsx
+++ b/src/components/elements/wrapper/conditional-renderer.tsx
@@ -25,7 +25,7 @@ export const ConditionalRenderer = ({ id, renderRules, children, schema }: IProp
 	// =============================================================================
 	// CONST, STATE, REF
 	// =============================================================================
-	const { watch } = useFormContext();
+	const { watch, getValues } = useFormContext();
 	const { formValidationConfig, removeFieldValidationConfig } = useValidationConfig();
 	const [show, toggleShow] = useState(false);
 	const [formValues, setFormValues] = useState<FieldValues>();
@@ -33,6 +33,11 @@ export const ConditionalRenderer = ({ id, renderRules, children, schema }: IProp
 	// =============================================================================
 	// EFFECTS
 	// =============================================================================
+	useEffect(() => {
+		const values = getValues();
+		setFormValues(values);
+	}, []);
+
 	useEffect(() => {
 		const subscription = watch((value) => setFormValues(value));
 


### PR DESCRIPTION
**Changes**
- save form values to state in conditional render, this allows default values to be saved and used to decide if the children can be rendered
- delete branch

**Additional information**
- this is to fix a bug when a field is pre-filled, the conditionally rendered fields are not rendered despite fulfilling the conditions
