### PR TITLE
[MOL-14379][CWH] Fix convertLatLngToXYEndpoint undefined call error

### DIFF
--- a/src/components/fields/location-field/location-modal/location-search/location-search.tsx
+++ b/src/components/fields/location-field/location-modal/location-search/location-search.tsx
@@ -497,14 +497,17 @@ export const LocationSearch = ({
 
 		setQueryString(nearestLocation.address);
 
-		const { X, Y } = await OneMapService.convertLatLngToXY(convertLatLngToXYEndpoint, addressLat, addressLng);
-		onChangeSelectedAddressInfo({
+		const locationFieldValue = {
 			...nearestLocation,
 			lat: addressLat,
 			lng: addressLng,
-			x: X,
-			y: Y,
-		});
+		};
+		if (convertLatLngToXYEndpoint) {
+			const { X, Y } = await OneMapService.convertLatLngToXY(convertLatLngToXYEndpoint, addressLat, addressLng);
+			locationFieldValue.x = X;
+			locationFieldValue.y = Y;
+		}
+		onChangeSelectedAddressInfo(locationFieldValue);
 
 		setSelectedIndex(nearestLocationIndex);
 	};


### PR DESCRIPTION
- add in checking on `convertLatLngToXYEndpoint`
- ensure it is not undefined before calling `convertLatLngToXY`
- avoid error been trigger and cause the `onChangeSelectedAddressInfo` not be trigger