### PR TITLE
[MOL-13378][MA] handle error from aborted web requests

### DIFF
--- a/src/components/fields/location-field/location-helper.ts
+++ b/src/components/fields/location-field/location-helper.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { debounce } from "lodash";
 import { MutableRefObject } from "react";
 import { OneMapService } from "../../../services";
@@ -88,7 +89,7 @@ export namespace LocationHelper {
 
 			return onemapLocationList;
 		} catch (error) {
-			if (error.code === "ERR_CANCELED") throw error;
+			if (axios.isCancel(error)) throw error;
 
 			const oneMapError = new OneMapError(error);
 			onError(oneMapError);

--- a/src/components/fields/location-field/location-helper.ts
+++ b/src/components/fields/location-field/location-helper.ts
@@ -88,6 +88,8 @@ export namespace LocationHelper {
 
 			return onemapLocationList;
 		} catch (error) {
+			if (error.code === "ERR_CANCELED") throw error;
+
 			const oneMapError = new OneMapError(error);
 			onError(oneMapError);
 			throw oneMapError;

--- a/src/utils/api-client/api-client.ts
+++ b/src/utils/api-client/api-client.ts
@@ -112,23 +112,6 @@ export class AxiosApiClient {
 	}
 
 	private _handleError(error: any) {
-		if (error.code === "ECONNABORTED") {
-			return Promise.reject("timeout");
-		}
-
-		if (error.response) {
-			// The request was made and the server responded with a status code
-			// that falls out of the range of 2xx
-			return Promise.reject({ ...error.response.data, httpStatus: error.response.status });
-		}
-
-		if (error.request) {
-			// The request was made but no response was received
-			// `error.request` is an instance of XMLHttpRequest in the browser and an instance of
-			// http.ClientRequest in node.js
-			return Promise.reject(error.request);
-		}
-
 		// Something happened in setting up the request that triggered an Error
 		return Promise.reject(error);
 	}

--- a/src/utils/api-client/api-client.ts
+++ b/src/utils/api-client/api-client.ts
@@ -112,7 +112,6 @@ export class AxiosApiClient {
 	}
 
 	private _handleError(error: any) {
-		// Something happened in setting up the request that triggered an Error
 		return Promise.reject(error);
 	}
 }


### PR DESCRIPTION
**Changes**

- Add error handling logic for errors from Axios when request is aborted in location-helper.ts
- Remove unnecessary logic in error interceptor for api-client.ts

**Changelog entry**

- Fixes on location-modal component
