### PR TITLE
Migrating changes from old mol-frontend-engine over

### DIFF
--- a/src/__tests__/components/fields/location-field/location-field.spec.tsx
+++ b/src/__tests__/components/fields/location-field/location-field.spec.tsx
@@ -524,7 +524,7 @@ describe("location-input-group", () => {
 							onSuccess(mock1PageFetchAddressResponse);
 						});
 						fetchSingleLocationByLatLngSpy.mockImplementation(
-							(_reverseGeoCodeEndpoint, _lat, _lng, handleResult) => {
+							(_reverseGeoCodeEndpoint, _convertLatLngToXYEndpoint, _lat, _lng, handleResult) => {
 								handleResult(fetchSingleLocationByLatLngSingleReponse);
 							}
 						);
@@ -574,7 +574,7 @@ describe("location-input-group", () => {
 				describe("when location is a pin location with only latlng values", () => {
 					beforeEach(async () => {
 						fetchSingleLocationByLatLngSpy.mockImplementation(
-							(_reverseGeoCodeEndpoint, _lat, _lng, handleResult) => {
+							(_reverseGeoCodeEndpoint, _convertLatLngToXYEndpoint, _lat, _lng, handleResult) => {
 								handleResult(fetchSingleLocationByLatLngSingleReponse);
 							}
 						);

--- a/src/components/fields/location-field/location-field.tsx
+++ b/src/components/fields/location-field/location-field.tsx
@@ -26,6 +26,7 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 			mapPanZoom,
 			interactiveMapPinIconUrl,
 			reverseGeoCodeEndpoint,
+			convertLatLngToXYEndpoint,
 			gettingCurrentLocationFetchMessage,
 			mustHavePostalCode,
 			locationModalStyles,
@@ -119,6 +120,7 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 						updateFormValues={updateFormValues}
 						mapPanZoom={mapPanZoom}
 						reverseGeoCodeEndpoint={reverseGeoCodeEndpoint}
+						convertLatLngToXYEndpoint={convertLatLngToXYEndpoint}
 						interactiveMapPinIconUrl={interactiveMapPinIconUrl}
 						gettingCurrentLocationFetchMessage={gettingCurrentLocationFetchMessage}
 						mustHavePostalCode={mustHavePostalCode}

--- a/src/components/fields/location-field/location-helper.ts
+++ b/src/components/fields/location-field/location-helper.ts
@@ -212,17 +212,27 @@ export namespace LocationHelper {
 		lat: number,
 		lng: number,
 		onSuccess: (resultListItem: IResultListItem | undefined) => void,
-		onError: (e: any) => void
+		onError: (e: any) => void,
+		mustHavePostalCode?: boolean
 	) => {
 		(async () => {
 			try {
-				const locationList = await reverseGeocode({
-					route: reverseGeoCodeEndpoint,
-					latitude: lat,
-					longitude: lng,
-				});
+				const locationList = (
+					await reverseGeocode({
+						route: reverseGeoCodeEndpoint,
+						latitude: lat,
+						longitude: lng,
+					})
+				).results;
 
-				onSuccess(locationList.results[0] || undefined);
+				const nearestLocationIndex = LocationHelper.getNearestLocationIndexFromList(
+					locationList,
+					lat,
+					lng,
+					mustHavePostalCode
+				);
+
+				onSuccess(locationList[nearestLocationIndex] || undefined);
 			} catch (error) {
 				const oneMapError = new OneMapError(error);
 				onError(oneMapError);

--- a/src/components/fields/location-field/location-helper.ts
+++ b/src/components/fields/location-field/location-helper.ts
@@ -209,6 +209,7 @@ export namespace LocationHelper {
 
 	export const fetchSingleLocationByLatLng = async (
 		reverseGeoCodeEndpoint: string,
+		convertLatLngToXYEndpoint: string,
 		lat: number,
 		lng: number,
 		onSuccess: (resultListItem: IResultListItem | undefined) => void,
@@ -232,7 +233,9 @@ export namespace LocationHelper {
 					mustHavePostalCode
 				);
 
-				onSuccess(locationList[nearestLocationIndex] || undefined);
+				const { X, Y } = await OneMapService.convertLatLngToXY(convertLatLngToXYEndpoint, lat, lng);
+
+				onSuccess({ ...locationList[nearestLocationIndex], x: X, y: Y } || undefined);
 			} catch (error) {
 				const oneMapError = new OneMapError(error);
 				onError(oneMapError);

--- a/src/components/fields/location-field/location-modal/location-modal.tsx
+++ b/src/components/fields/location-field/location-modal/location-modal.tsx
@@ -35,6 +35,7 @@ const LocationModal = ({
 	mapPanZoom,
 	interactiveMapPinIconUrl,
 	reverseGeoCodeEndpoint,
+	convertLatLngToXYEndpoint,
 	gettingCurrentLocationFetchMessage,
 	mustHavePostalCode,
 	locationModalStyles,
@@ -389,6 +390,7 @@ const LocationModal = ({
 								setSinglePanelMode={setSinglePanelMode}
 								showLocationModal={showLocationModal}
 								reverseGeoCodeEndpoint={reverseGeoCodeEndpoint}
+								convertLatLngToXYEndpoint={convertLatLngToXYEndpoint}
 								gettingCurrentLocationFetchMessage={gettingCurrentLocationFetchMessage}
 								mustHavePostalCode={mustHavePostalCode}
 							/>

--- a/src/components/fields/location-field/location-modal/location-search/location-search.tsx
+++ b/src/components/fields/location-field/location-modal/location-search/location-search.tsx
@@ -223,7 +223,8 @@ export const LocationSearch = ({
 				reverseGeoCodeLat,
 				reverseGeoCodeLng,
 				handleResult,
-				handleApiErrors
+				handleApiErrors,
+				mustHavePostalCode
 			);
 		}
 	}, []);
@@ -477,19 +478,24 @@ export const LocationSearch = ({
 		resultRef.current?.scrollTo(0, 0);
 		populateDisplayList({ results: resultListItem });
 
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		const [{ displayAddressText, ...firstItem }] = resultListItem;
+		const nearestLocationIndex = LocationHelper.getNearestLocationIndexFromList(
+			resultListItem,
+			addressLat,
+			addressLng,
+			mustHavePostalCode
+		);
+		const nearestLocation = resultListItem[nearestLocationIndex];
 
-		if (mustHavePostalCode && !LocationHelper.hasGotAddressValue(firstItem.address)) {
+		if (!nearestLocation || (mustHavePostalCode && !LocationHelper.hasGotAddressValue(nearestLocation.address))) {
 			setShowPostalCodeError(true);
 			setQueryString("");
 			return;
 		}
 
-		setQueryString(firstItem.address);
+		setQueryString(nearestLocation.address);
 
-		onChangeSelectedAddressInfo(firstItem);
-		setSelectedIndex(0);
+		onChangeSelectedAddressInfo(nearestLocation);
+		setSelectedIndex(nearestLocationIndex);
 	};
 
 	/**

--- a/src/components/fields/location-field/location-modal/location-search/location-search.tsx
+++ b/src/components/fields/location-field/location-modal/location-search/location-search.tsx
@@ -34,6 +34,7 @@ import {
 	SearchWrapper,
 } from "./location-search.styles";
 import { ILocationSearchProps } from "./types";
+import { OneMapService } from "../../../../../services";
 
 export const LocationSearch = ({
 	id = "location-search",
@@ -49,6 +50,7 @@ export const LocationSearch = ({
 	mapPickedLatLng,
 
 	reverseGeoCodeEndpoint,
+	convertLatLngToXYEndpoint,
 	addressFieldPlaceholder = "Street Name, Postal Code",
 	gettingCurrentLocationFetchMessage = "Getting current location...",
 	locationListTitle = "Select location",
@@ -220,6 +222,7 @@ export const LocationSearch = ({
 
 			fetchSingleLocationByLatLng(
 				reverseGeoCodeEndpoint,
+				convertLatLngToXYEndpoint,
 				reverseGeoCodeLat,
 				reverseGeoCodeLng,
 				handleResult,
@@ -494,7 +497,13 @@ export const LocationSearch = ({
 
 		setQueryString(nearestLocation.address);
 
-		onChangeSelectedAddressInfo(nearestLocation);
+		const { X, Y } = await OneMapService.convertLatLngToXY(convertLatLngToXYEndpoint, addressLat, addressLng);
+		onChangeSelectedAddressInfo({
+			...nearestLocation,
+			x: X,
+			y: Y,
+		});
+
 		setSelectedIndex(nearestLocationIndex);
 	};
 

--- a/src/components/fields/location-field/location-modal/location-search/types.ts
+++ b/src/components/fields/location-field/location-modal/location-search/types.ts
@@ -15,6 +15,7 @@ export interface ILocationSearchProps {
 	handleApiErrors: (error: any) => void;
 	mustHavePostalCode?: boolean | undefined;
 	reverseGeoCodeEndpoint?: string | undefined;
+	convertLatLngToXYEndpoint?: string | undefined;
 	onGetLocationCallback: (lat?: number | undefined, lng?: number | undefined) => void;
 	showLocationModal: boolean;
 	mapPickedLatLng?: ILocationCoord | undefined;

--- a/src/components/fields/location-field/location-modal/types.ts
+++ b/src/components/fields/location-field/location-modal/types.ts
@@ -6,7 +6,10 @@ export interface ILocationModalProps
 	extends Pick<ILocationPickerProps, "mapPanZoom" | "interactiveMapPinIconUrl">,
 		Pick<
 			ILocationSearchProps,
-			"reverseGeoCodeEndpoint" | "mustHavePostalCode" | "gettingCurrentLocationFetchMessage"
+			| "reverseGeoCodeEndpoint"
+			| "convertLatLngToXYEndpoint"
+			| "mustHavePostalCode"
+			| "gettingCurrentLocationFetchMessage"
 		> {
 	id: string;
 	className: string;

--- a/src/components/fields/location-field/types.ts
+++ b/src/components/fields/location-field/types.ts
@@ -9,7 +9,10 @@ export interface ILocationFieldSchema<V = undefined>
 		Pick<ILocationPickerProps, "interactiveMapPinIconUrl" | "mapPanZoom">,
 		Pick<
 			ILocationSearchProps,
-			"reverseGeoCodeEndpoint" | "mustHavePostalCode" | "gettingCurrentLocationFetchMessage"
+			| "reverseGeoCodeEndpoint"
+			| "convertLatLngToXYEndpoint"
+			| "mustHavePostalCode"
+			| "gettingCurrentLocationFetchMessage"
 		>,
 		Pick<ILocationInputProps, "locationInputPlaceholder">,
 		Pick<IStaticMapProps, "staticMapPinColor"> {

--- a/src/services/onemap/onemap-service.ts
+++ b/src/services/onemap/onemap-service.ts
@@ -49,6 +49,21 @@ const searchByAddress = async (param: OneMapSearchParam): Promise<OneMapSearchRe
 	return res;
 };
 
+const convertLatLngToXY = async (
+	route: string,
+	latitude: number,
+	longitude: number
+): Promise<{
+	X: number;
+	Y: number;
+}> => {
+	const res: any = await clientWithCredentials.get(route, {
+		params: { latitude, longitude },
+		headers: {},
+	});
+	return res?.data;
+};
+
 const getStaticMapUrl = (lat: number, lng: number, width: number, height: number, pinColor: IColor): string => {
 	const { r, g, b } = pinColor;
 	return `https://www.onemap.gov.sg/api/staticmap/getStaticImage?layerchosen=default&latitude=${lat}&longitude=${lng}&zoom=17&height=${height}&width=${width}&points=[${lat},${lng},"${r},${g},${b}"]`;
@@ -57,5 +72,6 @@ const getStaticMapUrl = (lat: number, lng: number, width: number, height: number
 export const OneMapService = {
 	reverseGeocode,
 	searchByAddress,
+	convertLatLngToXY,
 	getStaticMapUrl,
 };

--- a/src/services/onemap/onemap-service.ts
+++ b/src/services/onemap/onemap-service.ts
@@ -59,7 +59,6 @@ const convertLatLngToXY = async (
 }> => {
 	const res: any = await clientWithCredentials.get(route, {
 		params: { latitude, longitude },
-		headers: {},
 	});
 	return res?.data;
 };

--- a/src/stories/3-fields/location-field/location-field.stories.tsx
+++ b/src/stories/3-fields/location-field/location-field.stories.tsx
@@ -3,6 +3,8 @@ import { Meta } from "@storybook/react";
 import { ILocationFieldSchema, ILocationFieldValues } from "../../../components/fields/location-field/types";
 import { CommonFieldStoryProps, DefaultStoryTemplate, OVERRIDES_ARG_TYPE, OverrideStoryTemplate } from "../../common";
 
+const reverseGeoCodeEndpoint = "https://www.dev.lifesg.io/oneservice/api/v1/one-map/reverse-geo-code";
+const convertLatLngToXYEndpoint = "https://www.dev.lifesg.io/oneservice/api/v1/one-map/convert-latlng-to-xy";
 const meta: Meta = {
 	title: "Field/LocationField",
 	parameters: {
@@ -32,6 +34,8 @@ export const Default = DefaultStoryTemplate<ILocationFieldSchema>("location-fiel
 Default.args = {
 	uiType: "location-field",
 	label: "Default",
+	reverseGeoCodeEndpoint,
+	convertLatLngToXYEndpoint,
 };
 
 export const InitialAddress = DefaultStoryTemplate<ILocationFieldSchema, ILocationFieldValues>(
@@ -43,6 +47,8 @@ InitialAddress.args = {
 	defaultValues: {
 		address: "Fusionopolis View",
 	},
+	reverseGeoCodeEndpoint,
+	convertLatLngToXYEndpoint,
 };
 InitialAddress.parameters = {
 	docs: {
@@ -59,10 +65,12 @@ InitialLatLng.args = {
 	uiType: "location-field",
 	label: "Default",
 	defaultValues: {
-		lat: 1.2418352709904754,
-		lng: 103.61478567123413,
+		lat: 1.39309802477142,
+		lng: 104.044933681267,
 	},
-	reverseGeoCodeEndpoint: "https://www.dev.lifesg.io/oneservice/api/v1/one-map/reverse-geo-code",
+	mustHavePostalCode: true,
+	reverseGeoCodeEndpoint,
+	convertLatLngToXYEndpoint,
 };
 InitialLatLng.parameters = {
 	docs: {
@@ -89,7 +97,8 @@ FullInitialAddress.args = {
 		x: 23112.7395757,
 		y: 31366.5202628,
 	},
-	reverseGeoCodeEndpoint: "https://www.dev.lifesg.io/oneservice/api/v1/one-map/reverse-geo-code",
+	reverseGeoCodeEndpoint,
+	convertLatLngToXYEndpoint,
 };
 FullInitialAddress.parameters = {
 	docs: {
@@ -104,6 +113,8 @@ MustHavePostalCode.args = {
 	uiType: "location-field",
 	label: "MustHavePostalCode",
 	mustHavePostalCode: true,
+	reverseGeoCodeEndpoint,
+	convertLatLngToXYEndpoint,
 };
 
 export const WithCustomStyles = DefaultStoryTemplate<ILocationFieldSchema>("location-field-custom-styles").bind({});
@@ -111,6 +122,8 @@ WithCustomStyles.args = {
 	uiType: "location-field",
 	label: "WithCustomStyles",
 	locationModalStyles: "padding-top: 50px; margin-right: 10px;",
+	reverseGeoCodeEndpoint,
+	convertLatLngToXYEndpoint,
 };
 
 export const Overrides = OverrideStoryTemplate<ILocationFieldSchema>("location-field-overrides").bind({});
@@ -120,5 +133,7 @@ Overrides.args = {
 	overrides: {
 		label: "Overridden",
 	},
+	reverseGeoCodeEndpoint,
+	convertLatLngToXYEndpoint,
 };
 Overrides.argTypes = OVERRIDES_ARG_TYPE;

--- a/src/stories/3-fields/location-field/location-field.stories.tsx
+++ b/src/stories/3-fields/location-field/location-field.stories.tsx
@@ -65,10 +65,9 @@ InitialLatLng.args = {
 	uiType: "location-field",
 	label: "Default",
 	defaultValues: {
-		lat: 1.39309802477142,
-		lng: 104.044933681267,
+		lat: 1.2418352709904754,
+		lng: 103.61478567123413,
 	},
-	mustHavePostalCode: true,
 	reverseGeoCodeEndpoint,
 	convertLatLngToXYEndpoint,
 };


### PR DESCRIPTION
**Changes**
Migrating changes from old mol-frontend-engine over
- choose nearest location in reverse geocode results to pin drop's lat lng instead of first result
- convert X Y from lat lng instead of using X Y from reverse geocode result

-  keep branch

**Additional information**

-  You may refer to this [ticket](https://jira.ship.gov.sg/browse/MOL-13468)
-  **!!! Please merge the other [PR](https://github.com/LifeSG/web-frontend-engine/pull/157) first** 
