### PR TITLE
Ensure filter values are cleared on clicking clear button

### DIFF
--- a/src/__tests__/components/custom/filter/filter-checkbox.spec.tsx
+++ b/src/__tests__/components/custom/filter/filter-checkbox.spec.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import { IFilterCheckboxSchema } from "../../../../components/custom/filter/filter-checkbox/types";
 import { FrontendEngine, IFrontendEngineData } from "../../../../components/frontend-engine";
 import {
-	ERROR_MESSAGE,
 	FRONTEND_ENGINE_ID,
 	TOverrideField,
 	TOverrideSchema,
@@ -96,6 +95,20 @@ describe(REFERENCE_KEY, () => {
 		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
 	});
 
+	it("should be able to clear default values", async () => {
+		const defaultValues = ["Apple"];
+		renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: defaultValues } });
+
+		fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+
+		defaultValues.forEach((val) => {
+			const checkBox = getCheckboxByVal(val);
+			expect(checkBox.checked).toBeFalsy();
+		});
+		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
+	});
+
 	it("should be able to toggle the checkboxes", async () => {
 		renderComponent();
 		const checkboxes = getCheckboxes();
@@ -121,10 +134,9 @@ describe(REFERENCE_KEY, () => {
 		await waitFor(() => fireEvent.click(getSubmitButton()));
 		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Apple", "Berry"] }));
 
-		const [clearBtn] = screen.queryAllByText("Clear");
-		await waitFor(() => fireEvent.click(clearBtn));
+		fireEvent.click(screen.getByRole("button", { name: "Clear" }));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
 	});
 
 	describe("update options schema", () => {

--- a/src/components/custom/filter/filter/filter.tsx
+++ b/src/components/custom/filter/filter/filter.tsx
@@ -1,8 +1,13 @@
 import { Filter as FilterComponent } from "@lifesg/react-design-system";
-import _ from "lodash";
+import isArray from "lodash/isArray";
+import isEmpty from "lodash/isEmpty";
+import isNumber from "lodash/isNumber";
+import isString from "lodash/isString";
 import { useFormContext } from "react-hook-form";
-import { TestHelper, ObjectHelper } from "../../../../utils";
+import { ObjectHelper, TestHelper } from "../../../../utils";
 import { Wrapper } from "../../../elements/wrapper";
+import { IFilterCheckboxSchema } from "../filter-checkbox/types";
+import { IFilterItemSchema } from "../filter-item/types";
 import { IFilterProps } from "./types";
 
 export const Filter = (props: IFilterProps) => {
@@ -10,7 +15,7 @@ export const Filter = (props: IFilterProps) => {
 	// CONST, STATE, REF
 	// =============================================================================
 
-	const { resetField, getValues } = useFormContext();
+	const { setValue, getValues } = useFormContext();
 
 	const {
 		id,
@@ -20,23 +25,31 @@ export const Filter = (props: IFilterProps) => {
 	// =============================================================================
 	// HELPER FUNCTIONS
 	// =============================================================================
-	const getChildrenFormControlNamesList = (): string[] => {
-		const list = [];
+	const getChildrenFormFields = () => {
+		const fields: Record<string, IFilterItemSchema | IFilterCheckboxSchema> = {};
 		const formValues = getValues();
 		for (const key in formValues) {
-			if (!_.isEmpty(ObjectHelper.getNestedValueByKey(children, key))) {
-				list.push(key);
+			const nested = ObjectHelper.getNestedValueByKey(children, key);
+
+			if (!isEmpty(nested)) {
+				fields[key] = formValues[key];
 			}
 		}
-		return list;
+		return fields;
 	};
 
-	const resetChildrenFormFields = (fields: string[]): void => {
-		fields.forEach((item) => resetField(item));
+	const resetChildrenFormFields = (fields: Record<string, IFilterItemSchema | IFilterCheckboxSchema>): void => {
+		Object.entries(fields).forEach(([key, value]) => {
+			if (isArray(value)) {
+				setValue(key, []);
+			} else if (isString(value) || isNumber(value)) {
+				setValue(key, "");
+			}
+		});
 	};
 
 	const clearData = () => {
-		const fields = getChildrenFormControlNamesList();
+		const fields = getChildrenFormFields();
 		resetChildrenFormFields(fields);
 	};
 


### PR DESCRIPTION
**Changes**
- Ensured filter values are cleared on clicking clear button
- Used `setValue()` instead of `resetField()` or `reset()` because react-hook-form will revert to `defaultValues` on reset
