### PR TITLE
update to trigger firing of onChange event

### DIFF
--- a/src/components/custom/review/review.tsx
+++ b/src/components/custom/review/review.tsx
@@ -1,7 +1,10 @@
 import { UneditableSection } from "@lifesg/react-design-system/uneditable-section";
+import * as Yup from "yup";
 import { Wrapper } from "../../elements/wrapper";
 import { IGenericCustomFieldProps } from "../types";
 import { IReviewSchema } from "./types";
+import { useValidationConfig } from "../../../utils/hooks";
+import { useEffect } from "react";
 
 export const Review = (props: IGenericCustomFieldProps<IReviewSchema>) => {
 	// =============================================================================
@@ -11,6 +14,16 @@ export const Review = (props: IGenericCustomFieldProps<IReviewSchema>) => {
 		id,
 		schema: { label, description, items, topSection, bottomSection, ...otherSchema },
 	} = props;
+	const { setFieldValidationConfig } = useValidationConfig();
+
+	// =============================================================================
+	// EFFECTS
+	// =============================================================================
+	useEffect(() => {
+		// set validation config so frontend engine's first onChange event can be fired
+		setFieldValidationConfig(id, Yup.mixed());
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	// =============================================================================
 	// HELPER FUNCTIONS


### PR DESCRIPTION
**Changes**
- updated `review` component to trigger `onChange` event on mount
- this allows forms with only review component to continue to use `onChange` event to get form state updates
- e.g. get form isValid state to enable/disable external submit button