### PR TITLE
Validator fix

### DIFF
--- a/src/components/fields/image-upload/image-manager/image-manager.ts
+++ b/src/components/fields/image-upload/image-manager/image-manager.ts
@@ -3,10 +3,8 @@ import { AxiosApiClient, FileHelper, ImageHelper } from "../../../../utils";
 import { usePrevious } from "../../../../utils/hooks";
 import { ImageContext } from "../image-context";
 import { EImageStatus, IImage, ISharedImageProps, TImageUploadOutputFileType, TUploadMethod } from "../types";
-import { useFormContext } from "react-hook-form";
 
 interface IProps extends Omit<ISharedImageProps, "maxFiles"> {
-	isDirty: boolean;
 	editImage: boolean;
 	onChange: (...event: any[]) => void;
 	compress: boolean;
@@ -27,9 +25,8 @@ export const ImageManager = (props: IProps) => {
 	// =============================================================================
 	// CONST, STATE, REFS
 	// =============================================================================
-	const { accepts, compress, dimensions, editImage, id, isDirty, maxSizeInKb, outputType, upload, value } = props;
+	const { accepts, compress, dimensions, editImage, onChange, maxSizeInKb, outputType, upload, value } = props;
 	const { images, setImages, setErrorCount } = useContext(ImageContext);
-	const { setValue } = useFormContext();
 	const previousImages = usePrevious(images);
 	const [managerErrorCount, setManagerErrorCount] = useState(0);
 	const previousValue = usePrevious(value);
@@ -140,19 +137,17 @@ export const ImageManager = (props: IProps) => {
 		setErrorCount((prev) => Math.max(0, prev + updatedManagerErrorCount - managerErrorCount));
 		setManagerErrorCount(updatedManagerErrorCount);
 
-		setValue(
-			id,
-			images
-				.filter(({ status }) => status === EImageStatus.UPLOADED)
-				.map(({ dataURL, drawingDataURL, name, uploadResponse }) => ({
-					fileName: name,
-					dataURL: drawingDataURL || dataURL,
-					uploadResponse,
-				})),
-			{ shouldValidate: isDirty, shouldDirty: true }
-			// shouldValidate: isDirty to prevent validation on first set value
-			// this is a workaround to prevent crash on SSR (likely due to calling validation when field is not registered)
-		);
+		onChange({
+			target: {
+				value: images
+					.filter(({ status }) => status === EImageStatus.UPLOADED)
+					.map(({ dataURL, drawingDataURL, name, uploadResponse }) => ({
+						fileName: name,
+						dataURL: drawingDataURL || dataURL,
+						uploadResponse,
+					})),
+			},
+		});
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [images.map((image) => image.status).join(",")]);
 

--- a/src/components/fields/image-upload/image-upload.tsx
+++ b/src/components/fields/image-upload/image-upload.tsx
@@ -232,7 +232,6 @@ export const ImageUploadInner = (props: IGenericFieldProps<IImageUploadSchema>) 
 					dimensions={dimensions}
 					editImage={editImage}
 					id={id}
-					isDirty={isDirty}
 					maxSizeInKb={maxFileSize}
 					onChange={onChange}
 					outputType={outputType}

--- a/src/utils/hooks/use-validation-schema.ts
+++ b/src/utils/hooks/use-validation-schema.ts
@@ -11,8 +11,8 @@ import { ObjectHelper } from "../object-helper";
  */
 export const useValidationSchema = () => {
 	const { formValidationConfig } = useContext(YupContext);
-	const [hardValidationSchema, setHardValidationSchema] = useState<Yup.ObjectSchema<ObjectShape>>();
-	const [softValidationSchema, setSoftValidationSchema] = useState<Yup.ObjectSchema<ObjectShape>>();
+	const [hardValidationSchema, setHardValidationSchema] = useState<Yup.ObjectSchema<ObjectShape>>(Yup.object());
+	const [softValidationSchema, setSoftValidationSchema] = useState<Yup.ObjectSchema<ObjectShape>>(Yup.object());
 	const [warnings, setWarnings] = useState<Record<string, string>>({});
 
 	useEffect(() => {


### PR DESCRIPTION
**Changes**
- Initialise validation schema with an empty Yup object
- Revert previous fix applied to image manager
- This fixes the broken test cases
- Delete branch

**Additional information**
- Related to https://github.com/LifeSG/web-frontend-engine/pull/86
- Error was happening when attempting to set value before the validation schema is initialised
- As such, initialising the validation schema with an empty Yup object will allow the value changes to go through
- This scenario is to cater to pre-filling so validation is not needed at this point - it will run again when user makes a change or do a submission
