### PR TITLE
Histogram slider

### DIFF
--- a/src/__tests__/components/fields/histogram-slider/histogram-slider.spec.tsx
+++ b/src/__tests__/components/fields/histogram-slider/histogram-slider.spec.tsx
@@ -1,0 +1,247 @@
+import { Form } from "@lifesg/react-design-system/form";
+import { FormHistogramSliderProps } from "@lifesg/react-design-system/form/types";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import cloneDeep from "lodash/cloneDeep";
+import merge from "lodash/merge";
+import { FrontendEngine } from "../../../../components";
+import { IHistogramSliderSchema } from "../../../../components/fields";
+import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
+import { ERROR_MESSAGES } from "../../../../components/shared";
+import {
+	ERROR_MESSAGE,
+	FRONTEND_ENGINE_ID,
+	FrontendEngineWithCustomButton,
+	TOverrideField,
+	TOverrideSchema,
+	getResetButton,
+	getResetButtonProps,
+	getSubmitButton,
+	getSubmitButtonProps,
+} from "../../../common";
+
+const SUBMIT_FN = jest.fn();
+const COMPONENT_ID = "field";
+const UI_TYPE = "histogram-slider";
+
+const JSON_SCHEMA: IFrontendEngineData = {
+	id: FRONTEND_ENGINE_ID,
+	sections: {
+		section: {
+			uiType: "section",
+			children: {
+				[COMPONENT_ID]: {
+					label: "Histogram slider",
+					uiType: UI_TYPE,
+					bins: [
+						{ minValue: 10, count: 1 },
+						{ minValue: 20, count: 0 },
+						{ minValue: 30, count: 3 },
+						{ minValue: 90, count: 3 },
+					],
+					interval: 10,
+				},
+				...getSubmitButtonProps(),
+				...getResetButtonProps(),
+			},
+		},
+	},
+};
+
+const renderComponent = (overrideField?: TOverrideField<IHistogramSliderSchema>, overrideSchema?: TOverrideSchema) => {
+	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
+	merge(json, {
+		sections: {
+			section: {
+				children: {
+					[COMPONENT_ID]: overrideField,
+				},
+			},
+		},
+	});
+	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
+};
+
+const changeSliderValue = (
+	sliderSpy: jest.SpyInstance<JSX.Element, [FormHistogramSliderProps]>,
+	value: [number, number]
+) => {
+	act(() => sliderSpy.mock.lastCall[0].onChangeEnd(value));
+};
+
+describe(UI_TYPE, () => {
+	let sliderSpy: jest.SpyInstance<JSX.Element, [FormHistogramSliderProps]>;
+
+	beforeEach(() => {
+		jest.restoreAllMocks();
+
+		delete window.ResizeObserver;
+		window.ResizeObserver = jest.fn().mockImplementation(() => ({
+			observe: jest.fn(),
+			unobserve: jest.fn(),
+			disconnect: jest.fn(),
+		}));
+
+		sliderSpy = jest.spyOn(Form, "HistogramSlider");
+	});
+
+	it("should be able to render the field", () => {
+		renderComponent();
+
+		expect(screen.queryAllByRole("slider")).toHaveLength(2);
+	});
+
+	it("should initialise selection to all bins if no value is provided", async () => {
+		renderComponent();
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: { from: 10, to: 100 } }));
+	});
+
+	it("should be able to support default values", async () => {
+		const defaultValue = { from: 10, to: 50 };
+		renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: defaultValue } });
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+	});
+
+	it("should be able to render sub label and hint", () => {
+		renderComponent({
+			label: {
+				mainLabel: "Main label",
+				subLabel: "Sub label",
+				hint: { content: "Hint" },
+			},
+		});
+		fireEvent.click(screen.getByLabelText("popover-button"));
+
+		expect(screen.getByText("Main label")).toBeInTheDocument();
+		expect(screen.getByText("Sub label")).toBeInTheDocument();
+		expect(screen.getByText("Hint")).toBeVisible();
+	});
+
+	it.each`
+		validation            | invalid
+		${"from is required"} | ${{ from: undefined, to: 20 }}
+		${"to is required"}   | ${{ from: 20, to: undefined }}
+	`("should validate that $validation", async ({ invalid }) => {
+		renderComponent(
+			{ validation: [{ required: true, errorMessage: ERROR_MESSAGE }] },
+			{ defaultValues: { [COMPONENT_ID]: invalid } }
+		);
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+
+		expect(screen.queryByText(ERROR_MESSAGE)).toBeInTheDocument();
+	});
+
+	it.each`
+		validation                | invalid
+		${"from is a bin value"}  | ${{ from: 1, to: 50 }}
+		${"to is a bin value"}    | ${{ from: 10, to: 45 }}
+		${"from is less than to"} | ${{ from: 50, to: 10 }}
+		${"from is within range"} | ${{ from: 0, to: 50 }}
+		${"to is within range"}   | ${{ from: 10, to: 110 }}
+	`("should validate that $validation", async ({ invalid }) => {
+		renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: invalid } });
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+
+		expect(screen.queryByText(ERROR_MESSAGES.SLIDER.MUST_BE_INCREMENTAL)).toBeInTheDocument();
+	});
+
+	it("should be disabled if configured", async () => {
+		renderComponent({ disabled: true });
+
+		const sliders = screen.queryAllByRole("slider");
+		for (const slider of sliders) {
+			expect(slider).toHaveAttribute("aria-disabled", "true");
+		}
+	});
+
+	describe("reset", () => {
+		it("should clear selection on reset", async () => {
+			renderComponent();
+
+			changeSliderValue(sliderSpy, [20, 60]);
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: { from: 10, to: 100 } }));
+		});
+
+		it("should revert to default value on reset", async () => {
+			const defaultValue = { from: 10, to: 50 };
+			renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: defaultValue } });
+
+			changeSliderValue(sliderSpy, [20, 60]);
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		});
+	});
+
+	describe("dirty state", () => {
+		let formIsDirty: boolean;
+		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
+			formIsDirty = ref.current.isDirty;
+		};
+
+		beforeEach(() => {
+			formIsDirty = undefined;
+		});
+
+		it("should mount without setting field state as dirty", () => {
+			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(false);
+		});
+
+		it("should set form state as dirty if user modifies the field", async () => {
+			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
+			changeSliderValue(sliderSpy, [20, 60]);
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(true);
+		});
+
+		it("should support default value without setting form state as dirty", () => {
+			render(
+				<FrontendEngineWithCustomButton
+					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: { from: 10, to: 50 } } }}
+					onClick={handleClick}
+				/>
+			);
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(false);
+		});
+
+		it("should reset and revert form dirty state to false", async () => {
+			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
+			changeSliderValue(sliderSpy, [20, 60]);
+			fireEvent.click(getResetButton());
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(false);
+		});
+
+		it("should reset to default value without setting form state as dirty", async () => {
+			render(
+				<FrontendEngineWithCustomButton
+					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: { from: 10, to: 50 } } }}
+					onClick={handleClick}
+				/>
+			);
+			changeSliderValue(sliderSpy, [20, 60]);
+			fireEvent.click(getResetButton());
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(false);
+		});
+	});
+});

--- a/src/components/fields/histogram-slider/histogram-slider.tsx
+++ b/src/components/fields/histogram-slider/histogram-slider.tsx
@@ -1,6 +1,7 @@
 import { Form } from "@lifesg/react-design-system/form";
 import isNil from "lodash/isNil";
 import { useEffect, useState } from "react";
+import { useFormContext } from "react-hook-form";
 import * as Yup from "yup";
 import { IGenericFieldProps } from "..";
 import { TestHelper } from "../../../utils";
@@ -21,6 +22,7 @@ export const HistogramSlider = (props: IGenericFieldProps<IHistogramSliderSchema
 		value,
 		...otherProps
 	} = props;
+	const { setValue } = useFormContext();
 	const [stateValue, setStateValue] = useState<[number, number]>(undefined);
 	const { setFieldValidationConfig } = useValidationConfig();
 
@@ -28,11 +30,17 @@ export const HistogramSlider = (props: IGenericFieldProps<IHistogramSliderSchema
 	// EFFECTS
 	// =============================================================================
 	useEffect(() => {
-		if (isNil(value?.from) || isNil(value?.to)) {
-			setStateValue(undefined);
+		// prepopulate with full range selected if range is not selected
+		if (!value) {
+			const min = Math.min(...bins.map((bin) => bin.minValue));
+			const max = Math.max(...bins.map((bin) => bin.minValue)) + interval;
+
+			setValue(id, { from: min, to: max }, { shouldDirty: false });
+			setStateValue([min, max]);
 		} else {
 			setStateValue([value.from, value.to]);
 		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [value]);
 
 	useEffect(() => {

--- a/src/components/fields/histogram-slider/histogram-slider.tsx
+++ b/src/components/fields/histogram-slider/histogram-slider.tsx
@@ -1,0 +1,101 @@
+import { Form } from "@lifesg/react-design-system/form";
+import isNil from "lodash/isNil";
+import { useEffect, useState } from "react";
+import * as Yup from "yup";
+import { IGenericFieldProps } from "..";
+import { TestHelper } from "../../../utils";
+import { useValidationConfig } from "../../../utils/hooks";
+import { ERROR_MESSAGES } from "../../shared";
+import { IHistogramSliderSchema } from "./types";
+
+export const HistogramSlider = (props: IGenericFieldProps<IHistogramSliderSchema>) => {
+	// =============================================================================
+	// CONST, STATE, REFS
+	// =============================================================================
+	const {
+		error,
+		formattedLabel,
+		id,
+		onChange,
+		schema: { label: _label, bins, interval, validation, customOptions, ...otherSchema },
+		value,
+		...otherProps
+	} = props;
+	const [stateValue, setStateValue] = useState<[number, number]>(undefined);
+	const { setFieldValidationConfig } = useValidationConfig();
+
+	// =============================================================================
+	// EFFECTS
+	// =============================================================================
+	useEffect(() => {
+		if (isNil(value?.from) || isNil(value?.to)) {
+			setStateValue(undefined);
+		} else {
+			setStateValue([value.from, value.to]);
+		}
+	}, [value]);
+
+	useEffect(() => {
+		const isRequiredRule = validation?.find((rule) => "required" in rule);
+
+		setFieldValidationConfig(
+			id,
+			Yup.object({
+				from: Yup.number(),
+				to: Yup.number(),
+			})
+				.test(
+					"is-required",
+					isRequiredRule?.["errorMessage"] || ERROR_MESSAGES.COMMON.REQUIRED_OPTIONS,
+					(value) => {
+						if (!value || !isRequiredRule) return true;
+						return !isNil(value.from) && !isNil(value.to);
+					}
+				)
+				.test("is-bin", ERROR_MESSAGES.SLIDER.MUST_BE_INCREMENTAL, (value) => {
+					if (!value || typeof value.from !== "number" || typeof value.to !== "number") return true;
+
+					const { from, to } = value;
+
+					const min = Math.min(...bins.map((bin) => bin.minValue));
+					const max = Math.max(...bins.map((bin) => bin.minValue)) + interval;
+
+					if (from >= to || from < min || to > max) {
+						return false;
+					}
+
+					return Number.isInteger((from - min) / interval) && Number.isInteger((to - min) / interval);
+				}),
+			validation
+		);
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [validation, bins, interval]);
+
+	// =============================================================================
+	// EVENT HANDLERS
+	// =============================================================================
+	const handleChangeEnd = (value: [number, number]): void => {
+		const [from, to] = value;
+		onChange({ target: { value: { from, to } } });
+	};
+
+	// =============================================================================
+	// RENDER FUNCTIONS
+	// =============================================================================
+	return (
+		<Form.HistogramSlider
+			{...otherSchema}
+			{...otherProps}
+			{...customOptions}
+			id={id}
+			data-testid={TestHelper.generateId(id, "histogram-slider")}
+			label={formattedLabel}
+			errorMessage={error?.message}
+			onChangeEnd={handleChangeEnd}
+			value={stateValue}
+			bins={bins}
+			interval={interval}
+		/>
+	);
+};

--- a/src/components/fields/histogram-slider/histogram-slider.tsx
+++ b/src/components/fields/histogram-slider/histogram-slider.tsx
@@ -18,9 +18,8 @@ export const HistogramSlider = (props: IGenericFieldProps<IHistogramSliderSchema
 		formattedLabel,
 		id,
 		onChange,
-		schema: { label: _label, bins, interval, validation, customOptions, ...otherSchema },
+		schema: { label: _label, bins, interval, validation, disabled, readOnly, className, customOptions },
 		value,
-		...otherProps
 	} = props;
 	const { setValue } = useFormContext();
 	const [stateValue, setStateValue] = useState<[number, number]>(undefined);
@@ -93,8 +92,6 @@ export const HistogramSlider = (props: IGenericFieldProps<IHistogramSliderSchema
 	// =============================================================================
 	return (
 		<Form.HistogramSlider
-			{...otherSchema}
-			{...otherProps}
 			{...customOptions}
 			id={id}
 			data-testid={TestHelper.generateId(id, "histogram-slider")}
@@ -104,6 +101,9 @@ export const HistogramSlider = (props: IGenericFieldProps<IHistogramSliderSchema
 			value={stateValue}
 			bins={bins}
 			interval={interval}
+			disabled={disabled}
+			readOnly={readOnly}
+			className={className}
 		/>
 	);
 };

--- a/src/components/fields/histogram-slider/index.ts
+++ b/src/components/fields/histogram-slider/index.ts
@@ -1,0 +1,2 @@
+export * from "./histogram-slider";
+export * from "./types";

--- a/src/components/fields/histogram-slider/types.ts
+++ b/src/components/fields/histogram-slider/types.ts
@@ -1,0 +1,13 @@
+import { HistogramSliderProps } from "@lifesg/react-design-system/histogram-slider";
+import { TComponentOmitProps } from "../../frontend-engine";
+import { IBaseFieldSchema } from "../types";
+
+type TCustomOptions = Pick<HistogramSliderProps, "showRangeLabels" | "rangeLabelPrefix" | "rangeLabelSuffix">;
+
+export interface IHistogramSliderSchema<V = undefined>
+	extends IBaseFieldSchema<"histogram-slider", V>,
+		TComponentOmitProps<
+			Pick<HistogramSliderProps, "className" | "data-testid" | "disabled" | "readOnly" | "bins" | "interval">
+		> {
+	customOptions?: TCustomOptions | undefined;
+}

--- a/src/components/fields/histogram-slider/types.ts
+++ b/src/components/fields/histogram-slider/types.ts
@@ -4,6 +4,11 @@ import { IBaseFieldSchema } from "../types";
 
 type TCustomOptions = Pick<HistogramSliderProps, "showRangeLabels" | "rangeLabelPrefix" | "rangeLabelSuffix">;
 
+export interface IHistogramSliderValue {
+	from: number | undefined;
+	to: number | undefined;
+}
+
 export interface IHistogramSliderSchema<V = undefined>
 	extends IBaseFieldSchema<"histogram-slider", V>,
 		TComponentOmitProps<

--- a/src/components/fields/histogram-slider/types.ts
+++ b/src/components/fields/histogram-slider/types.ts
@@ -11,8 +11,6 @@ export interface IHistogramSliderValue {
 
 export interface IHistogramSliderSchema<V = undefined>
 	extends IBaseFieldSchema<"histogram-slider", V>,
-		TComponentOmitProps<
-			Pick<HistogramSliderProps, "className" | "data-testid" | "disabled" | "readOnly" | "bins" | "interval">
-		> {
+		TComponentOmitProps<Pick<HistogramSliderProps, "className" | "disabled" | "readOnly" | "bins" | "interval">> {
 	customOptions?: TCustomOptions | undefined;
 }

--- a/src/components/fields/index.ts
+++ b/src/components/fields/index.ts
@@ -4,6 +4,7 @@ export * from "./chips";
 export * from "./contact-field";
 export * from "./date-field";
 export * from "./date-range-field";
+export * from "./histogram-slider";
 export * from "./image-upload";
 export * from "./location-field";
 export * from "./multi-select";

--- a/src/components/fields/types.ts
+++ b/src/components/fields/types.ts
@@ -8,6 +8,7 @@ import { IChipsSchema } from "./chips";
 import { IContactFieldSchema } from "./contact-field";
 import { IDateFieldSchema } from "./date-field";
 import { TDateRangeFieldSchema } from "./date-range-field";
+import { IHistogramSliderSchema } from "./histogram-slider";
 import { IImageUploadSchema } from "./image-upload";
 import { ILocationFieldSchema } from "./location-field";
 import { IMultiSelectSchema } from "./multi-select";
@@ -37,6 +38,7 @@ export enum EFieldType {
 	"DATE-FIELD" = "DateField",
 	"DATE-RANGE-FIELD" = "DateRangeField",
 	"EMAIL-FIELD" = "TextField",
+	"HISTOGRAM-SLIDER" = "HistogramSlider",
 	"IMAGE-UPLOAD" = "ImageUpload",
 	"LOCATION-FIELD" = "LocationField",
 	"MULTI-SELECT" = "MultiSelect",
@@ -66,6 +68,7 @@ export type TFieldSchema<V = undefined> =
 	| IDateFieldSchema<V>
 	| TDateRangeFieldSchema<V>
 	| IEmailFieldSchema<V>
+	| IHistogramSliderSchema<V>
 	| IImageUploadSchema<V>
 	| ILocationFieldSchema<V>
 	| IMultiSelectSchema<V>

--- a/src/components/shared/error-messages.tsx
+++ b/src/components/shared/error-messages.tsx
@@ -41,6 +41,9 @@ export const ERROR_MESSAGES = {
 		INVALID: "Invalid input",
 		UNSUPPORTED: "This component is not supported by the engine",
 	},
+	SLIDER: {
+		MUST_BE_INCREMENTAL: "Input must be incremental",
+	},
 	UPLOAD: (unit = "file", unitPlural = `${unit}s`) => ({
 		REQUIRED: `Upload at least 1 ${unit}`,
 		MAX_FILES: (max: number) =>

--- a/src/stories/3-fields/histogram-slider/histogram-slider.stories.tsx
+++ b/src/stories/3-fields/histogram-slider/histogram-slider.stories.tsx
@@ -1,0 +1,211 @@
+import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
+import { Meta } from "@storybook/react";
+import { IHistogramSliderSchema, IHistogramSliderValue } from "../../../components/fields";
+import {
+	CommonFieldStoryProps,
+	DefaultStoryTemplate,
+	OVERRIDES_ARG_TYPE,
+	OverrideStoryTemplate,
+	ResetStoryTemplate,
+} from "../../common";
+
+const meta: Meta = {
+	title: "Field/HistogramSlider",
+	parameters: {
+		docs: {
+			page: () => (
+				<>
+					<Title>HistogramSlider</Title>
+					<Description>
+						This component allows users to select a lower limit and upper limit from a bin of numeric data
+						values.
+					</Description>
+					<Heading>Props</Heading>
+					<ArgsTable story={PRIMARY_STORY} />
+					<Stories includePrimary={true} title="Examples" />
+				</>
+			),
+		},
+	},
+	argTypes: {
+		...CommonFieldStoryProps("histogram-slider"),
+		disabled: {
+			description: "Specifies if the input should be disabled",
+			table: {
+				type: {
+					summary: "boolean",
+				},
+				defaultValue: { summary: false },
+			},
+			options: [true, false],
+			control: {
+				type: "boolean",
+			},
+		},
+		bins: {
+			description: "A list of histogram bins grouped by their lower limit",
+		},
+		interval: {
+			description: "The upper limit of each bin",
+		},
+		customOptions: {
+			description:
+				"<ul><li>`showRangeLabels` specifies if max and min labels are displayed.</li><br/><li>Use `rangeLabelPrefix` and `rangeLabelSuffix` to customise the labels</li></ul>",
+			table: {
+				type: {
+					summary: `{ showRangeLabels?: boolean; rangeLabelPrefix?: string; rangeLabelSuffix?: string; }`,
+				},
+			},
+			type: { name: "object", value: {} },
+		},
+	},
+};
+export default meta;
+
+export const Default = DefaultStoryTemplate<IHistogramSliderSchema>("histogram-slider-default").bind({});
+Default.args = {
+	uiType: "histogram-slider",
+	label: "Price of fruits",
+	bins: [
+		{ minValue: 0, count: 0 },
+		{ minValue: 10, count: 2 },
+		{ minValue: 20, count: 3 },
+		{ minValue: 90, count: 8 },
+	],
+	interval: 10,
+};
+
+export const DefaultValue = DefaultStoryTemplate<IHistogramSliderSchema, IHistogramSliderValue>(
+	"histogram-slider-default-value"
+).bind({});
+DefaultValue.args = {
+	uiType: "histogram-slider",
+	label: "Price of fruits",
+	bins: [
+		{ minValue: 0, count: 0 },
+		{ minValue: 10, count: 2 },
+		{ minValue: 20, count: 3 },
+		{ minValue: 90, count: 8 },
+	],
+	interval: 10,
+	defaultValues: { from: 0, to: 30 },
+};
+DefaultValue.argTypes = {
+	defaultValues: {
+		description: "Default value for the field, this is declared outside `sections`",
+		table: {
+			type: {
+				summary: "number",
+			},
+		},
+	},
+};
+
+export const Disabled = DefaultStoryTemplate<IHistogramSliderSchema>("histogram-slider-disabled").bind({});
+Disabled.args = {
+	uiType: "histogram-slider",
+	label: "Price of fruits",
+	bins: [
+		{ minValue: 0, count: 0 },
+		{ minValue: 10, count: 2 },
+		{ minValue: 20, count: 3 },
+		{ minValue: 90, count: 8 },
+	],
+	interval: 10,
+	disabled: true,
+};
+
+export const Labels = DefaultStoryTemplate<IHistogramSliderSchema>("histogram-slider-with-labels").bind({});
+Labels.args = {
+	uiType: "histogram-slider",
+	label: "Price of fruits",
+	bins: [
+		{ minValue: 0, count: 0 },
+		{ minValue: 10, count: 2 },
+		{ minValue: 20, count: 3 },
+		{ minValue: 90, count: 8 },
+	],
+	interval: 10,
+	customOptions: {
+		showRangeLabels: true,
+		rangeLabelPrefix: "$",
+		rangeLabelSuffix: ".00",
+	},
+};
+
+export const WithValidation = DefaultStoryTemplate<IHistogramSliderSchema>("histogram-slider-with-validation").bind({});
+WithValidation.args = {
+	uiType: "histogram-slider",
+	label: "Price of fruits",
+	bins: [
+		{ minValue: 0, count: 0 },
+		{ minValue: 10, count: 2 },
+		{ minValue: 20, count: 3 },
+		{ minValue: 90, count: 8 },
+	],
+	interval: 10,
+	validation: [{ required: true }],
+};
+
+export const Reset = ResetStoryTemplate<IHistogramSliderSchema>("histogram-slider-reset").bind({});
+Reset.args = {
+	uiType: "histogram-slider",
+	label: "Price of fruits",
+	bins: [
+		{ minValue: 0, count: 0 },
+		{ minValue: 10, count: 2 },
+		{ minValue: 20, count: 3 },
+		{ minValue: 90, count: 8 },
+	],
+	interval: 10,
+};
+
+export const ResetWithDefaultValues = ResetStoryTemplate<IHistogramSliderSchema, IHistogramSliderValue>(
+	"histogram-slider-reset-default-values"
+).bind({});
+ResetWithDefaultValues.args = {
+	uiType: "histogram-slider",
+	label: "Price of fruits",
+	bins: [
+		{ minValue: 0, count: 0 },
+		{ minValue: 10, count: 2 },
+		{ minValue: 20, count: 3 },
+		{ minValue: 90, count: 8 },
+	],
+	interval: 10,
+	defaultValues: { from: 0, to: 30 },
+};
+ResetWithDefaultValues.argTypes = {
+	defaultValues: {
+		description: "Default value for the field, this is declared outside `sections`",
+		table: {
+			type: {
+				summary: "string",
+			},
+		},
+	},
+};
+
+export const Overrides = OverrideStoryTemplate<IHistogramSliderSchema>("histogram-slider-overrides").bind({});
+Overrides.args = {
+	uiType: "histogram-slider",
+	label: "Price of fruits",
+	bins: [
+		{ minValue: 0, count: 0 },
+		{ minValue: 10, count: 2 },
+		{ minValue: 20, count: 3 },
+		{ minValue: 90, count: 8 },
+	],
+	interval: 10,
+	overrides: {
+		label: "Overridden",
+		bins: [
+			{ minValue: 0, count: 0 },
+			{ minValue: 10, count: 2 },
+			{ minValue: 20, count: 3 },
+			{ minValue: 90, count: 8 },
+		],
+		interval: 5,
+	},
+};
+Overrides.argTypes = OVERRIDES_ARG_TYPE;


### PR DESCRIPTION
**Changes**
- Port HistogramSlider, bumped DS to `2.3.0-canary.4` accordingly
- Value in the shape of `{ from: number; to: number; }`
- Support implicit validation through the `bins` and `interval` prop
-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   New histogram slider field