### PR TITLE
add `stripUnknown` flag to schema

### DIFF
--- a/src/__tests__/components/fields/date-range-field/date-range-field.spec.tsx
+++ b/src/__tests__/components/fields/date-range-field/date-range-field.spec.tsx
@@ -8,13 +8,13 @@ import { TDistributiveOmit } from "../../../../utils/ts-helper";
 import {
 	ERROR_MESSAGE,
 	FRONTEND_ENGINE_ID,
+	TOverrideSchema,
 	getErrorMessage,
 	getField,
 	getResetButton,
 	getResetButtonProps,
 	getSubmitButton,
 	getSubmitButtonProps,
-	TOverrideSchema,
 } from "../../../common";
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
@@ -278,9 +278,7 @@ describe(uiType, () => {
 			expect(getDayInput(TDateRangeInputType.END)).toHaveAttribute("value", "");
 			expect(getMonthInput(TDateRangeInputType.END)).toHaveAttribute("value", "");
 			expect(getYearInput(TDateRangeInputType.END)).toHaveAttribute("value", "");
-			expect(SUBMIT_FN).toBeCalledWith(
-				expect.objectContaining({ [COMPONENT_ID]: { from: undefined, to: undefined } })
-			);
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it("should revert to default value on reset", async () => {

--- a/src/__tests__/components/fields/image-upload/image-upload.spec.tsx
+++ b/src/__tests__/components/fields/image-upload/image-upload.spec.tsx
@@ -865,6 +865,7 @@ describe("image-upload", () => {
 			await act(async () => {
 				await flushPromise(100);
 				fireEvent.click(getResetButton());
+				await flushPromise();
 				await waitFor(() => fireEvent.click(getSubmitButton()));
 			});
 

--- a/src/__tests__/components/fields/range-select/range-select.spec.tsx
+++ b/src/__tests__/components/fields/range-select/range-select.spec.tsx
@@ -277,9 +277,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getResetButton()));
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
-			expect(SUBMIT_FN).toBeCalledWith(
-				expect.objectContaining({ [COMPONENT_ID]: { from: undefined, to: undefined } })
-			);
+			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it("should revert to default value on reset", async () => {

--- a/src/__tests__/components/fields/time-field/time-field.spec.tsx
+++ b/src/__tests__/components/fields/time-field/time-field.spec.tsx
@@ -176,10 +176,10 @@ describe(UI_TYPE, () => {
 			jest.spyOn(LocalTime, "now").mockReturnValue(LocalTime.parse(currentTime));
 			renderComponent({ useCurrentTime: true });
 			await pickValidTime();
-			await waitFor(() => fireEvent.click(getResetButton()));
-			await waitFor(() => fireEvent.click(getSubmitButton()));
-
+			fireEvent.click(getResetButton());
 			await waitFor(() => expect(getTimePicker()).toHaveValue(`${currentTime}pm`));
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
 			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: `${currentTime}PM` }));
 		});
 	});

--- a/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
+++ b/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
@@ -175,7 +175,7 @@ describe("frontend-engine", () => {
 			renderComponent({ onChange }, { ...JSON_SCHEMA, defaultValues: { nonExistentField: "hello world" } });
 			fireEvent.change(getFieldOne(), { target: { value: "hello" } });
 
-			const finalOnChangeCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+			const finalOnChangeCall = onChange.mock.lastCall[0];
 			expect(finalOnChangeCall).toEqual({
 				[FIELD_ONE_ID]: "hello",
 				nonExistentField: "hello world",
@@ -190,7 +190,7 @@ describe("frontend-engine", () => {
 			);
 			fireEvent.change(getFieldOne(), { target: { value: "hello" } });
 
-			const finalOnChangeCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+			const finalOnChangeCall = onChange.mock.lastCall[0];
 			expect(finalOnChangeCall).toEqual({
 				[FIELD_ONE_ID]: "hello",
 				submit: undefined,

--- a/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
+++ b/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
@@ -171,18 +171,6 @@ describe("frontend-engine", () => {
 		expect(onChange).toBeCalledWith(expect.objectContaining({ [FIELD_ONE_ID]: "a" }), false);
 	});
 
-	it("should call onSubmit prop on submit", async () => {
-		const onSubmit = jest.fn();
-		renderComponent({
-			onSubmit,
-		});
-
-		fireEvent.change(getFieldOne(), { target: { value: "hello" } });
-		await waitFor(() => fireEvent.click(getSubmitButton()));
-
-		expect(onSubmit).toBeCalled();
-	});
-
 	it("should call onSubmitError prop and not onSubmit prop on submit with validation error(s)", async () => {
 		const onSubmit = jest.fn();
 		const onSubmitError = jest.fn();
@@ -203,17 +191,66 @@ describe("frontend-engine", () => {
 		expect(onSubmit).not.toBeCalled();
 	});
 
-	it("should return form values through getValues method", () => {
-		let formValues: Record<string, any> = {};
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formValues = ref.current.getValues();
-		};
-		render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
+	describe("getValues()", () => {
+		let formValues: Record<string, unknown> = {};
+		it("should return form values", () => {
+			const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
+				formValues = ref.current.getValues();
+			};
+			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
 
-		fireEvent.change(getFieldOne(), { target: { value: "hello" } });
-		fireEvent.click(getCustomButton());
+			fireEvent.change(getFieldOne(), { target: { value: "hello" } });
+			fireEvent.click(getCustomButton());
 
-		expect(formValues?.[FIELD_ONE_ID]).toBe("hello");
+			expect(formValues).toEqual({
+				[FIELD_ONE_ID]: "hello",
+				submit: undefined,
+			});
+		});
+
+		it("should include form values of unregistered fields if stripUnknown is not true", async () => {
+			const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
+				ref.current.setValue("nonExistentField2", "john doe");
+				formValues = ref.current.getValues();
+			};
+			render(
+				<FrontendEngineWithCustomButton
+					data={{ ...JSON_SCHEMA, defaultValues: { nonExistentField: "hello world" } }}
+					onClick={handleClick}
+				/>
+			);
+
+			fireEvent.change(getFieldOne(), { target: { value: "hello" } });
+			await waitFor(() => fireEvent.click(getCustomButton()));
+
+			expect(formValues).toEqual({
+				[FIELD_ONE_ID]: "hello",
+				nonExistentField: "hello world",
+				nonExistentField2: "john doe",
+				submit: undefined,
+			});
+		});
+
+		it("should exclude form values of unregistered fields if stripUnknown is true", async () => {
+			const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
+				ref.current.setValue("nonExistentField2", "john doe");
+				formValues = ref.current.getValues();
+			};
+			render(
+				<FrontendEngineWithCustomButton
+					data={{ ...JSON_SCHEMA, stripUnknown: true, defaultValues: { nonExistentField: "hello world" } }}
+					onClick={handleClick}
+				/>
+			);
+
+			fireEvent.change(getFieldOne(), { target: { value: "hello" } });
+			await waitFor(() => fireEvent.click(getCustomButton()));
+
+			expect(formValues).toEqual({
+				[FIELD_ONE_ID]: "hello",
+				submit: undefined,
+			});
+		});
 	});
 
 	it("should update field value through setValue method", async () => {
@@ -259,15 +296,64 @@ describe("frontend-engine", () => {
 		expect(isDirty).toBe(true);
 	});
 
-	it("should submit through submit method", async () => {
-		const submitFn = jest.fn();
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => ref.current.submit();
-		render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} onSubmit={submitFn} />);
+	describe("submit", () => {
+		it("should submit through submit method", async () => {
+			const submitFn = jest.fn();
+			render(<FrontendEngine data={JSON_SCHEMA} onSubmit={submitFn} />);
 
-		fireEvent.change(getFieldOne(), { target: { value: "hello" } });
-		await waitFor(() => fireEvent.click(getCustomButton()));
+			fireEvent.change(getFieldOne(), { target: { value: "hello" } });
+			await waitFor(() => fireEvent.click(getSubmitButton()));
 
-		expect(submitFn).toBeCalled();
+			expect(submitFn).toBeCalledWith({ [FIELD_ONE_ID]: "hello", submit: undefined });
+		});
+
+		it("should include form values of unregistered fields if stripUnknown is not true", async () => {
+			const submitFn = jest.fn();
+			const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
+				ref.current.setValue("nonExistentField2", "john doe");
+			};
+			render(
+				<FrontendEngineWithCustomButton
+					data={{ ...JSON_SCHEMA, defaultValues: { nonExistentField: "hello world" } }}
+					onClick={handleClick}
+					onSubmit={submitFn}
+				/>
+			);
+
+			fireEvent.change(getFieldOne(), { target: { value: "hello" } });
+			fireEvent.click(getCustomButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(submitFn).toBeCalledWith({
+				[FIELD_ONE_ID]: "hello",
+				nonExistentField: "hello world",
+				nonExistentField2: "john doe",
+				submit: undefined,
+			});
+		});
+
+		it("should exclude form values of unregistered fields if stripUnknown is true", async () => {
+			const submitFn = jest.fn();
+			const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
+				ref.current.setValue("nonExistentField2", "john doe");
+			};
+			render(
+				<FrontendEngineWithCustomButton
+					data={{ ...JSON_SCHEMA, stripUnknown: true, defaultValues: { nonExistentField: "hello world" } }}
+					onClick={handleClick}
+					onSubmit={submitFn}
+				/>
+			);
+
+			fireEvent.change(getFieldOne(), { target: { value: "hello" } });
+			fireEvent.click(getCustomButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(submitFn).toBeCalledWith({
+				[FIELD_ONE_ID]: "hello",
+				submit: undefined,
+			});
+		});
 	});
 
 	it("should reset through reset method", async () => {

--- a/src/components/elements/wrapper/field-wrapper.tsx
+++ b/src/components/elements/wrapper/field-wrapper.tsx
@@ -18,10 +18,11 @@ export const FieldWrapper = ({ Field, id, schema }: IProps) => {
 	const {
 		formSchema: { defaultValues, restoreMode = "none" },
 	} = useFormSchema();
-	const { getField, setField } = useFormValues();
+	const { getField, setField, setRegisteredFields } = useFormValues();
 
 	useEffect(() => {
 		setValue(id, getField(id));
+		setRegisteredFields((prev) => [...prev, id]);
 
 		return () => {
 			switch (restoreMode) {
@@ -38,6 +39,7 @@ export const FieldWrapper = ({ Field, id, schema }: IProps) => {
 					break;
 				}
 			}
+			setRegisteredFields((prev) => prev.filter((fieldId) => fieldId !== id));
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);

--- a/src/components/elements/wrapper/wrapper.tsx
+++ b/src/components/elements/wrapper/wrapper.tsx
@@ -64,7 +64,7 @@ export const Wrapper = (props: IWrapperProps): JSX.Element | null => {
 						renderComponent = buildConditionalRenderer(childId, childSchema)(buildElement);
 					} else {
 						// let custom components fail silently
-						renderComponent = <></>;
+						renderComponent = <Fragment key={childId} />;
 					}
 				} else if ("uiType" in childSchema) {
 					if (fieldTypeKeys.includes(childSchema.uiType.toUpperCase())) {

--- a/src/components/frontend-engine/form-values/context-provider.tsx
+++ b/src/components/frontend-engine/form-values/context-provider.tsx
@@ -6,6 +6,9 @@ interface IFormValuesContext {
 	// allows access to the latest field values without having to wait for a rerender
 	formValuesRef: MutableRefObject<Record<string, unknown>>;
 	setFormValues: Dispatch<SetStateAction<Record<string, unknown>>>;
+	// track ids of registered fields because react-hook-form does not have any ways to do it
+	registeredFields: string[];
+	setRegisteredFields: Dispatch<SetStateAction<string[]>>;
 }
 
 interface IProps {
@@ -16,6 +19,8 @@ export const FormValuesContext = createContext<IFormValuesContext>({
 	formValues: null,
 	formValuesRef: null,
 	setFormValues: null,
+	registeredFields: null,
+	setRegisteredFields: null,
 });
 
 /**
@@ -29,10 +34,13 @@ export const FormValuesContext = createContext<IFormValuesContext>({
  */
 export const FormValuesProvider = ({ children }: IProps) => {
 	const [formValues, setFormValues] = useState<Record<string, unknown>>({});
+	const [registeredFields, setRegisteredFields] = useState<string[]>([]);
 	const formValuesRef = useRef<Record<string, unknown>>(formValues);
 
 	return (
-		<FormValuesContext.Provider value={{ formValues, setFormValues, formValuesRef }}>
+		<FormValuesContext.Provider
+			value={{ formValues, setFormValues, formValuesRef, registeredFields, setRegisteredFields }}
+		>
 			{children}
 		</FormValuesContext.Provider>
 	);

--- a/src/components/frontend-engine/frontend-engine.tsx
+++ b/src/components/frontend-engine/frontend-engine.tsx
@@ -158,10 +158,10 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 		// attach / fire onChange event only formValidationConfig has values
 		// otherwise isValid will be returned incorrectly as true
 		if (onChange && Object.keys(formValidationConfig || {}).length) {
-			const subscription = watch((value) => {
-				onChange(value, checkIsFormValid());
+			const subscription = watch(() => {
+				onChange(getFormValues(stripUnknown), checkIsFormValid());
 			});
-			onChange(getValues(), checkIsFormValid());
+			onChange(getFormValues(stripUnknown), checkIsFormValid());
 
 			return () => subscription.unsubscribe();
 		}

--- a/src/components/frontend-engine/frontend-engine.tsx
+++ b/src/components/frontend-engine/frontend-engine.tsx
@@ -29,6 +29,7 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 			defaultValues,
 			sections,
 			id,
+			stripUnknown,
 			revalidationMode = "onChange",
 			validationMode = "onTouched",
 		},
@@ -52,8 +53,6 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 		},
 	});
 	const { setFormSchema } = useFormSchema();
-	const { resetFields, setFields, setField } = useFormValues();
-
 	const {
 		reset,
 		watch,
@@ -64,6 +63,7 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 		formState,
 		clearErrors,
 	} = formMethods;
+	const { resetFields, setFields, setField, getFormValues } = useFormValues(formMethods);
 
 	const [oldFormValues, setOldFormValues] = useState<TFrontendEngineValues>({});
 
@@ -74,7 +74,7 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 		addFieldEventListener,
 		addCustomValidation: YupHelper.addCondition,
 		dispatchFieldEvent,
-		getValues,
+		getValues: () => getFormValues(stripUnknown),
 		isDirty: formState.isDirty,
 		isValid: checkIsFormValid,
 		removeFieldEventListener,
@@ -101,8 +101,8 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 		}
 	}, [getValues, hardValidationSchema]);
 
-	const handleSubmit = (data: TFrontendEngineValues): void => {
-		onSubmit?.(data);
+	const handleSubmit = (): void => {
+		onSubmit?.(getFormValues(stripUnknown));
 	};
 
 	const handleSubmitError = (errors: TFrontendEngineValues): void => {

--- a/src/components/frontend-engine/types.ts
+++ b/src/components/frontend-engine/types.ts
@@ -82,6 +82,10 @@ export interface IFrontendEngineData<V = undefined> {
 	 * - `"user-input"`: the latest value
 	 */
 	restoreMode?: TRestoreMode | undefined;
+	/**
+	 * Excludes values of fields that are not declared in the schema on submit / via getValues()
+	 */
+	stripUnknown?: boolean | undefined;
 }
 
 // NOTE: add all possible schema types here except section schema

--- a/src/stories/2-frontend-engine/frontend-engine.stories.tsx
+++ b/src/stories/2-frontend-engine/frontend-engine.stories.tsx
@@ -160,6 +160,21 @@ const meta: Meta = {
 				},
 			},
 		},
+		stripUnknown: {
+			description:
+				"Excludes values of fields that are not declared in the schema on submit / via getValues(). Note: Conditionally-hidden fields are never included in the form values.",
+			table: {
+				type: {
+					summary: "boolean",
+				},
+				defaultValue: {
+					summary: "false",
+				},
+			},
+			control: {
+				type: "boolean",
+			},
+		},
 	},
 };
 export default meta;
@@ -611,5 +626,50 @@ const onSubmitErrorData: IFrontendEngineData = {
 };
 
 OnSubmitError.parameters = {
+	controls: { hideNoControlsWarning: true },
+};
+
+export const StripUnknown: StoryFn<IFrontendEngineProps> = () => {
+	const ref = useRef<IFrontendEngineRef>();
+	const json: IFrontendEngineData = {
+		stripUnknown: true,
+		sections: {
+			section: {
+				uiType: "section",
+				children: {
+					explanation: {
+						uiType: "div",
+						className: "margin--bottom",
+						children: `When stripUnknown=true, fields that are not declared in the schema will not be included in
+							the submitted values or in getValues()`,
+					},
+					...DATA.sections.section.children,
+				},
+			},
+		},
+	};
+	const handleAddUnknownValues = () => {
+		ref.current.setValue("unknownField", "hello world");
+		action("add unknownField value to form")({ id: "unknownField", value: "hello world" });
+	};
+	const handleGetFormState = () => {
+		action("getValues")(ref.current.getValues());
+	};
+
+	return (
+		<>
+			<FrontendEngine data={json} ref={ref} />
+			<br />
+			<Button.Default styleType="secondary" onClick={handleAddUnknownValues}>
+				Add unknown field value to form
+			</Button.Default>
+			<br />
+			<Button.Default styleType="secondary" onClick={handleGetFormState}>
+				Get values
+			</Button.Default>
+		</>
+	);
+};
+StripUnknown.parameters = {
 	controls: { hideNoControlsWarning: true },
 };

--- a/src/utils/hooks/use-form-values.ts
+++ b/src/utils/hooks/use-form-values.ts
@@ -1,8 +1,12 @@
 import { useContext } from "react";
+import { UseFormReturn, useFormContext } from "react-hook-form";
+import { TFrontendEngineValues } from "../../components";
 import { FormValuesContext } from "../../components/frontend-engine/form-values";
 
-export const useFormValues = () => {
-	const { setFormValues, formValues, formValuesRef } = useContext(FormValuesContext);
+export const useFormValues = (formMethods?: UseFormReturn | undefined) => {
+	const formContext = useFormContext();
+	const { setFormValues, formValues, formValuesRef, registeredFields, setRegisteredFields } =
+		useContext(FormValuesContext);
 
 	const getField = (id: string) => {
 		return formValuesRef.current[id];
@@ -36,5 +40,31 @@ export const useFormValues = () => {
 		setFormValues(() => ({ ...values }));
 	};
 
-	return { formValues, getField, setFields, setField, resetFields };
+	/**
+	 * Get form values
+	 * @param stripUnknown whether to exclude values of unregistered fields
+	 */
+	const getFormValues = (stripUnknown = false): TFrontendEngineValues => {
+		const values = formMethods?.getValues() || formContext?.getValues();
+		if (!stripUnknown) return values;
+
+		const registeredFormValues = {};
+		Object.entries(values).forEach(([key, value]) => {
+			if (registeredFields.includes(key)) {
+				registeredFormValues[key] = value;
+			}
+		});
+		return registeredFormValues;
+	};
+
+	return {
+		formValues,
+		getField,
+		setFields,
+		setField,
+		resetFields,
+		registeredFields,
+		setRegisteredFields,
+		getFormValues,
+	};
 };


### PR DESCRIPTION
**Changes**
- Added `stripUnknown` flag to schema, this gives the ability to exclude values of fields that are not declared in the schema
- Track registered field ids through form values context and FieldWrapper component
- Added `getFieldValues()` to filter according to `stripUnknown` flag on submit / `getValues()`