### PR TITLE
Prevent shrinking checkboxes and radio buttons

### DIFF
--- a/src/components/fields/checkbox-group/checkbox-group.styles.tsx
+++ b/src/components/fields/checkbox-group/checkbox-group.styles.tsx
@@ -11,6 +11,7 @@ export const Label = styled(Text.BodySmall)<ILabelProps>`
 
 export const StyledCheckbox = styled(Checkbox)`
 	margin-right: 5px;
+	flex-shrink: 0;
 `;
 
 export const CheckboxContainer = styled.div`

--- a/src/components/fields/radio-button/radio-button.styles.tsx
+++ b/src/components/fields/radio-button/radio-button.styles.tsx
@@ -13,6 +13,7 @@ export const Label = styled(Text.BodySmall)<ILabelProps>`
 
 export const StyledRadioButton = styled(RadioButton)`
 	margin-right: 5px;
+	flex-shrink: 0;
 `;
 
 export const StyledImageButton = styled(ImageButton)`


### PR DESCRIPTION
**Changes**
- Prevent shrinking of checkboxes and radio buttons if the label is too long