### PR TITLE
`isDirty` flag

### DIFF
--- a/src/__tests__/common/helper.tsx
+++ b/src/__tests__/common/helper.tsx
@@ -1,6 +1,14 @@
 import { ByRoleOptions, screen } from "@testing-library/react";
-import { TFrontendEngineFieldSchema } from "../../components/frontend-engine";
+import {
+	FrontendEngine,
+	IFrontendEngineData,
+	IFrontendEngineProps,
+	IFrontendEngineRef,
+	TFrontendEngineFieldSchema,
+	TFrontendEngineValues,
+} from "../../components/frontend-engine";
 import { ERROR_MESSAGE, RESET_BUTTON_ID, RESET_BUTTON_LABEL, SUBMIT_BUTTON_ID, SUBMIT_BUTTON_LABEL } from "./data";
+import { useRef } from "react";
 
 type TAriaRoles = "textbox" | "generic" | "button" | "spinbutton" | "radio" | "list";
 
@@ -58,3 +66,22 @@ export const getErrorMessage = (isQuery = false): HTMLElement => {
 };
 
 export const flushPromise = (delay = 0) => new Promise((resolve) => setTimeout(resolve, delay));
+
+export const FrontendEngineWithCustomButton = (props: {
+	onClick: (ref: React.MutableRefObject<IFrontendEngineRef>) => void;
+	onSubmit?: (values: TFrontendEngineValues) => unknown | undefined;
+	data: IFrontendEngineData;
+	overrideProps?: Partial<Exclude<IFrontendEngineProps, "onSubmit">>;
+}) => {
+	const { data, onClick, onSubmit, overrideProps } = props;
+	const ref = useRef<IFrontendEngineRef>();
+
+	return (
+		<>
+			<FrontendEngine {...overrideProps} data={data} ref={ref} onSubmit={onSubmit} />
+			<button type="button" onClick={() => onClick(ref)}>
+				Custom Button
+			</button>
+		</>
+	);
+};

--- a/src/__tests__/components/fields/location-field/location-field.spec.tsx
+++ b/src/__tests__/components/fields/location-field/location-field.spec.tsx
@@ -6,7 +6,15 @@ import { FrontendEngine, IFrontendEngineData, IFrontendEngineProps, IFrontendEng
 import { ILocationFieldSchema, TSetCurrentLocationDetail } from "../../../../components/fields";
 import { LocationHelper } from "../../../../components/fields/location-field/location-helper";
 import { GeoLocationHelper, TestHelper } from "../../../../utils";
-import { FRONTEND_ENGINE_ID, TOverrideField, TOverrideSchema } from "../../../common";
+import {
+	FRONTEND_ENGINE_ID,
+	FrontendEngineWithCustomButton,
+	TOverrideField,
+	TOverrideSchema,
+	getResetButton,
+	getResetButtonProps,
+	getSubmitButtonProps,
+} from "../../../common";
 import {
 	fetchSingleLocationByLatLngSingleReponse,
 	mock1PageFetchAddressResponse,
@@ -1121,5 +1129,141 @@ describe("location-input-group", () => {
 
 	describe("customisation", () => {
 		it.todo("should support placeholder texts");
+	});
+
+	describe("dirty state", () => {
+		let formIsDirty: boolean;
+		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
+			formIsDirty = ref.current.isDirty;
+		};
+		const json: IFrontendEngineData = {
+			id: FRONTEND_ENGINE_ID,
+			sections: {
+				section: {
+					uiType: "section",
+					children: {
+						[COMPONENT_ID]: {
+							label: LABEL,
+							uiType: UI_TYPE,
+						},
+						...getSubmitButtonProps(),
+						...getResetButtonProps(),
+					},
+				},
+			},
+		};
+
+		beforeEach(() => {
+			getCurrentLocationSpy.mockRejectedValue({ code: 1 });
+			fetchAddressSpy.mockImplementation((queryString, pageNumber, onSuccess) => {
+				onSuccess(mock1PageFetchAddressResponse);
+			});
+			formIsDirty = undefined;
+		});
+
+		it("should mount without setting field state as dirty", () => {
+			render(<FrontendEngineWithCustomButton data={json} onClick={handleClick} />);
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(false);
+		});
+
+		it("should set form state as dirty if user modifies the field", async () => {
+			render(<FrontendEngineWithCustomButton data={json} onClick={handleClick} />);
+			await waitFor(() => window.dispatchEvent(new Event("online")));
+			getLocationInput().focus();
+			await waitFor(() => {
+				expect(getCurrentLocationErrorModal(true)).toBeInTheDocument();
+			});
+			within(getCurrentLocationErrorModal(true)).getByRole("button").click();
+			fireEvent.change(getLocationSearchInput(), { target: { value: "found something" } });
+			await waitFor(() => {
+				expect(getLocationSearchResults(true)).not.toBeEmptyDOMElement();
+			});
+			const resultContainer = getLocationSearchResults();
+			const selectedResult = resultContainer.getElementsByTagName("div")[0];
+			fireEvent.click(selectedResult);
+			fireEvent.click(getLocationModalControlButtons("Confirm"));
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(true);
+		});
+
+		it("should support default value without setting form state as dirty", () => {
+			render(
+				<FrontendEngineWithCustomButton
+					data={{
+						...json,
+						defaultValues: {
+							[COMPONENT_ID]: {
+								address: "Fusionopolis View",
+							},
+						},
+					}}
+					onClick={handleClick}
+				/>
+			);
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(false);
+		});
+
+		it("should reset and revert form dirty state to false", async () => {
+			render(<FrontendEngineWithCustomButton data={json} onClick={handleClick} />);
+			await waitFor(() => window.dispatchEvent(new Event("online")));
+			getLocationInput().focus();
+			await waitFor(() => {
+				expect(getCurrentLocationErrorModal(true)).toBeInTheDocument();
+			});
+			within(getCurrentLocationErrorModal(true)).getByRole("button").click();
+			fireEvent.change(getLocationSearchInput(), { target: { value: "found something" } });
+			await waitFor(() => {
+				expect(getLocationSearchResults(true)).not.toBeEmptyDOMElement();
+			});
+			const resultContainer = getLocationSearchResults();
+			const selectedResult = resultContainer.getElementsByTagName("div")[0];
+			fireEvent.click(selectedResult);
+			fireEvent.click(getLocationModalControlButtons("Confirm"));
+
+			fireEvent.click(getResetButton());
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(false);
+		});
+
+		it("should reset to default value without setting form state as dirty", async () => {
+			render(
+				<FrontendEngineWithCustomButton
+					data={{
+						...json,
+						defaultValues: {
+							[COMPONENT_ID]: {
+								address: "Fusionopolis View",
+							},
+						},
+					}}
+					onClick={handleClick}
+				/>
+			);
+			await waitFor(() => window.dispatchEvent(new Event("online")));
+			getLocationInput().focus();
+			await waitFor(() => {
+				expect(getCurrentLocationErrorModal(true)).toBeInTheDocument();
+			});
+			within(getCurrentLocationErrorModal(true)).getByRole("button").click();
+			fireEvent.change(getLocationSearchInput(), { target: { value: "found something" } });
+			await waitFor(() => {
+				expect(getLocationSearchResults(true)).not.toBeEmptyDOMElement();
+			});
+			const resultContainer = getLocationSearchResults();
+			const selectedResult = resultContainer.getElementsByTagName("div")[0];
+			fireEvent.click(selectedResult);
+			fireEvent.click(getLocationModalControlButtons("Confirm"));
+
+			fireEvent.click(getResetButton());
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(false);
+		});
 	});
 });

--- a/src/components/fields/contact-field/contact-field.tsx
+++ b/src/components/fields/contact-field/contact-field.tsx
@@ -121,10 +121,10 @@ export const ContactField = (props: IGenericFieldProps<IContactFieldSchema>) => 
 			if (!fixedCountry || (fixedCountry && prefixWithoutPlus === schemaPrefix)) {
 				const fieldPrefix = prefix || schemaPrefix;
 				const phoneNumberWithPrefix = parseAndApplyNumber({ countryCode: fieldPrefix, number });
-				setValue(id, phoneNumberWithPrefix, { shouldDirty: false });
+				setValue(id, phoneNumberWithPrefix);
 			} else {
 				const phoneNumberWithPrefix = parseAndApplyNumber({ countryCode: "", number: "" });
-				setValue(id, phoneNumberWithPrefix, { shouldDirty: false });
+				setValue(id, phoneNumberWithPrefix);
 			}
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/fields/date-field/date-field.tsx
+++ b/src/components/fields/date-field/date-field.tsx
@@ -153,7 +153,7 @@ export const DateField = (props: IGenericFieldProps<IDateFieldSchema>) => {
 				// runs on mount and reset
 				if (useCurrentDate) {
 					const currentDate = DateTimeHelper.formatDateTime(LocalDate.now().toString(), dateFormat, "date");
-					setValue(id, currentDate, { shouldDirty: false });
+					setValue(id, currentDate);
 
 					const inputDate = DateTimeHelper.formatDateTime(
 						LocalDate.now().toString(),

--- a/src/components/fields/date-field/date-field.tsx
+++ b/src/components/fields/date-field/date-field.tsx
@@ -153,7 +153,7 @@ export const DateField = (props: IGenericFieldProps<IDateFieldSchema>) => {
 				// runs on mount and reset
 				if (useCurrentDate) {
 					const currentDate = DateTimeHelper.formatDateTime(LocalDate.now().toString(), dateFormat, "date");
-					setValue(id, currentDate, { shouldDirty: true });
+					setValue(id, currentDate, { shouldDirty: false });
 
 					const inputDate = DateTimeHelper.formatDateTime(
 						LocalDate.now().toString(),

--- a/src/components/fields/image-upload/image-input/image-input.tsx
+++ b/src/components/fields/image-upload/image-input/image-input.tsx
@@ -75,7 +75,12 @@ export const ImageInput = (props: IImageInputProps) => {
 
 	const handleDeleteFile = (index: number) => (event: React.MouseEvent<HTMLButtonElement>) => {
 		event.preventDefault();
-		setImages((prev) => prev.filter((f, i) => i !== index));
+		setImages((prev) =>
+			prev.map((image, i) => ({
+				...image,
+				...(i === index ? { status: EImageStatus.TO_DELETE } : {}),
+			}))
+		);
 		setExceedError(false);
 	};
 

--- a/src/components/fields/image-upload/image-manager/image-manager.ts
+++ b/src/components/fields/image-upload/image-manager/image-manager.ts
@@ -148,7 +148,6 @@ export const ImageManager = (props: IProps) => {
 					dataURL: drawingDataURL || dataURL,
 					uploadResponse,
 				})),
-			// TODO: set true if not default value
 			{ shouldDirty }
 		);
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/fields/image-upload/image-review/image-review.styles.ts
+++ b/src/components/fields/image-upload/image-review/image-review.styles.ts
@@ -50,7 +50,7 @@ export const ReviewCloseButton = styled(IconButton)`
 	padding: 0.25rem;
 	background-color: transparent;
 	outline-style: none;
-	span {
+	> svg {
 		font-size: 2rem;
 		color: ${Color.Primary};
 	}

--- a/src/components/fields/image-upload/image-review/image-review.tsx
+++ b/src/components/fields/image-upload/image-review/image-review.tsx
@@ -143,7 +143,12 @@ export const ImageReview = (props: IProps) => {
 
 	const handleDeleteDecision = (decision: boolean) => {
 		if (decision) {
-			setImages(images.filter((image, i) => i !== activeFileIndex));
+			setImages((prev) =>
+				prev.map((image, i) => ({
+					...image,
+					...(i === activeFileIndex ? { status: EImageStatus.TO_DELETE } : {}),
+				}))
+			);
 			setActiveFileIndex(Math.max(0, activeFileIndex - 1));
 		}
 		setActivePrompt(null);

--- a/src/components/fields/image-upload/image-review/image-thumbnails/image-thumbnails.styles.ts
+++ b/src/components/fields/image-upload/image-review/image-thumbnails/image-thumbnails.styles.ts
@@ -96,6 +96,7 @@ export const AddImageButton = styled(IconButton)`
 	padding: 0;
 	width: 3rem;
 	height: 3rem;
+	background: #fff;
 
 	> img {
 		width: inherit;

--- a/src/components/fields/image-upload/image-upload.tsx
+++ b/src/components/fields/image-upload/image-upload.tsx
@@ -31,7 +31,6 @@ export const ImageUploadInner = (props: IGenericFieldProps<IImageUploadSchema>) 
 		id,
 		isDirty,
 		value,
-		onChange,
 		...otherProps
 	} = props;
 	const { images, setImages } = useContext(ImageContext);
@@ -233,7 +232,6 @@ export const ImageUploadInner = (props: IGenericFieldProps<IImageUploadSchema>) 
 					editImage={editImage}
 					id={id}
 					maxSizeInKb={maxFileSize}
-					onChange={onChange}
 					outputType={outputType}
 					upload={uploadOnAddingFile}
 					value={value}

--- a/src/components/fields/image-upload/types.ts
+++ b/src/components/fields/image-upload/types.ts
@@ -33,6 +33,7 @@ export interface ISharedImageProps {
 
 export enum EImageStatus {
 	INJECTED = -99,
+	TO_DELETE = -4,
 	ERROR_FORMAT = -3,
 	ERROR_GENERIC = -2,
 	ERROR_SIZE = -1,

--- a/src/components/fields/location-field/location-field.tsx
+++ b/src/components/fields/location-field/location-field.tsx
@@ -1,4 +1,5 @@
 import { Suspense, lazy, useState } from "react";
+import { useFormContext } from "react-hook-form";
 import { TestHelper } from "../../../utils";
 import { IGenericFieldProps } from "../../frontend-engine";
 import { StyledStaticMap } from "./location-field.styles";
@@ -27,16 +28,16 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 		},
 		// form values can initially be undefined when passed in via props
 		value: formValue,
-		onChange,
 	} = props;
 
 	const [showLocationModal, setShowLocationModal] = useState<boolean>(false);
+	const { setValue } = useFormContext();
 
 	// =============================================================================
 	// HELPER FUNCTIONS
 	// =============================================================================
-	const updateFormValues = (updatedValues: ILocationFieldValues) => {
-		onChange?.({ target: { value: updatedValues } });
+	const updateFormValues = (updatedValues: ILocationFieldValues, shouldDirty = true) => {
+		setValue(id, updatedValues, { shouldDirty });
 	};
 
 	// =============================================================================

--- a/src/components/fields/location-field/location-modal/location-search/location-search.tsx
+++ b/src/components/fields/location-field/location-modal/location-search/location-search.tsx
@@ -180,13 +180,13 @@ export const LocationSearch = ({
 				!mustHavePostalCode || LocationHelper.hasGotAddressValue(locationFieldValue.postalCode);
 
 			if (isEmpty(locationFieldValue) || !validPostalCode) {
-				updateFormValues({});
+				updateFormValues({}, false);
 				onChangeSelectedAddressInfo({});
 				return;
 			}
 
 			// complete form state with valid location
-			updateFormValues(locationFieldValue);
+			updateFormValues(locationFieldValue, false);
 			onChangeSelectedAddressInfo(locationFieldValue);
 			setQueryString(locationFieldValue.address);
 		};

--- a/src/components/fields/location-field/location-modal/location-search/types.ts
+++ b/src/components/fields/location-field/location-modal/location-search/types.ts
@@ -18,6 +18,6 @@ export interface ILocationSearchProps {
 	showLocationModal: boolean;
 	mapPickedLatLng?: ILocationCoord | undefined;
 	formValues?: ILocationFieldValues | undefined;
-	updateFormValues: (values: ILocationFieldValues) => void;
+	updateFormValues: (values: ILocationFieldValues, shouldDirty?: boolean) => void;
 	setSinglePanelMode: (panelMode: TSinglePanelInputMode) => void;
 }

--- a/src/components/fields/location-field/location-modal/types.ts
+++ b/src/components/fields/location-field/location-modal/types.ts
@@ -15,5 +15,5 @@ export interface ILocationModalProps
 	locationModalStyles?: string | undefined;
 	onClose: () => void;
 	onConfirm: (values: ILocationFieldValues) => void;
-	updateFormValues: (values: ILocationFieldValues) => void;
+	updateFormValues: (values: ILocationFieldValues, shouldDirty?: boolean) => void;
 }

--- a/src/components/frontend-engine/frontend-engine.tsx
+++ b/src/components/frontend-engine/frontend-engine.tsx
@@ -75,6 +75,7 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 		addCustomValidation: YupHelper.addCondition,
 		dispatchFieldEvent,
 		getValues,
+		isDirty: formState.isDirty,
 		isValid: checkIsFormValid,
 		removeFieldEventListener,
 		reset: (values, options) => {
@@ -169,6 +170,8 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 	}, [checkIsFormValid, onChange, watch, formValidationConfig]);
 
 	useEffect(() => {
+		// console.log("*** rhf isDirty", formState.isDirty);
+		// console.log("*** rhf touchedFields", formState.touchedFields);
 		const errors = formState.errors;
 
 		if (errors && !isEmpty(errors)) {

--- a/src/components/frontend-engine/frontend-engine.tsx
+++ b/src/components/frontend-engine/frontend-engine.tsx
@@ -170,8 +170,6 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 	}, [checkIsFormValid, onChange, watch, formValidationConfig]);
 
 	useEffect(() => {
-		// console.log("*** rhf isDirty", formState.isDirty);
-		// console.log("*** rhf touchedFields", formState.touchedFields);
 		const errors = formState.errors;
 
 		if (errors && !isEmpty(errors)) {

--- a/src/components/frontend-engine/types.ts
+++ b/src/components/frontend-engine/types.ts
@@ -133,6 +133,12 @@ export interface IFrontendEngineRef extends HTMLFormElement {
 	dispatchFieldEvent: <T = any>(type: string, id: string, detail?: T) => boolean;
 	/** gets form values */
 	getValues: () => TFrontendEngineValues;
+	/**
+	 * checks if form has been changed by user
+	 *
+	 * defaultValues do not set this to true
+	 */
+	isDirty: boolean;
 	/** checks if form is valid */
 	isValid: () => boolean;
 	/** adds custom validation rule */

--- a/src/stories/2-frontend-engine/frontend-engine.stories.tsx
+++ b/src/stories/2-frontend-engine/frontend-engine.stories.tsx
@@ -447,6 +447,26 @@ CheckIsValid.parameters = {
 	controls: { hideNoControlsWarning: true },
 };
 
+export const CheckUserIntervention: StoryFn<IFrontendEngineProps> = () => {
+	const ref = useRef<IFrontendEngineRef>();
+	const handleClick = () => {
+		action("isDirty")(ref.current.isDirty);
+	};
+
+	return (
+		<>
+			<FrontendEngine data={DATA} ref={ref} />
+			<br />
+			<Button.Default styleType="secondary" onClick={handleClick}>
+				Check if user has edited the form
+			</Button.Default>
+		</>
+	);
+};
+CheckUserIntervention.parameters = {
+	controls: { hideNoControlsWarning: true },
+};
+
 interface IYupCustomValidationRule {
 	mustBeHello?: boolean | undefined;
 }


### PR DESCRIPTION
**Changes**
- added `isDirty` flag which can be referenced from frontend engine ref
- fixed setting of dirty states on mount / prefilling / reset for
  - contact-field
  - date-field
  - image-upload
  - location-field
- added test cases for frontend engine and the 5 components
- test cases for the remaining components will be added in another PR