### PR TITLE
Review

### DIFF
--- a/src/__tests__/components/custom/review/review.spec.tsx
+++ b/src/__tests__/components/custom/review/review.spec.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { IReviewSchema } from "../../../../components/custom";
+import { FrontendEngine, IFrontendEngineData } from "../../../../components/frontend-engine";
+import { FRONTEND_ENGINE_ID, TOverrideField } from "../../../common";
+
+const COMPONENT_ID = "field";
+const REFERENCE_KEY = "review";
+const LABEL = "label";
+const DESCRIPTION = "description";
+const ITEMS = [
+	{ label: "Label 1", value: "Value 1" },
+	{ label: "Label 2", value: "Value 2" },
+];
+const ALERT_TOP = "test top alert";
+const ALERT_BOTTOM = "test bottom alert";
+
+const renderComponent = (overrideField?: TOverrideField<IReviewSchema>) => {
+	const json: IFrontendEngineData = {
+		id: FRONTEND_ENGINE_ID,
+		sections: {
+			section: {
+				uiType: "section",
+				children: {
+					[COMPONENT_ID]: {
+						referenceKey: REFERENCE_KEY,
+						label: LABEL,
+						description: DESCRIPTION,
+						items: ITEMS,
+						...overrideField,
+					},
+				},
+			},
+		},
+	};
+	return render(<FrontendEngine data={json} />);
+};
+
+describe(REFERENCE_KEY, () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it("should be able to render the field", () => {
+		renderComponent();
+
+		expect(screen.getByText(LABEL)).toBeInTheDocument();
+		expect(screen.getByText(DESCRIPTION)).toBeInTheDocument();
+		expect(screen.getByText(ITEMS[0].label)).toBeInTheDocument();
+		expect(screen.getByText(ITEMS[1].value)).toBeInTheDocument();
+	});
+
+	it("should be able to render the topSection and bottomSection", () => {
+		renderComponent({
+			topSection: {
+				alertTop: {
+					uiType: "alert",
+					type: "warning",
+					children: ALERT_TOP,
+				},
+			},
+			bottomSection: {
+				alertBottom: {
+					uiType: "alert",
+					type: "warning",
+					children: ALERT_BOTTOM,
+				},
+			},
+		});
+
+		expect(screen.getByText(ALERT_TOP)).toBeInTheDocument();
+		expect(screen.getByText(ALERT_BOTTOM)).toBeInTheDocument();
+	});
+});

--- a/src/components/custom/filter/filter-checkbox/types.ts
+++ b/src/components/custom/filter/filter-checkbox/types.ts
@@ -1,4 +1,5 @@
-import { ICustomFieldJsonSchema } from "../../../frontend-engine";
+import { ICustomFieldJsonSchema } from "../../types";
+
 export interface IFilterCheckboxSchema<V = undefined>
 	extends Omit<ICustomFieldJsonSchema<"filter-checkbox", V>, "validation"> {
 	label: string;

--- a/src/components/custom/filter/filter-item/types.ts
+++ b/src/components/custom/filter/filter-item/types.ts
@@ -1,6 +1,7 @@
-import { ICustomComponentJsonSchema, TFrontendEngineFieldSchema } from "../../../frontend-engine";
+import { TFrontendEngineFieldSchema } from "../../../frontend-engine";
+import { ICustomElementJsonSchema } from "../../types";
 
-export interface IFilterItemSchema<V = undefined> extends ICustomComponentJsonSchema<"filter-item"> {
+export interface IFilterItemSchema<V = undefined> extends ICustomElementJsonSchema<"filter-item"> {
 	label: string;
 	children: Record<string, TFrontendEngineFieldSchema<V>>;
 	collapsible?: boolean | undefined;

--- a/src/components/custom/filter/filter/types.ts
+++ b/src/components/custom/filter/filter/types.ts
@@ -1,8 +1,8 @@
-import { ICustomComponentJsonSchema } from "../../../frontend-engine";
+import { ICustomElementJsonSchema } from "../../types";
 import { IFilterCheckboxSchema } from "../filter-checkbox/types";
 import { IFilterItemSchema } from "../filter-item/types";
 
-export interface IFilterSchema extends ICustomComponentJsonSchema<"filter"> {
+export interface IFilterSchema extends ICustomElementJsonSchema<"filter"> {
 	label?: string | undefined;
 	toggleFilterButtonLabel?: string | undefined;
 	children: Record<string, IFilterItemSchema | IFilterCheckboxSchema>;

--- a/src/components/custom/index.ts
+++ b/src/components/custom/index.ts
@@ -1,1 +1,2 @@
 export * from "./filter";
+export * from "./types";

--- a/src/components/custom/review/index.ts
+++ b/src/components/custom/review/index.ts
@@ -1,3 +1,2 @@
-export * from "./filter";
 export * from "./review";
 export * from "./types";

--- a/src/components/custom/review/review.tsx
+++ b/src/components/custom/review/review.tsx
@@ -1,0 +1,37 @@
+import { UneditableSection } from "@lifesg/react-design-system/uneditable-section";
+import { Wrapper } from "../../elements/wrapper";
+import { IGenericCustomFieldProps } from "../types";
+import { IReviewSchema } from "./types";
+
+export const Review = (props: IGenericCustomFieldProps<IReviewSchema>) => {
+	// =============================================================================
+	// CONST, STATE, REF
+	// =============================================================================
+	const {
+		id,
+		schema: { label, description, items, topSection, bottomSection, ...otherSchema },
+	} = props;
+
+	// =============================================================================
+	// HELPER FUNCTIONS
+	// =============================================================================
+	const generateSection = (sectionSchema: IReviewSchema["topSection"] | IReviewSchema["bottomSection"]) => {
+		if (!sectionSchema) return undefined;
+
+		return <Wrapper>{sectionSchema}</Wrapper>;
+	};
+	// =========================================================================
+	// RENDER FUNCTIONS
+	// =========================================================================
+	return (
+		<UneditableSection
+			{...otherSchema}
+			id={id}
+			title={label}
+			description={description}
+			items={items}
+			topSection={generateSection(topSection)}
+			bottomSection={generateSection(bottomSection)}
+		/>
+	);
+};

--- a/src/components/custom/review/types.ts
+++ b/src/components/custom/review/types.ts
@@ -1,0 +1,14 @@
+import { UneditableSectionItemProps } from "@lifesg/react-design-system/uneditable-section/types";
+import type { IAlertSchema, ITextSchema } from "../../elements";
+import type { IWrapperSchema } from "../../elements/wrapper";
+import type { ICustomElementJsonSchema } from "../types";
+
+type TReviewSectionChildren = IAlertSchema | ITextSchema | IWrapperSchema;
+
+export interface IReviewSchema extends ICustomElementJsonSchema<"review"> {
+	label?: string | undefined;
+	description?: string | undefined;
+	items: UneditableSectionItemProps[];
+	topSection?: Record<string, TReviewSectionChildren> | undefined;
+	bottomSection?: Record<string, TReviewSectionChildren> | undefined;
+}

--- a/src/components/custom/types.ts
+++ b/src/components/custom/types.ts
@@ -1,0 +1,55 @@
+/**
+ * custom elements / fields are components that are defined by the `referenceKey` instead of `uiType` in the schema
+ * these are typically components that are more opinionated and do not fit into the generic components
+ */
+import type { IYupValidationRule, TFrontendEngineFieldSchema } from "../frontend-engine";
+import type { TRenderRules } from "../frontend-engine/yup";
+import type { IFilterSchema } from "./filter/filter/types";
+
+/**
+ * custom element types
+ * - components that do not have uiType and have specific schema to render
+ */
+export enum ECustomElementType {
+	FILTER = "Filter",
+	"FILTER-ITEM" = "FilterItem",
+}
+
+/**
+ * custom fields types
+ */
+export enum ECustomFieldType {
+	"FILTER-CHECKBOX" = "FilterCheckbox",
+}
+
+/**
+ * union type to represent all custom elements / fields schema
+ */
+export type TCustomComponentSchema = ICustomElementJsonSchema<string> | IFilterSchema;
+
+/**
+ * base schema for custom elements
+ */
+export interface ICustomElementJsonSchema<T> {
+	referenceKey: T;
+	uiType?: never | undefined;
+}
+
+/**
+ * base schema for custom fields
+ */
+export interface ICustomFieldJsonSchema<T, V = undefined, U = undefined> extends ICustomElementJsonSchema<T> {
+	validation?: (V | U | IYupValidationRule)[];
+	/** render conditions
+	 * - need to fulfil at least 1 object in array (OR condition)
+	 * - in order for an object to be valid, need to fulfil all conditions in that object (AND condition) */
+	showIf?: TRenderRules[] | undefined;
+}
+
+/**
+ * common props for all custom elements / fields
+ */
+export interface IGenericCustomFieldProps<T = TFrontendEngineFieldSchema> {
+	id: string;
+	schema: T;
+}

--- a/src/components/custom/types.ts
+++ b/src/components/custom/types.ts
@@ -5,6 +5,7 @@
 import type { IYupValidationRule, TFrontendEngineFieldSchema } from "../frontend-engine";
 import type { TRenderRules } from "../frontend-engine/yup";
 import type { IFilterSchema } from "./filter/filter/types";
+import type { IReviewSchema } from "./review";
 
 /**
  * custom element types
@@ -13,6 +14,7 @@ import type { IFilterSchema } from "./filter/filter/types";
 export enum ECustomElementType {
 	FILTER = "Filter",
 	"FILTER-ITEM" = "FilterItem",
+	REVIEW = "Review",
 }
 
 /**
@@ -25,7 +27,7 @@ export enum ECustomFieldType {
 /**
  * union type to represent all custom elements / fields schema
  */
-export type TCustomComponentSchema = ICustomElementJsonSchema<string> | IFilterSchema;
+export type TCustomComponentSchema = ICustomElementJsonSchema<string> | IFilterSchema | IReviewSchema;
 
 /**
  * base schema for custom elements

--- a/src/components/elements/wrapper/wrapper.tsx
+++ b/src/components/elements/wrapper/wrapper.tsx
@@ -6,14 +6,9 @@ import * as FrontendEngineElements from "..";
 import { TestHelper } from "../../../utils";
 import { useFormSchema } from "../../../utils/hooks";
 import * as FrontendEngineCustomComponents from "../../custom";
+import { ECustomElementType, ECustomFieldType } from "../../custom";
 import * as FrontendEngineFields from "../../fields";
-import {
-	ECustomElementType,
-	ECustomFieldType,
-	EElementType,
-	EFieldType,
-	TFrontendEngineFieldSchema,
-} from "../../frontend-engine/types";
+import { EElementType, EFieldType, TFrontendEngineFieldSchema } from "../../frontend-engine/types";
 import { ERROR_MESSAGES } from "../../shared";
 import { ConditionalRenderer } from "./conditional-renderer";
 import { FieldWrapper } from "./field-wrapper";

--- a/src/components/frontend-engine/types.ts
+++ b/src/components/frontend-engine/types.ts
@@ -5,7 +5,7 @@ import {
 	UseFormSetValue,
 	ValidationMode,
 } from "react-hook-form";
-import { IFilterSchema } from "../custom/filter/filter/types";
+import { ICustomElementJsonSchema, TCustomComponentSchema } from "../custom";
 import { IAlertSchema, ITextSchema } from "../elements";
 import { ISectionSchema } from "../elements/section";
 import { IWrapperSchema } from "../elements/wrapper";
@@ -90,11 +90,9 @@ export type TFrontendEngineFieldSchema<V = undefined> =
 	| ICheckboxGroupSchema<V>
 	| IChipsSchema<V>
 	| IContactFieldSchema<V>
-	| ICustomComponentJsonSchema<string>
 	| IDateFieldSchema<V>
 	| TDateRangeFieldSchema<V>
 	| IEmailFieldSchema<V>
-	| IFilterSchema
 	| IImageUploadSchema<V>
 	| ILocationFieldSchema<V>
 	| IMultiSelectSchema<V>
@@ -110,7 +108,8 @@ export type TFrontendEngineFieldSchema<V = undefined> =
 	| ITextFieldSchema<V>
 	| ITimeFieldSchema<V>
 	| IUnitNumberFieldSchema<V>
-	| IWrapperSchema;
+	| IWrapperSchema
+	| TCustomComponentSchema;
 
 export type TFrontendEngineValues<T = any> = Record<keyof T, T[keyof T]>;
 export type TRevalidationMode = Exclude<keyof ValidationMode, "onTouched" | "all">;
@@ -177,22 +176,6 @@ export interface IFrontendEngineBaseFieldJsonSchema<T, V = undefined, U = undefi
 	validation?: (V | U | IYupValidationRule)[];
 	/** escape hatch for other form / frontend engines to have unsupported attributes */
 	customOptions?: Record<string, unknown> | undefined;
-}
-
-/**
- * to support custom components from other form / frontend engines
- */
-export interface ICustomComponentJsonSchema<T> {
-	referenceKey: T;
-	uiType?: never | undefined;
-}
-
-export interface ICustomFieldJsonSchema<T, V = undefined, U = undefined> extends ICustomComponentJsonSchema<T> {
-	validation?: (V | U | IYupValidationRule)[];
-	/** render conditions
-	 * - need to fulfil at least 1 object in array (OR condition)
-	 * - in order for an object to be valid, need to fulfil all conditions in that object (AND condition) */
-	showIf?: TRenderRules[] | undefined;
 }
 
 /**
@@ -280,19 +263,6 @@ export enum EElementType {
 	H5 = "Wrapper",
 	H6 = "Wrapper",
 	P = "Wrapper",
-}
-
-/**
- * Custom element types
- * - components that do not have uiType and have specific schema to render
- */
-export enum ECustomElementType {
-	FILTER = "Filter",
-	"FILTER-ITEM" = "FilterItem",
-}
-
-export enum ECustomFieldType {
-	"FILTER-CHECKBOX" = "FilterCheckbox",
 }
 
 // =============================================================================

--- a/src/stories/5-custom/review/review.stories.tsx
+++ b/src/stories/5-custom/review/review.stories.tsx
@@ -1,0 +1,140 @@
+import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
+import { Meta } from "@storybook/react";
+import { IReviewSchema } from "../../../components/custom/review";
+import { CommonCustomStoryProps, DefaultStoryTemplate } from "../../common";
+import { UneditableSectionItemProps } from "@lifesg/react-design-system/uneditable-section";
+
+const meta: Meta = {
+	title: "Custom/Review",
+	parameters: {
+		docs: {
+			page: () => (
+				<>
+					<Title>Review</Title>
+					<Description>
+						Displays data fields and information that cannot be edited, this is typically used for review
+						purposes.
+					</Description>
+					<Heading>Props</Heading>
+					<ArgsTable story={PRIMARY_STORY} />
+					<Stories includePrimary={true} title="Examples" />
+				</>
+			),
+		},
+	},
+	argTypes: {
+		...CommonCustomStoryProps("review"),
+		label: {
+			description: "A name of the purpose of the element",
+			table: {
+				type: {
+					summary: "string",
+				},
+			},
+		},
+		description: {
+			description: "Extra line of copy underneath the label",
+			table: {
+				type: {
+					summary: "string",
+				},
+			},
+		},
+		items: {
+			type: { name: "object", value: {}, required: true },
+			description:
+				"<div>The uneditable items to be displayed. Items are displayed in a label and value format.</div><ul><li><strong>label</strong>: Label of the uneditable item</li><li><strong>value</strong>: Value of the uneditable item</li><li><strong>displayWidth</strong>: Width that the item can span across the entire section.</li></ul>",
+			table: {
+				type: {
+					summary: "{ label: string, value: string, displayWidth?: half|full }",
+				},
+				defaultValue: { summary: null },
+			},
+		},
+		topSection: {
+			type: { name: "object", value: {} },
+			description: "A custom section that can be rendered above the main uneditable items section",
+			table: {
+				type: {
+					summary: "Record<string, TReviewSectionChildren>",
+				},
+			},
+		},
+		bottomSection: {
+			type: { name: "object", value: {} },
+			description: "A custom section that can be rendered below the main uneditable items section",
+			table: {
+				type: {
+					summary: "Record<string, TReviewSectionChildren>",
+				},
+			},
+		},
+	},
+};
+export default meta;
+
+const SAMPLE_ITEMS: UneditableSectionItemProps[] = [
+	{
+		label: "Name (as in NRIC or passport)",
+		value: "Tom Tan Li Ho",
+		displayWidth: "half",
+	},
+	{
+		label: "NRIC or FIN",
+		value: "S••••534J",
+		displayWidth: "half",
+	},
+	{
+		label: "Date of birth",
+		value: "6 November 1992",
+		displayWidth: "half",
+	},
+	{
+		label: "Residential Address",
+		value: "Block 287, #05-11, Tampines street 22, Singapore 534788",
+		displayWidth: "half",
+	},
+	{
+		label: "Ethnicity",
+		value: "Chinese",
+	},
+];
+
+export const Default = DefaultStoryTemplate<IReviewSchema>("review-default").bind({});
+Default.args = {
+	referenceKey: "review",
+	label: "Your personal information",
+	description: "Retrieved on 27 Jun 2023",
+	items: SAMPLE_ITEMS,
+};
+
+export const CustomTopSection = DefaultStoryTemplate<IReviewSchema>("review-default").bind({});
+CustomTopSection.args = {
+	referenceKey: "review",
+	label: "Your personal information",
+	description: "Retrieved on 27 Jun 2023",
+	items: SAMPLE_ITEMS,
+	topSection: {
+		alert: {
+			uiType: "alert",
+			type: "warning",
+			className: "margin--bottom",
+			children: "Sample alert",
+		},
+	},
+};
+
+export const CustomBottomSection = DefaultStoryTemplate<IReviewSchema>("review-default").bind({});
+CustomBottomSection.args = {
+	referenceKey: "review",
+	label: "Your personal information",
+	description: "Retrieved on 27 Jun 2023",
+	items: SAMPLE_ITEMS,
+	bottomSection: {
+		alert: {
+			uiType: "alert",
+			type: "warning",
+			children: "Sample alert",
+		},
+	},
+};


### PR DESCRIPTION
**Changes**
- added review component based on `UneditableSection` from design system
- moved custom component typings to custom folder for better readability / maintainability (the same will be done for elements and fields in the future)

Proposed shape of review schema
```
{
	referenceKey: "review",
	label?: string | undefined;
	description?: string | undefined;
	items: UneditableSectionItemProps[];
	topSection?: Record<string, schema> | undefined;
	bottomSection?: Record<string, schema> | undefined;
}
```