### PR TITLE
[MOL-13378][MA] fix styling for DeleteButton

### DIFF
--- a/src/components/fields/image-upload/image-input/file-item/file-item.styles.ts
+++ b/src/components/fields/image-upload/image-input/file-item/file-item.styles.ts
@@ -116,5 +116,9 @@ export const DeleteButton = styled(IconButton)`
 	background-color: transparent;
 	outline-style: none;
 	color: ${Color.Neutral[3]};
-	font-size: 2rem;
+
+	svg {
+		height: 1.875rem;
+		width: 1.875rem;
+	}
 `;

--- a/src/components/fields/image-upload/image-input/file-item/file-item.styles.ts
+++ b/src/components/fields/image-upload/image-input/file-item/file-item.styles.ts
@@ -115,9 +115,6 @@ export const DeleteButton = styled(IconButton)`
 	// additional 0.5 negative marginRight because the image itself has padding already
 	background-color: transparent;
 	outline-style: none;
-
-	span {
-		font-size: 2rem;
-		color: ${Color.Neutral[3]};
-	}
+	color: ${Color.Neutral[3]};
+	font-size: 2rem;
 `;


### PR DESCRIPTION
**Changes**

- Update DeleteButton style to fix bug regarding styles not being applied to cross icon. 
- Previous implementation for DS v1 was designed to wrap the `Icon` component from `react-design-system` which contained a span, whereas the implementation in for DS v2 wraps a `CrossIcon` svg from `react-icons` hence removing the need for applied styles on spans

**Changelog entry**

-   Fix style bug on cross icon for uploaded images

**Additional information**

-   You may refer to [MOL-13719](https://jira.ship.gov.sg/browse/MOL-13719)
