### PR TITLE
[SECTION][WL] update layoutType

### DIFF
--- a/src/components/elements/section/section.styles.ts
+++ b/src/components/elements/section/section.styles.ts
@@ -1,0 +1,10 @@
+import { Layout } from "@lifesg/react-design-system/layout";
+import styled from "styled-components";
+
+export const GridWrapper = styled(Layout.Container)`
+	gap: 2rem;
+`;
+
+export const Contained = styled.div`
+	flex: 1;
+`;

--- a/src/components/elements/section/section.tsx
+++ b/src/components/elements/section/section.tsx
@@ -1,7 +1,7 @@
 import { Layout } from "@lifesg/react-design-system/layout";
 import { Wrapper } from "../wrapper";
+import { Contained, GridWrapper } from "./section.styles";
 import { ISectionProps } from "./types";
-import styled from "styled-components";
 
 export const Section = (props: ISectionProps) => {
 	// =============================================================================
@@ -15,21 +15,30 @@ export const Section = (props: ISectionProps) => {
 	// =============================================================================
 	// RENDER FUNCTIONS
 	// =============================================================================
-	if (layoutType === "grid") {
-		return (
-			<GridContainer type="grid">
+	const renderInGrid = () => (
+		<Layout.Section>
+			<GridWrapper type="grid">
 				<Wrapper {...otherProps}>{children}</Wrapper>
-			</GridContainer>
-		);
-	}
+			</GridWrapper>
+		</Layout.Section>
+	);
 
-	return <Wrapper {...otherProps}>{children}</Wrapper>;
+	const renderContained = () => (
+		<Layout.Content>
+			<Contained>
+				<Wrapper {...otherProps}>{children}</Wrapper>
+			</Contained>
+		</Layout.Content>
+	);
+
+	const renderDefault = () => <Wrapper {...otherProps}>{children}</Wrapper>;
+
+	switch (layoutType) {
+		case "grid":
+			return renderInGrid();
+		case "contain":
+			return renderContained();
+		default:
+			return renderDefault();
+	}
 };
-
-const GridContainer = styled(Layout.Container)`
-	padding: 0;
-	gap: 2rem;
-	&:not(:last-child) {
-		margin-bottom: 2rem;
-	}
-`;

--- a/src/components/elements/section/types.ts
+++ b/src/components/elements/section/types.ts
@@ -6,7 +6,7 @@ export interface ISectionSchema<V = undefined>
 	extends IBaseElementSchema<"section">,
 		TComponentOmitProps<IWrapperSchema> {
 	children: Record<string, TFrontendEngineFieldSchema<V>>;
-	layoutType?: "grid" | undefined;
+	layoutType?: "default" | "grid" | "contain" | undefined;
 }
 
 export interface ISectionProps {

--- a/src/stories/4-elements/section/section.stories.tsx
+++ b/src/stories/4-elements/section/section.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta = {
 		},
 	},
 	argTypes: {
-		...CommonFieldStoryProps("alert", true),
+		...CommonFieldStoryProps("section", true),
 		children: {
 			description: "Elements that are the descendant of this component",
 			table: {

--- a/src/stories/4-elements/section/section.stories.tsx
+++ b/src/stories/4-elements/section/section.stories.tsx
@@ -1,0 +1,118 @@
+import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
+import { Meta, StoryFn } from "@storybook/react";
+import { ISectionSchema } from "../../../components/elements/section";
+import { CommonFieldStoryProps, FrontendEngine } from "../../common";
+
+const meta: Meta = {
+	title: "Element/Section",
+	parameters: {
+		docs: {
+			page: () => (
+				<>
+					<Title>Section</Title>
+					<Description>
+						Wrapping component that must be rendered as a direct descendant of `sections` uiType.
+					</Description>
+					<Heading>Props</Heading>
+					<ArgsTable story={PRIMARY_STORY} />
+					<Stories includePrimary={true} title="Example" />
+				</>
+			),
+		},
+	},
+	argTypes: {
+		...CommonFieldStoryProps("alert", true),
+		children: {
+			description: "Elements that are the descendant of this component",
+			table: {
+				type: { summary: "TFrontendEngineFieldSchema" },
+			},
+			type: { name: "object", value: {}, required: true },
+		},
+		layoutType: {
+			description:
+				"<div>Determines how the presentation of the children is structured and displayed.<ul><li><strong>default:</strong> Does not modify the layout.</li><li><strong>grid</strong>: Render children in <a href='https://designsystem.life.gov.sg/react/index.html?path=/story/getting-started-layout--grid-layout' target='_blank' rel='noopener noreferrer'>grid layout</a>.</li><li><strong>contain</strong>: Render children within <a href='https://designsystem.life.gov.sg/react/index.html?path=/docs/getting-started-layout--general-usage' target='_blank' rel='noopener noreferrer' >Layout.Content</a> within 1320px in block display.</li></ul></div>",
+			table: {
+				type: {
+					summary: "default | grid | contain",
+				},
+				defaultValue: { summary: "default" },
+			},
+			options: ["default", "grid", "contain"],
+			control: {
+				type: "select",
+			},
+		},
+	},
+};
+export default meta;
+
+const Template = (id: string) =>
+	((args) => (
+		<FrontendEngine
+			data={{
+				sections: {
+					[id]: args,
+				},
+			}}
+		/>
+	)) as StoryFn<ISectionSchema>;
+
+export const Default = Template("section-default").bind({});
+Default.args = {
+	uiType: "section",
+	children: {
+		text: {
+			uiType: "text-field",
+			label: "Text",
+		},
+		text2: {
+			uiType: "text-field",
+			label: "Text 2",
+		},
+	},
+};
+
+export const Grid = Template("section-grid").bind({});
+Grid.args = {
+	uiType: "section",
+	layoutType: "grid",
+	children: {
+		text1: {
+			uiType: "text-field",
+			label: "Text",
+			columns: { desktop: 6 },
+		},
+		text2: {
+			uiType: "text-field",
+			label: "Text 2",
+			columns: { desktop: 6 },
+		},
+		text3: {
+			uiType: "text-field",
+			label: "Text 3",
+			columns: { desktop: 6 },
+		},
+		text4: {
+			uiType: "text-field",
+			label: "Text 4",
+			columns: { desktop: 6 },
+		},
+	},
+};
+
+export const Contained = Template("section-contain").bind({});
+Contained.args = {
+	uiType: "section",
+	layoutType: "contain",
+	children: {
+		text1: {
+			uiType: "text-field",
+			label: "Contained within 1320px",
+		},
+		text2: {
+			uiType: "text-field",
+			label: "Contained within 1320px",
+		},
+	},
+};


### PR DESCRIPTION
**Changes**
- updated `section` uiType
- use `Layout.Content` for `grid layoutType with 0.75rem horizontal padding
- new contain layoutType to offer `Layout.Content` with block display
- added default layoutType
- added dedicated section stories
- delete branch

**Changelog entry**
- section
  - grid layoutType now comes with 0.75rem horizontal padding
  - new contain layoutType that comes with 1320px max-width for general layout purposes
  - new default layoutType to represent the standard layoutType 
