### PR TITLE
Populate conditionally rendered fields

### DIFF
--- a/src/__tests__/components/elements/wrapper/conditional-renderer.spec.tsx
+++ b/src/__tests__/components/elements/wrapper/conditional-renderer.spec.tsx
@@ -4,6 +4,7 @@ import {
 	FrontendEngine,
 	IFrontendEngineData,
 	TFrontendEngineFieldSchema,
+	TRestoreMode,
 } from "../../../../components/frontend-engine";
 import { ERROR_MESSAGE, FRONTEND_ENGINE_ID, getField, getSubmitButton, getSubmitButtonProps } from "../../../common";
 
@@ -18,7 +19,8 @@ const FIELD_THREE_LABEL = "Field three";
 const renderComponent = (
 	fields: Record<string, TFrontendEngineFieldSchema>,
 	defaultValues?: Record<string, unknown> | undefined,
-	overrides?: Record<string, unknown> | undefined
+	overrides?: Record<string, unknown> | undefined,
+	restoreMode?: TRestoreMode | undefined
 ) => {
 	const json: IFrontendEngineData = {
 		id: FRONTEND_ENGINE_ID,
@@ -33,6 +35,7 @@ const renderComponent = (
 		},
 		defaultValues,
 		overrides,
+		restoreMode,
 	};
 
 	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
@@ -419,6 +422,161 @@ describe("conditional-renderer", () => {
 			fireEvent.change(getFieldOne(), { target: { value: "hi" } });
 
 			expect(getFieldTwo()).toBeInTheDocument();
+		});
+	});
+
+	describe("restore mode", () => {
+		const defaultValue = "world";
+		const userInput = "bye";
+
+		it("should restore default value of conditionally rendered components", async () => {
+			const uiType = "text-field";
+			const fields: Record<string, TFrontendEngineFieldSchema> = {
+				[FIELD_ONE_ID]: {
+					label: FIELD_ONE_LABEL,
+					uiType,
+				},
+				[FIELD_TWO_ID]: {
+					label: FIELD_TWO_LABEL,
+					uiType,
+					showIf: [{ [FIELD_ONE_ID]: [{ min: 5 }] }],
+				},
+			};
+			renderComponent(
+				fields,
+				{ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: defaultValue },
+				undefined,
+				"default-value"
+			);
+
+			fireEvent.change(getFieldTwo(), { target: { value: userInput } });
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+			expect(SUBMIT_FN).toBeCalledWith(
+				expect.objectContaining({ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: userInput })
+			);
+
+			fireEvent.change(getFieldOne(), { target: { value: "hi" } });
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [FIELD_ONE_ID]: "hi" }));
+			expect(SUBMIT_FN).toBeCalledWith(expect.not.objectContaining({ [FIELD_TWO_ID]: expect.anything() }));
+
+			fireEvent.change(getFieldOne(), { target: { value: "hello" } });
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+			expect(SUBMIT_FN).toBeCalledWith(
+				expect.objectContaining({ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: defaultValue })
+			);
+		});
+
+		it("should restore previous input value of conditionally rendered components", async () => {
+			const uiType = "text-field";
+			const fields: Record<string, TFrontendEngineFieldSchema> = {
+				[FIELD_ONE_ID]: {
+					label: FIELD_ONE_LABEL,
+					uiType,
+				},
+				[FIELD_TWO_ID]: {
+					label: FIELD_TWO_LABEL,
+					uiType,
+					showIf: [{ [FIELD_ONE_ID]: [{ min: 5 }] }],
+				},
+			};
+			renderComponent(fields, { [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: defaultValue }, undefined, "user-input");
+
+			fireEvent.change(getFieldTwo(), { target: { value: userInput } });
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+			expect(SUBMIT_FN).toBeCalledWith(
+				expect.objectContaining({ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: userInput })
+			);
+
+			fireEvent.change(getFieldOne(), { target: { value: "hi" } });
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [FIELD_ONE_ID]: "hi" }));
+			expect(SUBMIT_FN).toBeCalledWith(expect.not.objectContaining({ [FIELD_TWO_ID]: expect.anything() }));
+
+			fireEvent.change(getFieldOne(), { target: { value: "hello" } });
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+			expect(SUBMIT_FN).toBeCalledWith(
+				expect.objectContaining({ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: userInput })
+			);
+		});
+
+		it("should reset to default value when field is reset while hidden", async () => {
+			const uiType = "text-field";
+			const fields: Record<string, TFrontendEngineFieldSchema> = {
+				[FIELD_ONE_ID]: {
+					label: FIELD_ONE_LABEL,
+					uiType,
+				},
+				[FIELD_TWO_ID]: {
+					label: FIELD_TWO_LABEL,
+					uiType,
+					showIf: [{ [FIELD_ONE_ID]: [{ min: 5 }] }],
+				},
+				reset: {
+					label: "Reset",
+					uiType: "reset",
+				},
+			};
+			renderComponent(
+				fields,
+				{ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: defaultValue },
+				undefined,
+				"default-value"
+			);
+
+			fireEvent.change(getFieldTwo(), { target: { value: userInput } });
+			fireEvent.change(getFieldOne(), { target: { value: "hi" } });
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [FIELD_ONE_ID]: "hi" }));
+			expect(SUBMIT_FN).toBeCalledWith(expect.not.objectContaining({ [FIELD_TWO_ID]: expect.anything() }));
+
+			fireEvent.click(screen.queryByText("Reset"));
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+			expect(SUBMIT_FN).toBeCalledWith(
+				expect.objectContaining({ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: defaultValue })
+			);
+		});
+
+		it("should reset to default value when field is reset while hidden", async () => {
+			const uiType = "text-field";
+			const fields: Record<string, TFrontendEngineFieldSchema> = {
+				[FIELD_ONE_ID]: {
+					label: FIELD_ONE_LABEL,
+					uiType,
+				},
+				[FIELD_TWO_ID]: {
+					label: FIELD_TWO_LABEL,
+					uiType,
+					showIf: [{ [FIELD_ONE_ID]: [{ min: 5 }] }],
+				},
+				reset: {
+					label: "Reset",
+					uiType: "reset",
+				},
+			};
+			renderComponent(fields, { [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: defaultValue }, undefined, "user-input");
+
+			fireEvent.change(getFieldTwo(), { target: { value: userInput } });
+			fireEvent.change(getFieldOne(), { target: { value: "hi" } });
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [FIELD_ONE_ID]: "hi" }));
+			expect(SUBMIT_FN).toBeCalledWith(expect.not.objectContaining({ [FIELD_TWO_ID]: expect.anything() }));
+
+			fireEvent.click(screen.queryByText("Reset"));
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+			expect(SUBMIT_FN).toBeCalledWith(
+				expect.objectContaining({ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: defaultValue })
+			);
 		});
 	});
 });

--- a/src/__tests__/components/elements/wrapper/conditional-renderer.spec.tsx
+++ b/src/__tests__/components/elements/wrapper/conditional-renderer.spec.tsx
@@ -428,25 +428,30 @@ describe("conditional-renderer", () => {
 	describe("restore mode", () => {
 		const defaultValue = "world";
 		const userInput = "bye";
+		const uiType = "text-field";
+		const defaultValues = { [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: defaultValue };
 
-		it("should restore default value of conditionally rendered components", async () => {
-			const uiType = "text-field";
-			const fields: Record<string, TFrontendEngineFieldSchema> = {
-				[FIELD_ONE_ID]: {
-					label: FIELD_ONE_LABEL,
-					uiType,
-				},
-				[FIELD_TWO_ID]: {
-					label: FIELD_TWO_LABEL,
-					uiType,
-					showIf: [{ [FIELD_ONE_ID]: [{ min: 5 }] }],
-				},
-			};
+		it.each`
+			restoreMode        | expected
+			${"none"}          | ${{ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: "" }}
+			${"default-value"} | ${{ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: defaultValue }}
+			${"user-input"}    | ${{ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: userInput }}
+		`("should populate conditionally rendered field in `$restoreMode` mode", async ({ restoreMode, expected }) => {
 			renderComponent(
-				fields,
-				{ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: defaultValue },
+				{
+					[FIELD_ONE_ID]: {
+						label: FIELD_ONE_LABEL,
+						uiType,
+					},
+					[FIELD_TWO_ID]: {
+						label: FIELD_TWO_LABEL,
+						uiType,
+						showIf: [{ [FIELD_ONE_ID]: [{ min: 5 }] }],
+					},
+				},
+				defaultValues,
 				undefined,
-				"default-value"
+				restoreMode
 			);
 
 			fireEvent.change(getFieldTwo(), { target: { value: userInput } });
@@ -465,106 +470,43 @@ describe("conditional-renderer", () => {
 			fireEvent.change(getFieldOne(), { target: { value: "hello" } });
 
 			await waitFor(() => fireEvent.click(getSubmitButton()));
-			expect(SUBMIT_FN).toBeCalledWith(
-				expect.objectContaining({ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: defaultValue })
-			);
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining(expected));
 		});
 
-		it("should restore previous input value of conditionally rendered components", async () => {
-			const uiType = "text-field";
-			const fields: Record<string, TFrontendEngineFieldSchema> = {
-				[FIELD_ONE_ID]: {
-					label: FIELD_ONE_LABEL,
-					uiType,
-				},
-				[FIELD_TWO_ID]: {
-					label: FIELD_TWO_LABEL,
-					uiType,
-					showIf: [{ [FIELD_ONE_ID]: [{ min: 5 }] }],
-				},
-			};
-			renderComponent(fields, { [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: defaultValue }, undefined, "user-input");
-
-			fireEvent.change(getFieldTwo(), { target: { value: userInput } });
-
-			await waitFor(() => fireEvent.click(getSubmitButton()));
-			expect(SUBMIT_FN).toBeCalledWith(
-				expect.objectContaining({ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: userInput })
-			);
-
-			fireEvent.change(getFieldOne(), { target: { value: "hi" } });
-
-			await waitFor(() => fireEvent.click(getSubmitButton()));
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [FIELD_ONE_ID]: "hi" }));
-			expect(SUBMIT_FN).toBeCalledWith(expect.not.objectContaining({ [FIELD_TWO_ID]: expect.anything() }));
-
-			fireEvent.change(getFieldOne(), { target: { value: "hello" } });
-
-			await waitFor(() => fireEvent.click(getSubmitButton()));
-			expect(SUBMIT_FN).toBeCalledWith(
-				expect.objectContaining({ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: userInput })
-			);
-		});
-
-		it("should reset to default value when field is reset while hidden", async () => {
-			const uiType = "text-field";
-			const fields: Record<string, TFrontendEngineFieldSchema> = {
-				[FIELD_ONE_ID]: {
-					label: FIELD_ONE_LABEL,
-					uiType,
-				},
-				[FIELD_TWO_ID]: {
-					label: FIELD_TWO_LABEL,
-					uiType,
-					showIf: [{ [FIELD_ONE_ID]: [{ min: 5 }] }],
-				},
-				reset: {
-					label: "Reset",
-					uiType: "reset",
-				},
-			};
+		it.each`
+			restoreMode        | expected
+			${"none"}          | ${{ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: "" }}
+			${"default-value"} | ${{ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: defaultValue }}
+			${"user-input"}    | ${{ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: userInput }}
+		`("should reset hidden field in `$restoreMode` mode", async ({ restoreMode }) => {
 			renderComponent(
-				fields,
-				{ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: defaultValue },
+				{
+					[FIELD_ONE_ID]: {
+						label: FIELD_ONE_LABEL,
+						uiType,
+					},
+					[FIELD_TWO_ID]: {
+						label: FIELD_TWO_LABEL,
+						uiType,
+						showIf: [{ [FIELD_ONE_ID]: [{ min: 5 }] }],
+					},
+					reset: {
+						label: "Reset",
+						uiType: "reset",
+					},
+				},
+				defaultValues,
 				undefined,
-				"default-value"
+				restoreMode
 			);
 
 			fireEvent.change(getFieldTwo(), { target: { value: userInput } });
-			fireEvent.change(getFieldOne(), { target: { value: "hi" } });
-
-			await waitFor(() => fireEvent.click(getSubmitButton()));
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [FIELD_ONE_ID]: "hi" }));
-			expect(SUBMIT_FN).toBeCalledWith(expect.not.objectContaining({ [FIELD_TWO_ID]: expect.anything() }));
-
-			fireEvent.click(screen.queryByText("Reset"));
 
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 			expect(SUBMIT_FN).toBeCalledWith(
-				expect.objectContaining({ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: defaultValue })
+				expect.objectContaining({ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: userInput })
 			);
-		});
 
-		it("should reset to default value when field is reset while hidden", async () => {
-			const uiType = "text-field";
-			const fields: Record<string, TFrontendEngineFieldSchema> = {
-				[FIELD_ONE_ID]: {
-					label: FIELD_ONE_LABEL,
-					uiType,
-				},
-				[FIELD_TWO_ID]: {
-					label: FIELD_TWO_LABEL,
-					uiType,
-					showIf: [{ [FIELD_ONE_ID]: [{ min: 5 }] }],
-				},
-				reset: {
-					label: "Reset",
-					uiType: "reset",
-				},
-			};
-			renderComponent(fields, { [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: defaultValue }, undefined, "user-input");
-
-			fireEvent.change(getFieldTwo(), { target: { value: userInput } });
 			fireEvent.change(getFieldOne(), { target: { value: "hi" } });
 
 			await waitFor(() => fireEvent.click(getSubmitButton()));

--- a/src/components/elements/wrapper/conditional-renderer.tsx
+++ b/src/components/elements/wrapper/conditional-renderer.tsx
@@ -1,13 +1,12 @@
 import isEmpty from "lodash/isEmpty";
 import isObject from "lodash/isObject";
-import React, { useEffect, useState } from "react";
-import { FieldValues, useFormContext } from "react-hook-form";
+import React, { useState } from "react";
 import { useDeepCompareEffectNoCheck } from "use-deep-compare-effect";
-import { useValidationConfig } from "../../../utils/hooks";
+import { useFormValues, useValidationConfig } from "../../../utils/hooks";
+import { IFilterCheckboxSchema } from "../../custom/filter/filter-checkbox/types";
+import { IFilterItemSchema } from "../../custom/filter/filter-item/types";
 import { TFrontendEngineFieldSchema } from "../../frontend-engine";
 import { TFormYupConfig, TRenderRules, TYupSchemaType, YupHelper } from "../../frontend-engine/yup";
-import { IFilterItemSchema } from "../../custom/filter/filter-item/types";
-import { IFilterCheckboxSchema } from "../../custom/filter/filter-checkbox/types";
 
 interface IProps {
 	id: string;
@@ -25,24 +24,9 @@ export const ConditionalRenderer = ({ id, renderRules, children, schema }: IProp
 	// =============================================================================
 	// CONST, STATE, REF
 	// =============================================================================
-	const { watch, getValues } = useFormContext();
 	const { formValidationConfig, removeFieldValidationConfig } = useValidationConfig();
 	const [show, toggleShow] = useState(false);
-	const [formValues, setFormValues] = useState<FieldValues>();
-
-	// =============================================================================
-	// EFFECTS
-	// =============================================================================
-	useEffect(() => {
-		const values = getValues();
-		setFormValues(values);
-	}, []);
-
-	useEffect(() => {
-		const subscription = watch((value) => setFormValues(value));
-
-		return () => subscription.unsubscribe();
-	}, [watch]);
+	const { formValues } = useFormValues();
 
 	useDeepCompareEffectNoCheck(() => {
 		if (isEmpty(renderRules)) return;

--- a/src/components/elements/wrapper/field-wrapper.tsx
+++ b/src/components/elements/wrapper/field-wrapper.tsx
@@ -10,49 +10,32 @@ interface IProps {
 }
 
 export const FieldWrapper = ({ Field, id, schema }: IProps) => {
-	const { control, watch, setValue } = useFormContext();
+	const { control, setValue } = useFormContext();
 
 	const {
 		formSchema: { defaultValues, restoreMode },
 	} = useFormSchema();
-	const { formValues, setField } = useFormValues();
+	const { formValues, setField, isFieldShown, setFieldShown } = useFormValues();
 
 	useEffect(() => {
-		const value = getInitialValue();
-		setField(id, value);
-		setValue(id, value);
-	}, []);
-
-	useEffect(() => {
-		const subscription = watch((value, { name, type }) => {
-			if (name) {
-				if (name === id) {
-					setField(id, value[name]);
-				}
-			}
-		});
-
-		return () => subscription.unsubscribe();
-	}, [watch]);
-
-	// =========================================================================
-	// HELPERS
-	// =========================================================================
-
-	function getInitialValue() {
-		switch (restoreMode) {
-			case "default-value":
-				return defaultValues?.[id];
-			case "user-input":
-			default:
-				return formValues[id];
+		if (isFieldShown(id)) {
+			// for conditionally rendered fields, we have to put the field back into the react-hook-form state
+			setValue(id, formValues[id]);
+		} else {
+			setFieldShown(id);
 		}
-	}
+
+		return () => {
+			if (restoreMode === "default-value") {
+				setField(id, defaultValues?.[id]);
+			}
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	// =========================================================================
 	// RENDER
 	// =========================================================================
-
 	return (
 		<Controller
 			control={control}

--- a/src/components/elements/wrapper/field-wrapper.tsx
+++ b/src/components/elements/wrapper/field-wrapper.tsx
@@ -1,0 +1,72 @@
+import { useEffect } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+import { useFormSchema, useFormValues } from "../../../utils/hooks";
+import { TFrontendEngineFieldSchema } from "../../frontend-engine/types";
+
+interface IProps {
+	id: string;
+	schema: TFrontendEngineFieldSchema;
+	Field: React.ComponentType<any>;
+}
+
+export const FieldWrapper = ({ Field, id, schema }: IProps) => {
+	const { control, watch, setValue } = useFormContext();
+
+	const {
+		formSchema: { defaultValues, restoreMode },
+	} = useFormSchema();
+	const { formValues, setField } = useFormValues();
+
+	useEffect(() => {
+		const value = getInitialValue();
+		setField(id, value);
+		setValue(id, value);
+	}, []);
+
+	useEffect(() => {
+		const subscription = watch((value, { name, type }) => {
+			if (name) {
+				if (name === id) {
+					setField(id, value[name]);
+				}
+			}
+		});
+
+		return () => subscription.unsubscribe();
+	}, [watch]);
+
+	// =========================================================================
+	// HELPERS
+	// =========================================================================
+
+	function getInitialValue() {
+		switch (restoreMode) {
+			case "default-value":
+				return defaultValues?.[id];
+			case "user-input":
+			default:
+				return formValues[id];
+		}
+	}
+
+	// =========================================================================
+	// RENDER
+	// =========================================================================
+
+	return (
+		<Controller
+			control={control}
+			name={id}
+			shouldUnregister={true}
+			render={({ field, fieldState }) => {
+				const fieldProps = {
+					...field,
+					id,
+					value: formValues[id],
+					ref: undefined, // not passing ref because not all components have fields to be manipulated
+				};
+				return <Field schema={schema} {...fieldProps} {...fieldState} />;
+			}}
+		/>
+	);
+};

--- a/src/components/elements/wrapper/field-wrapper.tsx
+++ b/src/components/elements/wrapper/field-wrapper.tsx
@@ -15,12 +15,12 @@ export const FieldWrapper = ({ Field, id, schema }: IProps) => {
 	const {
 		formSchema: { defaultValues, restoreMode },
 	} = useFormSchema();
-	const { formValues, setField, isFieldShown, setFieldShown } = useFormValues();
+	const { getField, setField, isFieldShown, setFieldShown } = useFormValues();
 
 	useEffect(() => {
 		if (isFieldShown(id)) {
 			// for conditionally rendered fields, we have to put the field back into the react-hook-form state
-			setValue(id, formValues[id]);
+			setValue(id, getField(id));
 		} else {
 			setFieldShown(id);
 		}
@@ -45,7 +45,7 @@ export const FieldWrapper = ({ Field, id, schema }: IProps) => {
 				const fieldProps = {
 					...field,
 					id,
-					value: formValues[id],
+					value: getField(id),
 					ref: undefined, // not passing ref because not all components have fields to be manipulated
 				};
 				return <Field schema={schema} {...fieldProps} {...fieldState} />;

--- a/src/components/elements/wrapper/field-wrapper.tsx
+++ b/src/components/elements/wrapper/field-wrapper.tsx
@@ -15,15 +15,10 @@ export const FieldWrapper = ({ Field, id, schema }: IProps) => {
 	const {
 		formSchema: { defaultValues, restoreMode },
 	} = useFormSchema();
-	const { getField, setField, isFieldShown, setFieldShown } = useFormValues();
+	const { getField, setField } = useFormValues();
 
 	useEffect(() => {
-		if (isFieldShown(id)) {
-			// for conditionally rendered fields, we have to put the field back into the react-hook-form state
-			setValue(id, getField(id));
-		} else {
-			setFieldShown(id);
-		}
+		setValue(id, getField(id));
 
 		return () => {
 			if (restoreMode === "default-value") {

--- a/src/components/elements/wrapper/field-wrapper.tsx
+++ b/src/components/elements/wrapper/field-wrapper.tsx
@@ -1,3 +1,6 @@
+import isArray from "lodash/isArray";
+import isNumber from "lodash/isNumber";
+import isString from "lodash/isString";
 import { useEffect } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 import { useFormSchema, useFormValues } from "../../../utils/hooks";
@@ -13,7 +16,7 @@ export const FieldWrapper = ({ Field, id, schema }: IProps) => {
 	const { control, setValue } = useFormContext();
 
 	const {
-		formSchema: { defaultValues, restoreMode },
+		formSchema: { defaultValues, restoreMode = "none" },
 	} = useFormSchema();
 	const { getField, setField } = useFormValues();
 
@@ -21,8 +24,19 @@ export const FieldWrapper = ({ Field, id, schema }: IProps) => {
 		setValue(id, getField(id));
 
 		return () => {
-			if (restoreMode === "default-value") {
-				setField(id, defaultValues?.[id]);
+			switch (restoreMode) {
+				case "default-value":
+					setField(id, defaultValues?.[id]);
+					break;
+				case "none": {
+					const value = getField(id);
+					if (isArray(value)) {
+						setField(id, []);
+					} else if (isString(value) || isNumber(value)) {
+						setField(id, "");
+					}
+					break;
+				}
 			}
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/elements/wrapper/wrapper.tsx
+++ b/src/components/elements/wrapper/wrapper.tsx
@@ -1,6 +1,6 @@
 import isEmpty from "lodash/isEmpty";
 import React, { Fragment, ReactNode, useState } from "react";
-import { Controller, useFormContext } from "react-hook-form";
+import { useFormContext } from "react-hook-form";
 import useDeepCompareEffect from "use-deep-compare-effect";
 import * as FrontendEngineElements from "..";
 import { TestHelper } from "../../../utils";
@@ -16,6 +16,7 @@ import {
 } from "../../frontend-engine/types";
 import { ERROR_MESSAGES } from "../../shared";
 import { ConditionalRenderer } from "./conditional-renderer";
+import { FieldWrapper } from "./field-wrapper";
 import { IWrapperProps } from "./types";
 import { DSAlert } from "./wrapper.styles";
 
@@ -111,22 +112,14 @@ export const Wrapper = (props: IWrapperProps): JSX.Element | null => {
 		}
 
 		if (!Field) return null;
+
+		const warning = warnings?.[childId];
+
 		return (
-			<Controller
-				control={control}
-				name={childId}
-				shouldUnregister={true}
-				render={({ field, fieldState }) => {
-					const fieldProps = { ...field, id: childId, ref: undefined }; // not passing ref because not all components have fields to be manipulated
-					const warning = warnings?.[childId];
-					return (
-						<>
-							<Field schema={childSchema} {...fieldProps} {...fieldState} />
-							{warning && <DSAlert type="warning">{warning}</DSAlert>}
-						</>
-					);
-				}}
-			/>
+			<>
+				<FieldWrapper id={childId} schema={childSchema} Field={Field} />
+				{warning && <DSAlert type="warning">{warning}</DSAlert>}
+			</>
 		);
 	};
 

--- a/src/components/fields/chips/chips.tsx
+++ b/src/components/fields/chips/chips.tsx
@@ -28,12 +28,19 @@ export const Chips = (props: IGenericFieldProps<IChipsSchema>) => {
 	const [stateValue, setStateValue] = useState<string[]>(value || []);
 	const [showTextarea, setShowTextarea] = useState(false);
 	const [multi, setMulti] = useState(true);
-	const { setValue } = useFormContext();
+	const { setValue, unregister } = useFormContext();
 	const { setFieldValidationConfig, removeFieldValidationConfig } = useValidationConfig();
 
 	// =============================================================================
 	// EFFECTS
 	// =============================================================================
+	useEffect(() => {
+		if (!showTextarea) {
+			// at the start, the textarea's default value has to be manually cleared from the form state
+			unregister(getTextareaId());
+		}
+	}, []);
+
 	useEffect(() => {
 		const isRequiredRule = validation?.find((rule) => "required" in rule);
 		const maxRule = validation?.find((rule) => "max" in rule);

--- a/src/components/fields/chips/chips.tsx
+++ b/src/components/fields/chips/chips.tsx
@@ -92,7 +92,6 @@ export const Chips = (props: IGenericFieldProps<IChipsSchema>) => {
 		setShowTextarea(show);
 		if (!show) {
 			removeFieldValidationConfig(getTextareaId());
-			setValue(getTextareaId(), undefined);
 		}
 	};
 

--- a/src/components/fields/chips/chips.tsx
+++ b/src/components/fields/chips/chips.tsx
@@ -1,10 +1,11 @@
 import { Form } from "@lifesg/react-design-system/form";
 import { useEffect, useState } from "react";
-import { Controller, useFormContext } from "react-hook-form";
+import { useFormContext } from "react-hook-form";
 import useDeepCompareEffect from "use-deep-compare-effect";
 import * as Yup from "yup";
 import { TestHelper } from "../../../utils";
 import { useValidationConfig } from "../../../utils/hooks";
+import { FieldWrapper } from "../../elements/wrapper/field-wrapper";
 import { IGenericFieldProps } from "../../frontend-engine";
 import { Chip, ERROR_MESSAGES } from "../../shared";
 import { ITextareaSchema, Textarea } from "../textarea";
@@ -27,7 +28,7 @@ export const Chips = (props: IGenericFieldProps<IChipsSchema>) => {
 	const [stateValue, setStateValue] = useState<string[]>(value || []);
 	const [showTextarea, setShowTextarea] = useState(false);
 	const [multi, setMulti] = useState(true);
-	const { control, setValue } = useFormContext();
+	const { setValue } = useFormContext();
 	const { setFieldValidationConfig, removeFieldValidationConfig } = useValidationConfig();
 
 	// =============================================================================
@@ -167,19 +168,7 @@ export const Chips = (props: IGenericFieldProps<IChipsSchema>) => {
 			label,
 			...textarea,
 		};
-		return showTextarea ? (
-			<Controller
-				control={control}
-				name={textareaId}
-				shouldUnregister={false}
-				render={({ field, fieldState }) => {
-					const fieldProps = { ...field, id: textareaId, ref: undefined };
-					return <Textarea schema={schema} {...fieldProps} {...fieldState} />;
-				}}
-			/>
-		) : (
-			<></>
-		);
+		return showTextarea ? <FieldWrapper id={textareaId} schema={schema} Field={Textarea} /> : <></>;
 	};
 
 	return (

--- a/src/components/fields/reset-button/reset-button.tsx
+++ b/src/components/fields/reset-button/reset-button.tsx
@@ -1,8 +1,9 @@
-import isArray from "lodash/isArray";
-import isString from "lodash/isString";
-import isNumber from "lodash/isNumber";
 import { Button } from "@lifesg/react-design-system/button";
+import isArray from "lodash/isArray";
+import isNumber from "lodash/isNumber";
+import isString from "lodash/isString";
 import { useFormContext } from "react-hook-form";
+import { useFormSchema, useFormValues } from "../../../utils/hooks";
 import { IGenericFieldProps } from "../../frontend-engine";
 import { IResetButtonSchema } from "./types";
 
@@ -17,6 +18,10 @@ export const ResetButton = (props: IGenericFieldProps<IResetButtonSchema>) => {
 	} = props;
 
 	const { reset, getValues } = useFormContext();
+	const { resetFields } = useFormValues();
+	const {
+		formSchema: { defaultValues },
+	} = useFormSchema();
 
 	// =============================================================================
 	// EFFECTS
@@ -32,7 +37,11 @@ export const ResetButton = (props: IGenericFieldProps<IResetButtonSchema>) => {
 				}
 			});
 			reset(values);
-		} else reset();
+			resetFields(values);
+		} else {
+			reset();
+			resetFields(defaultValues);
+		}
 	};
 
 	// =============================================================================

--- a/src/components/frontend-engine/form-values/context-provider.tsx
+++ b/src/components/frontend-engine/form-values/context-provider.tsx
@@ -1,7 +1,8 @@
-import { Dispatch, ReactElement, SetStateAction, createContext, useState } from "react";
+import { Dispatch, MutableRefObject, ReactElement, SetStateAction, createContext, useRef, useState } from "react";
 
 interface IFormValuesContext {
 	formValues: Record<string, unknown>;
+	formValuesRef: MutableRefObject<Record<string, unknown>>;
 	setFormValues: Dispatch<SetStateAction<Record<string, unknown>>>;
 	fieldHistory: Record<string, true>;
 	setFieldHistory: Dispatch<SetStateAction<Record<string, true>>>;
@@ -13,6 +14,7 @@ interface IProps {
 
 export const FormValuesContext = createContext<IFormValuesContext>({
 	formValues: null,
+	formValuesRef: null,
 	setFormValues: null,
 	fieldHistory: null,
 	setFieldHistory: null,
@@ -21,9 +23,10 @@ export const FormValuesContext = createContext<IFormValuesContext>({
 export const FormValuesProvider = ({ children }: IProps) => {
 	const [formValues, setFormValues] = useState<Record<string, unknown>>({});
 	const [fieldHistory, setFieldHistory] = useState<Record<string, true>>({});
+	const formValuesRef = useRef<Record<string, unknown>>(formValues);
 
 	return (
-		<FormValuesContext.Provider value={{ formValues, setFormValues, fieldHistory, setFieldHistory }}>
+		<FormValuesContext.Provider value={{ formValues, setFormValues, fieldHistory, setFieldHistory, formValuesRef }}>
 			{children}
 		</FormValuesContext.Provider>
 	);

--- a/src/components/frontend-engine/form-values/context-provider.tsx
+++ b/src/components/frontend-engine/form-values/context-provider.tsx
@@ -1,7 +1,9 @@
 import { Dispatch, MutableRefObject, ReactElement, SetStateAction, createContext, useRef, useState } from "react";
 
 interface IFormValuesContext {
+	// form state mapping the field id to its value
 	formValues: Record<string, unknown>;
+	// allows access to the latest field values without having to wait for a rerender
 	formValuesRef: MutableRefObject<Record<string, unknown>>;
 	setFormValues: Dispatch<SetStateAction<Record<string, unknown>>>;
 }
@@ -16,6 +18,15 @@ export const FormValuesContext = createContext<IFormValuesContext>({
 	setFormValues: null,
 });
 
+/**
+ * This context stores the form values in parallel to react-hook-form's state.
+ *
+ * The main difference is that it persists the values of fields that are currently conditionally hidden.
+ * Otherwise we won't be able to get their previous values (as the fields are unregistered from react-hook-form).
+ *
+ * This is used to populate the values of conditionally rendered fields when they are shown again.
+ *
+ */
 export const FormValuesProvider = ({ children }: IProps) => {
 	const [formValues, setFormValues] = useState<Record<string, unknown>>({});
 	const formValuesRef = useRef<Record<string, unknown>>(formValues);

--- a/src/components/frontend-engine/form-values/context-provider.tsx
+++ b/src/components/frontend-engine/form-values/context-provider.tsx
@@ -1,0 +1,21 @@
+import { Dispatch, ReactElement, SetStateAction, createContext, useState } from "react";
+
+interface IFormValuesContext {
+	formValues: Record<string, unknown>;
+	setFormValues: Dispatch<SetStateAction<Record<string, unknown>>>;
+}
+
+interface IProps {
+	children: ReactElement;
+}
+
+export const FormValuesContext = createContext<IFormValuesContext>({
+	formValues: null,
+	setFormValues: null,
+});
+
+export const FormValuesProvider = ({ children }: IProps) => {
+	const [formValues, setFormValues] = useState<Record<string, unknown>>({});
+
+	return <FormValuesContext.Provider value={{ formValues, setFormValues }}>{children}</FormValuesContext.Provider>;
+};

--- a/src/components/frontend-engine/form-values/context-provider.tsx
+++ b/src/components/frontend-engine/form-values/context-provider.tsx
@@ -4,8 +4,6 @@ interface IFormValuesContext {
 	formValues: Record<string, unknown>;
 	formValuesRef: MutableRefObject<Record<string, unknown>>;
 	setFormValues: Dispatch<SetStateAction<Record<string, unknown>>>;
-	fieldHistory: Record<string, true>;
-	setFieldHistory: Dispatch<SetStateAction<Record<string, true>>>;
 }
 
 interface IProps {
@@ -16,17 +14,14 @@ export const FormValuesContext = createContext<IFormValuesContext>({
 	formValues: null,
 	formValuesRef: null,
 	setFormValues: null,
-	fieldHistory: null,
-	setFieldHistory: null,
 });
 
 export const FormValuesProvider = ({ children }: IProps) => {
 	const [formValues, setFormValues] = useState<Record<string, unknown>>({});
-	const [fieldHistory, setFieldHistory] = useState<Record<string, true>>({});
 	const formValuesRef = useRef<Record<string, unknown>>(formValues);
 
 	return (
-		<FormValuesContext.Provider value={{ formValues, setFormValues, fieldHistory, setFieldHistory, formValuesRef }}>
+		<FormValuesContext.Provider value={{ formValues, setFormValues, formValuesRef }}>
 			{children}
 		</FormValuesContext.Provider>
 	);

--- a/src/components/frontend-engine/form-values/context-provider.tsx
+++ b/src/components/frontend-engine/form-values/context-provider.tsx
@@ -3,6 +3,8 @@ import { Dispatch, ReactElement, SetStateAction, createContext, useState } from 
 interface IFormValuesContext {
 	formValues: Record<string, unknown>;
 	setFormValues: Dispatch<SetStateAction<Record<string, unknown>>>;
+	fieldHistory: Record<string, true>;
+	setFieldHistory: Dispatch<SetStateAction<Record<string, true>>>;
 }
 
 interface IProps {
@@ -12,10 +14,17 @@ interface IProps {
 export const FormValuesContext = createContext<IFormValuesContext>({
 	formValues: null,
 	setFormValues: null,
+	fieldHistory: null,
+	setFieldHistory: null,
 });
 
 export const FormValuesProvider = ({ children }: IProps) => {
 	const [formValues, setFormValues] = useState<Record<string, unknown>>({});
+	const [fieldHistory, setFieldHistory] = useState<Record<string, true>>({});
 
-	return <FormValuesContext.Provider value={{ formValues, setFormValues }}>{children}</FormValuesContext.Provider>;
+	return (
+		<FormValuesContext.Provider value={{ formValues, setFormValues, fieldHistory, setFieldHistory }}>
+			{children}
+		</FormValuesContext.Provider>
+	);
 };

--- a/src/components/frontend-engine/form-values/index.ts
+++ b/src/components/frontend-engine/form-values/index.ts
@@ -1,0 +1,1 @@
+export * from "./context-provider";

--- a/src/components/frontend-engine/frontend-engine.tsx
+++ b/src/components/frontend-engine/frontend-engine.tsx
@@ -5,7 +5,13 @@ import { ReactElement, Ref, forwardRef, useCallback, useEffect, useImperativeHan
 import { FormProvider, useForm } from "react-hook-form";
 import useDeepCompareEffect, { useDeepCompareEffectNoCheck } from "use-deep-compare-effect";
 import { ObjectHelper, TestHelper } from "../../utils";
-import { useFieldEvent, useFormSchema, useValidationConfig, useValidationSchema } from "../../utils/hooks";
+import {
+	useFieldEvent,
+	useFormSchema,
+	useFormValues,
+	useValidationConfig,
+	useValidationSchema,
+} from "../../utils/hooks";
 import { Sections } from "../elements/sections";
 import { EventProvider } from "./event";
 import { FormSchemaProvider } from "./form-schema";
@@ -46,6 +52,7 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 		},
 	});
 	const { setFormSchema } = useFormSchema();
+	const { resetFields } = useFormValues();
 
 	const {
 		reset,
@@ -169,6 +176,7 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 
 	useDeepCompareEffectNoCheck(() => {
 		reset(cloneDeep(defaultValues));
+		resetFields(defaultValues);
 	}, [defaultValues]);
 
 	useDeepCompareEffect(() => {

--- a/src/components/frontend-engine/frontend-engine.tsx
+++ b/src/components/frontend-engine/frontend-engine.tsx
@@ -77,7 +77,10 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 		getValues,
 		isValid: checkIsFormValid,
 		removeFieldEventListener,
-		reset,
+		reset: (values, options) => {
+			reset(values, options);
+			resetFields(values ?? defaultValues);
+		},
 		setErrors,
 		setValue,
 		submit: reactFormHookSubmit(handleSubmit, handleSubmitError),

--- a/src/components/frontend-engine/frontend-engine.tsx
+++ b/src/components/frontend-engine/frontend-engine.tsx
@@ -8,9 +8,10 @@ import { ObjectHelper, TestHelper } from "../../utils";
 import { useFieldEvent, useFormSchema, useValidationConfig, useValidationSchema } from "../../utils/hooks";
 import { Sections } from "../elements/sections";
 import { EventProvider } from "./event";
+import { FormSchemaProvider } from "./form-schema";
+import { FormValuesProvider } from "./form-values";
 import { IFrontendEngineProps, IFrontendEngineRef, TErrorPayload, TFrontendEngineValues, TNoInfer } from "./types";
 import { IYupValidationRule, YupHelper, YupProvider } from "./yup";
-import { FormSchemaProvider } from "./form-schema";
 
 const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>((props, ref) => {
 	// =============================================================================
@@ -206,7 +207,9 @@ export const FrontendEngine = forwardRef<IFrontendEngineRef, IFrontendEngineProp
 		<YupProvider>
 			<EventProvider>
 				<FormSchemaProvider>
-					<FrontendEngineInner {...props} ref={ref} />
+					<FormValuesProvider>
+						<FrontendEngineInner {...props} ref={ref} />
+					</FormValuesProvider>
 				</FormSchemaProvider>
 			</EventProvider>
 		</YupProvider>

--- a/src/components/frontend-engine/frontend-engine.tsx
+++ b/src/components/frontend-engine/frontend-engine.tsx
@@ -79,7 +79,12 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 		removeFieldEventListener,
 		reset: (values, options) => {
 			reset(values, options);
-			resetFields(values ?? defaultValues);
+
+			if (typeof values === "function") {
+				resetFields(values(formMethods.getValues()) ?? defaultValues);
+			} else {
+				resetFields(values ?? defaultValues);
+			}
 		},
 		setErrors,
 		setValue,
@@ -138,7 +143,7 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 	}, []);
 
 	useEffect(() => {
-		const subscription = watch((value, { name, type }) => {
+		const subscription = watch((value, { name }) => {
 			if (name) {
 				setField(name, value[name]);
 			} else {

--- a/src/components/frontend-engine/frontend-engine.tsx
+++ b/src/components/frontend-engine/frontend-engine.tsx
@@ -52,7 +52,7 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 		},
 	});
 	const { setFormSchema } = useFormSchema();
-	const { resetFields } = useFormValues();
+	const { resetFields, setFields, setField } = useFormValues();
 
 	const {
 		reset,
@@ -134,6 +134,21 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 	// EFFECTS
 	// =============================================================================
 	useEffect(() => {
+		setFields(getValues());
+	}, []);
+
+	useEffect(() => {
+		const subscription = watch((value, { name, type }) => {
+			if (name) {
+				setField(name, value[name]);
+			} else {
+				setFields(value);
+			}
+		});
+		return () => subscription.unsubscribe();
+	}, []);
+
+	useEffect(() => {
 		// attach / fire onChange event only formValidationConfig has values
 		// otherwise isValid will be returned incorrectly as true
 		if (onChange && Object.keys(formValidationConfig || {}).length) {
@@ -179,7 +194,6 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 
 	useDeepCompareEffectNoCheck(() => {
 		reset(cloneDeep(defaultValues));
-		resetFields(defaultValues);
 	}, [defaultValues]);
 
 	useDeepCompareEffect(() => {

--- a/src/components/frontend-engine/types.ts
+++ b/src/components/frontend-engine/types.ts
@@ -107,7 +107,7 @@ export type TFrontendEngineFieldSchema<V = undefined> =
 export type TFrontendEngineValues<T = any> = Record<keyof T, T[keyof T]>;
 export type TRevalidationMode = Exclude<keyof ValidationMode, "onTouched" | "all">;
 export type TValidationMode = keyof ValidationMode;
-export type TRestoreMode = "default-value" | "user-input";
+export type TRestoreMode = "none" | "default-value" | "user-input";
 
 export type TErrorMessage = string | string[] | Record<string, string | string[]>;
 export type TErrorPayload = Record<string, TErrorMessage>;

--- a/src/components/frontend-engine/types.ts
+++ b/src/components/frontend-engine/types.ts
@@ -74,6 +74,12 @@ export interface IFrontendEngineData<V = undefined> {
 	validationMode?: TValidationMode | undefined;
 	/** Additional properties to mutate the sections schema on-the-fly */
 	overrides?: Record<string, RecursivePartial<TFrontendEngineFieldSchema<V>>> | undefined;
+	/**
+	 * Specifies how a conditionally rendered field gets populated when it is shown again
+	 * - `"none"`: cleared
+	 * - `"default-value"`: the initial value
+	 * - `"user-input"`: the latest value
+	 */
 	restoreMode?: TRestoreMode | undefined;
 }
 

--- a/src/components/frontend-engine/types.ts
+++ b/src/components/frontend-engine/types.ts
@@ -74,6 +74,7 @@ export interface IFrontendEngineData<V = undefined> {
 	validationMode?: TValidationMode | undefined;
 	/** Additional properties to mutate the sections schema on-the-fly */
 	overrides?: Record<string, RecursivePartial<TFrontendEngineFieldSchema<V>>> | undefined;
+	restoreMode?: "default-value" | "user-input" | undefined;
 }
 
 // NOTE: add all possible schema types here except section schema

--- a/src/components/frontend-engine/types.ts
+++ b/src/components/frontend-engine/types.ts
@@ -74,7 +74,7 @@ export interface IFrontendEngineData<V = undefined> {
 	validationMode?: TValidationMode | undefined;
 	/** Additional properties to mutate the sections schema on-the-fly */
 	overrides?: Record<string, RecursivePartial<TFrontendEngineFieldSchema<V>>> | undefined;
-	restoreMode?: "default-value" | "user-input" | undefined;
+	restoreMode?: TRestoreMode | undefined;
 }
 
 // NOTE: add all possible schema types here except section schema
@@ -107,6 +107,7 @@ export type TFrontendEngineFieldSchema<V = undefined> =
 export type TFrontendEngineValues<T = any> = Record<keyof T, T[keyof T]>;
 export type TRevalidationMode = Exclude<keyof ValidationMode, "onTouched" | "all">;
 export type TValidationMode = keyof ValidationMode;
+export type TRestoreMode = "default-value" | "user-input";
 
 export type TErrorMessage = string | string[] | Record<string, string | string[]>;
 export type TErrorPayload = Record<string, TErrorMessage>;

--- a/src/stories/2-frontend-engine/conditional-rendering/conditional-rendering-array.stories.tsx
+++ b/src/stories/2-frontend-engine/conditional-rendering/conditional-rendering-array.stories.tsx
@@ -5,7 +5,7 @@ import { TFrontendEngineFieldSchema } from "../../../components/frontend-engine"
 import { SUBMIT_BUTTON_SCHEMA } from "../../common";
 
 export default {
-	title: "Form/Conditional Rendering/Arrays",
+	title: "Form/Conditional Rendering/Rules/Arrays",
 	component: null,
 	parameters: {
 		docs: {

--- a/src/stories/2-frontend-engine/conditional-rendering/conditional-rendering-number.stories.tsx
+++ b/src/stories/2-frontend-engine/conditional-rendering/conditional-rendering-number.stories.tsx
@@ -5,7 +5,7 @@ import { TFrontendEngineFieldSchema } from "../../../components/frontend-engine"
 import { SUBMIT_BUTTON_SCHEMA } from "../../common";
 
 export default {
-	title: "Form/Conditional Rendering/Numbers",
+	title: "Form/Conditional Rendering/Rules/Numbers",
 	component: null,
 	parameters: {
 		docs: {

--- a/src/stories/2-frontend-engine/conditional-rendering/conditional-rendering-restore-mode.stories.tsx
+++ b/src/stories/2-frontend-engine/conditional-rendering/conditional-rendering-restore-mode.stories.tsx
@@ -1,0 +1,110 @@
+import { Button } from "@lifesg/react-design-system/button";
+import { Description, Stories, Title } from "@storybook/addon-docs";
+import { Meta, Story } from "@storybook/react/types-6-0";
+import { useRef } from "react";
+import { IFrontendEngineData, IFrontendEngineProps, IFrontendEngineRef } from "../../../components/frontend-engine";
+import { FrontendEngine, SUBMIT_BUTTON_SCHEMA } from "../../common";
+
+const DATA: IFrontendEngineData = {
+	sections: {
+		section: {
+			uiType: "section",
+			children: {
+				field1: {
+					label: "Field 1",
+					uiType: "text-field",
+					placeholder: 'Type "show"',
+					validation: [{ required: true }],
+				},
+				field2: {
+					label: "Field 2 (depends on Field 1)",
+					uiType: "date-field",
+					showIf: [{ field1: [{ equals: "show" }] }],
+					validation: [{ required: true }],
+					withButton: false,
+				},
+				field3: {
+					label: "Field 3 (depends on Field 1)",
+					uiType: "chips",
+					showIf: [{ field1: [{ equals: "show" }] }],
+					validation: [{ required: true }],
+					options: [
+						{ value: "1", label: "Opt 1" },
+						{ value: "2", label: "Opt 2" },
+						{ value: "3", label: "Opt 3" },
+					],
+					textarea: {
+						label: "Others",
+					},
+				},
+				unrelated: {
+					label: "Unrelated field",
+					uiType: "text-field",
+				},
+				unrelatedWithDefault: {
+					label: "Unrelated field with default",
+					uiType: "text-field",
+				},
+				...SUBMIT_BUTTON_SCHEMA,
+			},
+		},
+	},
+	defaultValues: {
+		field1: "show",
+		field2: "2023-01-01",
+		"field3-textarea": "hello",
+		unrelatedWithDefault: "default",
+	},
+};
+
+export default {
+	title: "Form/Conditional Rendering/Restore",
+	component: null,
+	parameters: {
+		docs: {
+			page: () => (
+				<>
+					<Title>Restore conditionally rendered fields</Title>
+					<Description>
+						You can configure if the current value of a field is persisted when its visibility is toggled.
+					</Description>
+					<Stories includePrimary={true} title="Examples" />
+				</>
+			),
+		},
+	},
+} as Meta;
+
+const Template: Story<IFrontendEngineProps> = (args) => {
+	const ref = useRef<IFrontendEngineRef>();
+	const handleReset = () => {
+		ref.current.reset();
+	};
+
+	return (
+		<>
+			<style dangerouslySetInnerHTML={{ __html: ".hidden {display: none};" }} />
+			<FrontendEngine ref={ref} {...args} />
+			<br />
+			<Button.Default styleType="secondary" onClick={handleReset}>
+				Reset form
+			</Button.Default>
+		</>
+	);
+};
+
+export const RestoreDefaultValue = Template.bind({});
+RestoreDefaultValue.args = {
+	data: {
+		...DATA,
+		restoreMode: "default-value",
+	},
+};
+
+export const RestoreUserInput = Template.bind({});
+RestoreUserInput.args = {
+	data: {
+		...DATA,
+		restoreMode: "user-input",
+	},
+};

--- a/src/stories/2-frontend-engine/conditional-rendering/conditional-rendering-restore-mode.stories.tsx
+++ b/src/stories/2-frontend-engine/conditional-rendering/conditional-rendering-restore-mode.stories.tsx
@@ -85,6 +85,14 @@ const Template: Story<IFrontendEngineProps> = (args) => {
 	);
 };
 
+export const None = Template.bind({});
+None.args = {
+	data: {
+		...DATA,
+		restoreMode: "none",
+	},
+};
+
 export const RestoreDefaultValue = Template.bind({});
 RestoreDefaultValue.args = {
 	data: {

--- a/src/stories/2-frontend-engine/conditional-rendering/conditional-rendering-restore-mode.stories.tsx
+++ b/src/stories/2-frontend-engine/conditional-rendering/conditional-rendering-restore-mode.stories.tsx
@@ -37,14 +37,6 @@ const DATA: IFrontendEngineData = {
 						label: "Others",
 					},
 				},
-				unrelated: {
-					label: "Unrelated field",
-					uiType: "text-field",
-				},
-				unrelatedWithDefault: {
-					label: "Unrelated field with default",
-					uiType: "text-field",
-				},
 				...SUBMIT_BUTTON_SCHEMA,
 			},
 		},
@@ -53,20 +45,20 @@ const DATA: IFrontendEngineData = {
 		field1: "show",
 		field2: "2023-01-01",
 		"field3-textarea": "hello",
-		unrelatedWithDefault: "default",
 	},
 };
 
 export default {
-	title: "Form/Conditional Rendering/Restore",
+	title: "Form/Conditional Rendering/Restoring Values",
 	component: null,
 	parameters: {
 		docs: {
 			page: () => (
 				<>
-					<Title>Restore conditionally rendered fields</Title>
+					<Title>Restore values</Title>
 					<Description>
-						You can configure if the current value of a field is persisted when its visibility is toggled.
+						When a field&apos;s visibility is restored, the value that is populated can be configured via
+						the `restoreMode` flag.
 					</Description>
 					<Stories includePrimary={true} title="Examples" />
 				</>

--- a/src/stories/2-frontend-engine/conditional-rendering/conditional-rendering-string.stories.tsx
+++ b/src/stories/2-frontend-engine/conditional-rendering/conditional-rendering-string.stories.tsx
@@ -5,7 +5,7 @@ import { TFrontendEngineFieldSchema } from "../../../components/frontend-engine"
 import { SUBMIT_BUTTON_SCHEMA } from "../../common";
 
 export default {
-	title: "Form/Conditional Rendering/Strings",
+	title: "Form/Conditional Rendering/Rules/Strings",
 	component: null,
 	parameters: {
 		docs: {

--- a/src/stories/2-frontend-engine/conditional-rendering/conditional-rendering.stories.tsx
+++ b/src/stories/2-frontend-engine/conditional-rendering/conditional-rendering.stories.tsx
@@ -5,7 +5,7 @@ import { TFrontendEngineFieldSchema } from "../../../components/frontend-engine"
 import { SUBMIT_BUTTON_SCHEMA } from "../../common";
 
 export default {
-	title: "Form/Conditional Rendering",
+	title: "Form/Conditional Rendering/Rules",
 	component: null,
 	parameters: {
 		docs: {

--- a/src/stories/2-frontend-engine/frontend-engine.stories.tsx
+++ b/src/stories/2-frontend-engine/frontend-engine.stories.tsx
@@ -163,7 +163,7 @@ export default {
 		},
 		"data.validationMode": {
 			description:
-				"Validation strategy before a user submits the form (onSubmit event). RRefer to React Hook Form's <a href='https://react-hook-form.com/api/useform/#props' target='_blank' rel='noopener noreferrer'>documentation</a> for more info.",
+				"Validation strategy before a user submits the form (onSubmit event). Refer to React Hook Form's <a href='https://react-hook-form.com/api/useform/#props' target='_blank' rel='noopener noreferrer'>documentation</a> for more info.",
 			table: {
 				type: {
 					summary: "TValidationMode",
@@ -171,6 +171,19 @@ export default {
 				},
 				defaultValue: {
 					summary: "onTouched",
+				},
+			},
+		},
+		"data.restoreMode": {
+			description:
+				"Specifies how the value of a conditionally rendered field is populated when it is shown again.",
+			table: {
+				type: {
+					summary: "TRestoreMode",
+					detail: "none | default-value | user-input",
+				},
+				defaultValue: {
+					summary: "none",
 				},
 			},
 		},

--- a/src/stories/5-custom/filter/filter-checkbox-item.stories.tsx
+++ b/src/stories/5-custom/filter/filter-checkbox-item.stories.tsx
@@ -81,7 +81,7 @@ export default {
 		// },
 		showIf: {
 			description:
-				"A set of conditions to render the field. For more info, refer to the <a href='../?path=/docs/form-conditional-rendering--filled'>Conditional Rendering</a> stories",
+				"A set of conditions to render the field. For more info, refer to the <a href='../?path=/docs/form-conditional-rendering-rules--filled'>Conditional Rendering</a> stories",
 			table: {
 				type: {
 					summary: "array",

--- a/src/stories/common.tsx
+++ b/src/stories/common.tsx
@@ -80,7 +80,7 @@ export const CommonFieldStoryProps = (uiType: string, onlyFieldType = false) => 
 		},
 		showIf: {
 			description:
-				"A set of conditions to render the field. For more info, refer to the <a href='../?path=/docs/form-conditional-rendering--filled'>Conditional Rendering</a> stories",
+				"A set of conditions to render the field. For more info, refer to the <a href='../?path=/docs/form-conditional-rendering-rules--filled'>Conditional Rendering</a> stories",
 			table: {
 				type: {
 					summary: "array",

--- a/src/utils/hooks/index.ts
+++ b/src/utils/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from "./use-field-event";
 export * from "./use-form-schema";
+export * from "./use-form-values";
 export * from "./use-previous";
 export * from "./use-validation-config";
 export * from "./use-validation-schema";

--- a/src/utils/hooks/use-form-values.ts
+++ b/src/utils/hooks/use-form-values.ts
@@ -2,30 +2,30 @@ import { useContext } from "react";
 import { FormValuesContext } from "../../components/frontend-engine/form-values";
 
 export const useFormValues = () => {
-	const { setFormValues, formValues, formValuesRef, setFieldHistory, fieldHistory } = useContext(FormValuesContext);
+	const { setFormValues, formValues, formValuesRef } = useContext(FormValuesContext);
 
 	const getField = (id: string) => {
 		return formValuesRef.current[id];
 	};
 
 	const setField = (id: string, value: unknown) => {
-		setFormValues((formValues) => {
+		formValuesRef.current[id] = value;
+		setFormValues((state) => {
 			const newState = {
-				...formValues,
+				...state,
 				[id]: value,
 			};
-			formValuesRef.current = newState;
 			return newState;
 		});
 	};
 
 	const setFields = (values: Record<string, unknown>) => {
-		setFormValues((formValues) => {
+		formValuesRef.current = { ...formValuesRef.current, ...values };
+		setFormValues((state) => {
 			const newState = {
-				...formValues,
+				...state,
 				...values,
 			};
-			formValuesRef.current = newState;
 			return newState;
 		});
 	};
@@ -36,18 +36,5 @@ export const useFormValues = () => {
 		setFormValues(newState);
 	};
 
-	const isFieldShown = (id: string): boolean => {
-		return !!fieldHistory[id];
-	};
-
-	const setFieldShown = (id: string) => {
-		setFieldHistory((state) => {
-			return {
-				...state,
-				[id]: true,
-			};
-		});
-	};
-
-	return { formValues, getField, setFields, setField, resetFields, fieldHistory, isFieldShown, setFieldShown };
+	return { formValues, getField, setFields, setField, resetFields };
 };

--- a/src/utils/hooks/use-form-values.ts
+++ b/src/utils/hooks/use-form-values.ts
@@ -31,9 +31,9 @@ export const useFormValues = () => {
 	};
 
 	const resetFields = (values: Record<string, unknown>) => {
-		const newState = { ...values };
-		formValuesRef.current = newState;
-		setFormValues(newState);
+		// ensure object references are different
+		formValuesRef.current = { ...values };
+		setFormValues(() => ({ ...values }));
 	};
 
 	return { formValues, getField, setFields, setField, resetFields };

--- a/src/utils/hooks/use-form-values.ts
+++ b/src/utils/hooks/use-form-values.ts
@@ -1,0 +1,26 @@
+import { useContext } from "react";
+import { FormValuesContext } from "../../components/frontend-engine/form-values";
+
+export const useFormValues = () => {
+	const { setFormValues, formValues } = useContext(FormValuesContext);
+
+	const setField = (id: string, value: unknown) => {
+		setFormValues((formValues) => ({
+			...formValues,
+			[id]: value,
+		}));
+	};
+
+	const setFields = (values: Record<string, unknown>) => {
+		setFormValues((formValues) => ({
+			...formValues,
+			...values,
+		}));
+	};
+
+	const resetFields = (values: Record<string, unknown>) => {
+		setFormValues({ ...values });
+	};
+
+	return { formValues, setFields, setField, resetFields };
+};

--- a/src/utils/hooks/use-form-values.ts
+++ b/src/utils/hooks/use-form-values.ts
@@ -2,25 +2,43 @@ import { useContext } from "react";
 import { FormValuesContext } from "../../components/frontend-engine/form-values";
 
 export const useFormValues = () => {
-	const { setFormValues, formValues } = useContext(FormValuesContext);
+	const { setFormValues, formValues, setFieldHistory, fieldHistory } = useContext(FormValuesContext);
 
 	const setField = (id: string, value: unknown) => {
-		setFormValues((formValues) => ({
-			...formValues,
-			[id]: value,
-		}));
+		setFormValues((formValues) => {
+			return {
+				...formValues,
+				[id]: value,
+			};
+		});
 	};
 
 	const setFields = (values: Record<string, unknown>) => {
-		setFormValues((formValues) => ({
-			...formValues,
-			...values,
-		}));
+		setFormValues((formValues) => {
+			const res = {
+				...formValues,
+				...values,
+			};
+			return res;
+		});
 	};
 
 	const resetFields = (values: Record<string, unknown>) => {
 		setFormValues({ ...values });
 	};
 
-	return { formValues, setFields, setField, resetFields };
+	const isFieldShown = (id: string): boolean => {
+		return !!fieldHistory[id];
+	};
+
+	const setFieldShown = (id: string) => {
+		setFieldHistory((fieldHistory) => {
+			return {
+				...fieldHistory,
+				[id]: true,
+			};
+		});
+	};
+
+	return { formValues, setFields, setField, resetFields, fieldHistory, isFieldShown, setFieldShown };
 };

--- a/src/utils/hooks/use-form-values.ts
+++ b/src/utils/hooks/use-form-values.ts
@@ -2,29 +2,38 @@ import { useContext } from "react";
 import { FormValuesContext } from "../../components/frontend-engine/form-values";
 
 export const useFormValues = () => {
-	const { setFormValues, formValues, setFieldHistory, fieldHistory } = useContext(FormValuesContext);
+	const { setFormValues, formValues, formValuesRef, setFieldHistory, fieldHistory } = useContext(FormValuesContext);
+
+	const getField = (id: string) => {
+		return formValuesRef.current[id];
+	};
 
 	const setField = (id: string, value: unknown) => {
 		setFormValues((formValues) => {
-			return {
+			const newState = {
 				...formValues,
 				[id]: value,
 			};
+			formValuesRef.current = newState;
+			return newState;
 		});
 	};
 
 	const setFields = (values: Record<string, unknown>) => {
 		setFormValues((formValues) => {
-			const res = {
+			const newState = {
 				...formValues,
 				...values,
 			};
-			return res;
+			formValuesRef.current = newState;
+			return newState;
 		});
 	};
 
 	const resetFields = (values: Record<string, unknown>) => {
-		setFormValues({ ...values });
+		const newState = { ...values };
+		formValuesRef.current = newState;
+		setFormValues(newState);
 	};
 
 	const isFieldShown = (id: string): boolean => {
@@ -32,13 +41,13 @@ export const useFormValues = () => {
 	};
 
 	const setFieldShown = (id: string) => {
-		setFieldHistory((fieldHistory) => {
+		setFieldHistory((state) => {
 			return {
-				...fieldHistory,
+				...state,
 				[id]: true,
 			};
 		});
 	};
 
-	return { formValues, setFields, setField, resetFields, fieldHistory, isFieldShown, setFieldShown };
+	return { formValues, getField, setFields, setField, resetFields, fieldHistory, isFieldShown, setFieldShown };
 };


### PR DESCRIPTION
**Changes**

- Track user's historical field inputs in a `FormValues` context
- Update fields on changes (via `watch`) and reset
- Introduce a `restoreMode` that configures how conditionally rendered fields are populated when they are toggled
- Added and reorganised stories under `Condtional Rendering/Rules` and `Condtional Rendering/Restoring Values`
- [delete] branch