### PR TITLE
set current date with delay

### DIFF
--- a/src/components/fields/date-field/date-field.tsx
+++ b/src/components/fields/date-field/date-field.tsx
@@ -116,7 +116,7 @@ export const DateField = (props: IGenericFieldProps<IDateFieldSchema>) => {
 				// runs on mount and reset
 				if (useCurrentDate) {
 					const currentDate = DateTimeHelper.formatDateTime(LocalDate.now().toString(), dateFormat, "date");
-					setValue(id, currentDate, { shouldDirty: true });
+					setTimeout(() => setValue(id, currentDate, { shouldDirty: true }));
 
 					const inputDate = DateTimeHelper.formatDateTime(
 						LocalDate.now().toString(),


### PR DESCRIPTION
**Note**
- converting to draft first because bug is not resolved and root cause not identified yet

**Changes**
- added delay before setting current date

**Additional information**
- users reported the current date is getting cleared when using the date picker
- it appears that the date is not getting set in react-hook-form on initial mount, a delay is needed
