### PR TITLE
ensure listAllChildIds is recursing through the children

### DIFF
--- a/src/__tests__/components/elements/wrapper/conditional-renderer.spec.tsx
+++ b/src/__tests__/components/elements/wrapper/conditional-renderer.spec.tsx
@@ -299,13 +299,18 @@ describe("conditional-renderer", () => {
 				uiType: "div",
 				showIf: [{ [FIELD_ONE_ID]: [{ filled: true }, { min: 5 }] }],
 				children: {
-					[FIELD_TWO_ID]: {
-						label: FIELD_TWO_LABEL,
-						uiType,
-						validation: [
-							{ required: true, errorMessage: ERROR_MESSAGE },
-							{ min: 5, errorMessage: ERROR_MESSAGE },
-						],
+					nested: {
+						uiType: "div",
+						children: {
+							[FIELD_TWO_ID]: {
+								label: FIELD_TWO_LABEL,
+								uiType,
+								validation: [
+									{ required: true, errorMessage: ERROR_MESSAGE },
+									{ min: 5, errorMessage: ERROR_MESSAGE },
+								],
+							},
+						},
 					},
 				},
 			},
@@ -319,7 +324,9 @@ describe("conditional-renderer", () => {
 		expect(screen.getByText(ERROR_MESSAGE)).toBeInTheDocument();
 		expect(SUBMIT_FN).not.toBeCalled();
 
+		fireEvent.change(getFieldTwo(), { target: { value: "" } });
 		fireEvent.change(getFieldOne(), { target: { value: "hi" } });
+
 		await waitFor(() => fireEvent.click(getSubmitButton()));
 		expect(SUBMIT_FN).toBeCalled();
 	});

--- a/src/components/elements/wrapper/conditional-renderer.tsx
+++ b/src/components/elements/wrapper/conditional-renderer.tsx
@@ -98,10 +98,10 @@ export const ConditionalRenderer = ({ id, renderRules, children, schema }: IProp
 		if (isEmpty(children) || !isObject(children)) {
 			return childIdList;
 		}
-		Object.keys(children).forEach((id) => {
+		Object.entries(children).forEach(([id, child]) => {
 			childIdList.push(id);
-			if (children["children"]) {
-				childIdList.push(...listAllChildIds(children["children"]));
+			if (child["children"]) {
+				childIdList.push(...listAllChildIds(child["children"]));
 			}
 		});
 


### PR DESCRIPTION
**Changes**
- similar fix in validation-schema-generator: https://github.com/LifeSG/validation-schema-generator/pull/33
- ensure recursive logic is correct
- validation is actually already removed correctly because `field-wrapper` will remove the validation on unmount, but still fixing function to ensure the logic is correctly