### PR TITLE
Add html support to filter checkbox option label

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The intention of frontend engine is to take out the heavy lifting of form develo
 
 Developers are expected to have the following packages installed:
 
--   @lifesg/react-design-system 2.3.0-canary.6
+-   @lifesg/react-design-system 2.3.0-canary.7
 -   @lifesg/react-icons 1.2.0
 -   react 17.0.2 or 18
 -   react-dom 17.0.2 or 18

--- a/jest/mocks/match-media.ts
+++ b/jest/mocks/match-media.ts
@@ -1,0 +1,13 @@
+window.matchMedia = jest.fn().mockImplementation(() => {
+	return {
+		matches: false,
+		addListener: function () {
+			// stub
+		},
+		removeListener: function () {
+			// stub
+		},
+	};
+});
+
+export {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 				"@babel/preset-env": "^7.19.3",
 				"@babel/preset-react": "^7.18.6",
 				"@babel/preset-typescript": "^7.18.6",
-				"@lifesg/react-design-system": "^2.3.0-canary.6",
+				"@lifesg/react-design-system": "^2.3.0-canary.7",
 				"@lifesg/react-icons": "^1.2.0",
 				"@rollup/plugin-commonjs": "^22.0.2",
 				"@rollup/plugin-image": "^2.1.1",
@@ -94,7 +94,7 @@
 				"typescript": "^4.8.4"
 			},
 			"peerDependencies": {
-				"@lifesg/react-design-system": "^2.3.0-canary.6",
+				"@lifesg/react-design-system": "^2.3.0-canary.7",
 				"@lifesg/react-icons": "^1.2.0",
 				"react": "^17.0.2 || ^18.0.0",
 				"react-dom": "^17.0.2 || ^18.0.0",
@@ -2725,31 +2725,46 @@
 			"dev": true
 		},
 		"node_modules/@floating-ui/core": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
-			"integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+			"integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
 			"dev": true,
 			"dependencies": {
-				"@floating-ui/utils": "^0.1.3"
+				"@floating-ui/utils": "^0.2.1"
 			}
 		},
 		"node_modules/@floating-ui/dom": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
-			"integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.1.tgz",
+			"integrity": "sha512-iA8qE43/H5iGozC3W0YSnVSW42Vh522yyM1gj+BqRwVsTNOyr231PsXDaV04yT39PsO0QL2QpbI/M0ZaLUQgRQ==",
 			"dev": true,
 			"dependencies": {
-				"@floating-ui/core": "^1.4.2",
-				"@floating-ui/utils": "^0.1.3"
+				"@floating-ui/core": "^1.6.0",
+				"@floating-ui/utils": "^0.2.1"
+			}
+		},
+		"node_modules/@floating-ui/react": {
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.9.tgz",
+			"integrity": "sha512-p86wynZJVEkEq2BBjY/8p2g3biQ6TlgT4o/3KgFKyTWoJLU1GZ8wpctwRqtkEl2tseYA+kw7dBAIDFcednfI5w==",
+			"dev": true,
+			"dependencies": {
+				"@floating-ui/react-dom": "^2.0.8",
+				"@floating-ui/utils": "^0.2.1",
+				"tabbable": "^6.0.1"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
 			}
 		},
 		"node_modules/@floating-ui/react-dom": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
-			"integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+			"integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
 			"dev": true,
 			"dependencies": {
-				"@floating-ui/dom": "^1.5.1"
+				"@floating-ui/dom": "^1.6.1"
 			},
 			"peerDependencies": {
 				"react": ">=16.8.0",
@@ -2757,9 +2772,9 @@
 			}
 		},
 		"node_modules/@floating-ui/utils": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
-			"integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==",
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+			"integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==",
 			"dev": true
 		},
 		"node_modules/@hookform/resolvers": {
@@ -3666,11 +3681,13 @@
 			"dev": true
 		},
 		"node_modules/@lifesg/react-design-system": {
-			"version": "2.3.0-canary.6",
-			"resolved": "https://registry.npmjs.org/@lifesg/react-design-system/-/react-design-system-2.3.0-canary.6.tgz",
-			"integrity": "sha512-YIhECIg4Dr+P3ua0ia5OxOfP/Ean3W26YsZJ66rHvqg3pFFmoKMK3aLLY3a/pjFnp6HXcOIG16//Aj0b8X43aQ==",
+			"version": "2.3.0-canary.7",
+			"resolved": "https://registry.npmjs.org/@lifesg/react-design-system/-/react-design-system-2.3.0-canary.7.tgz",
+			"integrity": "sha512-5hXNC+j+imsXGpqr1KK8H5sqZUwroOEPr4gzabB7MCWugdiesvSn6uijBB8lEQEAu+NMwZmaxi5mF4IA0pge2g==",
 			"dev": true,
 			"dependencies": {
+				"@floating-ui/dom": "^1.5.4",
+				"@floating-ui/react": "^0.26.6",
 				"immer": "^10.0.2",
 				"react-slider": "^2.0.6",
 				"react-zoom-pan-pinch": "^3.3.0"
@@ -21564,6 +21581,12 @@
 			"integrity": "sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==",
 			"dev": true
 		},
+		"node_modules/tabbable": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+			"integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+			"dev": true
+		},
 		"node_modules/tapable": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -25041,37 +25064,48 @@
 			"dev": true
 		},
 		"@floating-ui/core": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
-			"integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+			"integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
 			"dev": true,
 			"requires": {
-				"@floating-ui/utils": "^0.1.3"
+				"@floating-ui/utils": "^0.2.1"
 			}
 		},
 		"@floating-ui/dom": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
-			"integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.1.tgz",
+			"integrity": "sha512-iA8qE43/H5iGozC3W0YSnVSW42Vh522yyM1gj+BqRwVsTNOyr231PsXDaV04yT39PsO0QL2QpbI/M0ZaLUQgRQ==",
 			"dev": true,
 			"requires": {
-				"@floating-ui/core": "^1.4.2",
-				"@floating-ui/utils": "^0.1.3"
+				"@floating-ui/core": "^1.6.0",
+				"@floating-ui/utils": "^0.2.1"
+			}
+		},
+		"@floating-ui/react": {
+			"version": "0.26.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.9.tgz",
+			"integrity": "sha512-p86wynZJVEkEq2BBjY/8p2g3biQ6TlgT4o/3KgFKyTWoJLU1GZ8wpctwRqtkEl2tseYA+kw7dBAIDFcednfI5w==",
+			"dev": true,
+			"requires": {
+				"@floating-ui/react-dom": "^2.0.8",
+				"@floating-ui/utils": "^0.2.1",
+				"tabbable": "^6.0.1"
 			}
 		},
 		"@floating-ui/react-dom": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
-			"integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+			"integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
 			"dev": true,
 			"requires": {
-				"@floating-ui/dom": "^1.5.1"
+				"@floating-ui/dom": "^1.6.1"
 			}
 		},
 		"@floating-ui/utils": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
-			"integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==",
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+			"integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==",
 			"dev": true
 		},
 		"@hookform/resolvers": {
@@ -25760,11 +25794,13 @@
 			"dev": true
 		},
 		"@lifesg/react-design-system": {
-			"version": "2.3.0-canary.6",
-			"resolved": "https://registry.npmjs.org/@lifesg/react-design-system/-/react-design-system-2.3.0-canary.6.tgz",
-			"integrity": "sha512-YIhECIg4Dr+P3ua0ia5OxOfP/Ean3W26YsZJ66rHvqg3pFFmoKMK3aLLY3a/pjFnp6HXcOIG16//Aj0b8X43aQ==",
+			"version": "2.3.0-canary.7",
+			"resolved": "https://registry.npmjs.org/@lifesg/react-design-system/-/react-design-system-2.3.0-canary.7.tgz",
+			"integrity": "sha512-5hXNC+j+imsXGpqr1KK8H5sqZUwroOEPr4gzabB7MCWugdiesvSn6uijBB8lEQEAu+NMwZmaxi5mF4IA0pge2g==",
 			"dev": true,
 			"requires": {
+				"@floating-ui/dom": "^1.5.4",
+				"@floating-ui/react": "^0.26.6",
 				"immer": "^10.0.2",
 				"react-slider": "^2.0.6",
 				"react-zoom-pan-pinch": "^3.3.0"
@@ -38793,6 +38829,12 @@
 			"version": "2.0.17",
 			"resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.17.tgz",
 			"integrity": "sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==",
+			"dev": true
+		},
+		"tabbable": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+			"integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
 			"dev": true
 		},
 		"tapable": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"yup": "^0.32.11"
 	},
 	"peerDependencies": {
-		"@lifesg/react-design-system": "^2.3.0-canary.6",
+		"@lifesg/react-design-system": "^2.3.0-canary.7",
 		"@lifesg/react-icons": "^1.2.0",
 		"react": "^17.0.2 || ^18.0.0",
 		"react-dom": "^17.0.2 || ^18.0.0",
@@ -66,7 +66,7 @@
 		"@babel/preset-env": "^7.19.3",
 		"@babel/preset-react": "^7.18.6",
 		"@babel/preset-typescript": "^7.18.6",
-		"@lifesg/react-design-system": "^2.3.0-canary.6",
+		"@lifesg/react-design-system": "^2.3.0-canary.7",
 		"@lifesg/react-icons": "^1.2.0",
 		"@rollup/plugin-commonjs": "^22.0.2",
 		"@rollup/plugin-image": "^2.1.1",

--- a/src/__tests__/common/tests/labels.ts
+++ b/src/__tests__/common/tests/labels.ts
@@ -10,7 +10,7 @@ export const labelTestSuite = (renderComponent: (overrideField: unknown) => void
 					hint: { content: "Hint" },
 				},
 			});
-			fireEvent.click(screen.getByLabelText("popover-button"));
+			fireEvent.click(screen.getByTestId("field-popover"));
 
 			expect(screen.getByText("Main label")).toBeInTheDocument();
 			expect(screen.getByText("Sub label")).toBeInTheDocument();
@@ -25,7 +25,7 @@ export const labelTestSuite = (renderComponent: (overrideField: unknown) => void
 					hint: { content: "<strong>Hint</strong>" },
 				},
 			});
-			fireEvent.click(screen.getByLabelText("popover-button"));
+			fireEvent.click(screen.getByTestId("field-popover"));
 
 			expect(screen.getByText("Main label").nodeName).toBe("STRONG");
 			expect(screen.getByText("Sub label").nodeName).toBe("STRONG");
@@ -40,7 +40,7 @@ export const labelTestSuite = (renderComponent: (overrideField: unknown) => void
 					hint: { content: "Hint<script>console.log('hello world')</script>" },
 				},
 			});
-			fireEvent.click(screen.getByLabelText("popover-button"));
+			fireEvent.click(screen.getByTestId("field-popover"));
 
 			expect(document.querySelector("form").innerHTML.includes("script")).toBe(false);
 		});

--- a/src/__tests__/components/custom/filter/filter-checkbox.spec.tsx
+++ b/src/__tests__/components/custom/filter/filter-checkbox.spec.tsx
@@ -58,10 +58,7 @@ const getCheckboxes = (): HTMLElement[] => {
 };
 
 const getCheckboxByVal = (val: string) => {
-	return screen
-		.getAllByText(val)
-		.find((el) => el.getAttribute("data-testid") !== "toggle-label")
-		?.querySelector("input");
+	return screen.getByText(val).closest("label").querySelector("input");
 };
 
 describe(REFERENCE_KEY, () => {

--- a/src/__tests__/components/custom/filter/filter.spec.tsx
+++ b/src/__tests__/components/custom/filter/filter.spec.tsx
@@ -1,14 +1,16 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { mocked } from "jest-mock";
+import "../../../../../jest/mocks/match-media";
 import { ITextFieldSchema } from "../../../../components/fields";
 import { FrontendEngine, IFrontendEngineData } from "../../../../components/frontend-engine";
-import { FRONTEND_ENGINE_ID, TOverrideField, TOverrideSchema, getSubmitButtonProps, getField } from "../../../common";
+import { FRONTEND_ENGINE_ID, TOverrideField, TOverrideSchema, getField, getSubmitButtonProps } from "../../../common";
 const { ResizeObserver } = window;
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const REFERENCE_KEY = "filter-item";
 const TEXTFIELD_LABEL = "Name";
-const clearCallback = jest.fn();
+
 const renderComponent = (overrideField?: TOverrideField<ITextFieldSchema>, overrideSchema?: TOverrideSchema) => {
 	const json: IFrontendEngineData = {
 		id: FRONTEND_ENGINE_ID,
@@ -59,40 +61,64 @@ describe(REFERENCE_KEY, () => {
 		jest.restoreAllMocks();
 	});
 
-	it("should be able to render child filter items and child fields", () => {
-		renderComponent();
-		expect(screen.getByRole("heading", { name: "Filters" })).toBeInTheDocument();
+	describe("desktop", () => {
+		beforeEach(() => {
+			mocked(window.matchMedia).mockImplementation(() => {
+				return {
+					matches: false,
+					addListener: jest.fn(),
+					removeListener: jest.fn(),
+				} as Partial<MediaQueryList> as MediaQueryList;
+			});
+		});
+
+		it("should be able to render child filter items and child fields", () => {
+			renderComponent();
+			expect(screen.getByRole("heading", { name: "Filters" })).toBeInTheDocument();
+		});
+
+		it("should clear form when when clicked on clear button", async () => {
+			renderComponent();
+			expect(screen.getByTestId("filterItem1__filter-item")).toBeInTheDocument();
+			const [clearBtn] = screen.queryAllByText("Clear");
+			const textfield = getField("textbox", TEXTFIELD_LABEL);
+			await waitFor(() => fireEvent.change(textfield, { target: { value: "something value" } }));
+			expect(screen.getAllByDisplayValue("something value")[0]).toBeInTheDocument();
+			await waitFor(() => fireEvent.click(clearBtn));
+			expect(screen.queryAllByDisplayValue("something value")).toHaveLength(0);
+		});
 	});
 
-	it("should render modal with Done button when clicked on filters button", async () => {
-		renderComponent();
-		expect(screen.getAllByTestId("filterItem1__filter-item")).toHaveLength(2);
-		const [filterBtn] = screen.queryAllByText("Filters");
-		expect(filterBtn).toBeInTheDocument();
-		await waitFor(() => fireEvent.click(filterBtn));
-		expect(screen.getByText("Done")).toBeVisible();
-	});
+	describe("mobile", () => {
+		beforeEach(() => {
+			mocked(window.matchMedia).mockImplementation(() => {
+				return {
+					matches: true,
+					addListener: jest.fn(),
+					removeListener: jest.fn(),
+				} as Partial<MediaQueryList> as MediaQueryList;
+			});
+		});
 
-	it("should clear form when when clicked on clear button", async () => {
-		renderComponent();
-		expect(screen.getAllByTestId("filterItem1__filter-item")).toHaveLength(2);
-		const [clearBtn] = screen.queryAllByText("Clear");
-		const textfield = getField("textbox", TEXTFIELD_LABEL);
-		await waitFor(() => fireEvent.change(textfield, { target: { value: "something value" } }));
-		expect(screen.getAllByDisplayValue("something value")[0]).toBeInTheDocument();
-		await waitFor(() => fireEvent.click(clearBtn));
-		expect(screen.queryAllByDisplayValue("something value")).toHaveLength(0);
-	});
+		it("should render modal with Done button when clicked on filters button", async () => {
+			renderComponent();
+			expect(screen.getByTestId("filterItem1__filter-item")).toBeInTheDocument();
+			const filterBtn = screen.queryByRole("button", { name: "Filters" });
+			expect(filterBtn).toBeInTheDocument();
+			await waitFor(() => fireEvent.click(filterBtn));
+			expect(screen.getByText("Done")).toBeVisible();
+		});
 
-	it("should be able to close the rendered modal with close button.", async () => {
-		renderComponent();
-		expect(screen.getAllByTestId("filterItem1__filter-item")).toHaveLength(2);
-		const [filterBtn] = screen.queryAllByText("Filters");
-		expect(filterBtn).toBeInTheDocument();
-		await waitFor(() => fireEvent.click(filterBtn));
-		expect(screen.getByText("Done")).toBeVisible();
-		const closeBtn = screen.getByLabelText("Dismiss");
-		await waitFor(() => fireEvent.click(closeBtn));
-		expect(screen.getByText("Done")).not.toBeVisible();
+		it("should be able to close the rendered modal with close button.", async () => {
+			renderComponent();
+			expect(screen.getByTestId("filterItem1__filter-item")).toBeInTheDocument();
+			const filterBtn = screen.queryByRole("button", { name: "Filters" });
+			expect(filterBtn).toBeInTheDocument();
+			await waitFor(() => fireEvent.click(filterBtn));
+			expect(screen.getByText("Done")).toBeVisible();
+			const closeBtn = screen.getByLabelText("Dismiss");
+			await waitFor(() => fireEvent.click(closeBtn));
+			expect(screen.getByText("Done")).not.toBeVisible();
+		});
 	});
 });

--- a/src/__tests__/components/fields/chips/chips.spec.tsx
+++ b/src/__tests__/components/fields/chips/chips.spec.tsx
@@ -136,21 +136,6 @@ describe(UI_TYPE, () => {
 		);
 	});
 
-	it("should be able to render sub label and hint", () => {
-		renderComponent({
-			label: {
-				mainLabel: "Main label",
-				subLabel: "Sub label",
-				hint: { content: "Hint" },
-			},
-		});
-		fireEvent.click(screen.getByLabelText("popover-button"));
-
-		expect(screen.getByText("Main label")).toBeInTheDocument();
-		expect(screen.getByText("Sub label")).toBeInTheDocument();
-		expect(screen.getByText("Hint")).toBeVisible();
-	});
-
 	it("should be able to support validation schema", async () => {
 		renderComponent({ validation: [{ required: true, errorMessage: ERROR_MESSAGE }] });
 

--- a/src/__tests__/components/fields/histogram-slider/histogram-slider.spec.tsx
+++ b/src/__tests__/components/fields/histogram-slider/histogram-slider.spec.tsx
@@ -18,6 +18,7 @@ import {
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
+import { labelTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
@@ -105,21 +106,6 @@ describe(UI_TYPE, () => {
 		await waitFor(() => fireEvent.click(getSubmitButton()));
 
 		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
-	});
-
-	it("should be able to render sub label and hint", () => {
-		renderComponent({
-			label: {
-				mainLabel: "Main label",
-				subLabel: "Sub label",
-				hint: { content: "Hint" },
-			},
-		});
-		fireEvent.click(screen.getByLabelText("popover-button"));
-
-		expect(screen.getByText("Main label")).toBeInTheDocument();
-		expect(screen.getByText("Sub label")).toBeInTheDocument();
-		expect(screen.getByText("Hint")).toBeVisible();
 	});
 
 	it.each`
@@ -244,4 +230,6 @@ describe(UI_TYPE, () => {
 			expect(formIsDirty).toBe(false);
 		});
 	});
+
+	labelTestSuite(renderComponent);
 });

--- a/src/__tests__/components/fields/slider/slider.spec.tsx
+++ b/src/__tests__/components/fields/slider/slider.spec.tsx
@@ -19,6 +19,7 @@ import {
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
+import { labelTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
@@ -92,21 +93,6 @@ describe(UI_TYPE, () => {
 		await waitFor(() => fireEvent.click(getSubmitButton()));
 
 		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
-	});
-
-	it("should be able to render sub label and hint", () => {
-		renderComponent({
-			label: {
-				mainLabel: "Main label",
-				subLabel: "Sub label",
-				hint: { content: "Hint" },
-			},
-		});
-		fireEvent.click(screen.getByLabelText("popover-button"));
-
-		expect(screen.getByText("Main label")).toBeInTheDocument();
-		expect(screen.getByText("Sub label")).toBeInTheDocument();
-		expect(screen.getByText("Hint")).toBeVisible();
 	});
 
 	it("should be able to support validation schema", async () => {
@@ -231,4 +217,6 @@ describe(UI_TYPE, () => {
 			expect(formIsDirty).toBe(false);
 		});
 	});
+
+	labelTestSuite(renderComponent);
 });

--- a/src/components/custom/filter/filter-checkbox/filter-checkbox.tsx
+++ b/src/components/custom/filter/filter-checkbox/filter-checkbox.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import useDeepCompareEffect from "use-deep-compare-effect";
 import { TestHelper } from "../../../../utils";
+import { Sanitize } from "../../../shared";
 import { IGenericCustomFieldProps } from "../../types";
 import { IFilterCheckboxSchema, IOption } from "./types";
 
@@ -56,6 +57,7 @@ export const FilterCheckbox = (props: IGenericCustomFieldProps<IFilterCheckboxSc
 			expanded={expandedState}
 			onExpandChange={setExpandedState}
 			onSelect={handleChange}
+			labelExtractor={(item) => <Sanitize sanitizeOptions={{ allowedAttributes: false }}>{item.label}</Sanitize>}
 		></Filter.Checkbox>
 	);
 };

--- a/src/components/custom/filter/filter-checkbox/filter-checkbox.tsx
+++ b/src/components/custom/filter/filter-checkbox/filter-checkbox.tsx
@@ -1,4 +1,4 @@
-import { Filter } from "@lifesg/react-design-system";
+import { Filter } from "@lifesg/react-design-system/filter";
 import { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import useDeepCompareEffect from "use-deep-compare-effect";

--- a/src/components/custom/filter/filter-item/filter-item.tsx
+++ b/src/components/custom/filter/filter-item/filter-item.tsx
@@ -1,4 +1,4 @@
-import { Filter } from "@lifesg/react-design-system";
+import { Filter } from "@lifesg/react-design-system/filter";
 import { TestHelper } from "../../../../utils";
 import { Wrapper } from "../../../elements/wrapper";
 import { IGenericCustomElementProps } from "../../types";

--- a/src/components/custom/filter/filter/filter.tsx
+++ b/src/components/custom/filter/filter/filter.tsx
@@ -1,4 +1,4 @@
-import { Filter as FilterComponent } from "@lifesg/react-design-system";
+import { Filter as FilterComponent } from "@lifesg/react-design-system/filter";
 import isArray from "lodash/isArray";
 import isEmpty from "lodash/isEmpty";
 import isNumber from "lodash/isNumber";

--- a/src/components/elements/wrapper/field-wrapper.tsx
+++ b/src/components/elements/wrapper/field-wrapper.tsx
@@ -93,7 +93,7 @@ export const FieldWrapper = ({ Field, id, schema }: IProps) => {
 					  {
 							type: "popover",
 							content: <StyledHint className="label-hint">{label.hint?.content}</StyledHint>,
-							"data-testid": schema["data-testid"] || id,
+							"data-testid": (schema["data-testid"] || id) + "-popover",
 					  }
 					: /* eslint-enable indent */
 					  undefined,

--- a/src/stories/5-custom/filter/filter-checkbox-item.stories.tsx
+++ b/src/stories/5-custom/filter/filter-checkbox-item.stories.tsx
@@ -214,6 +214,22 @@ HideDivider.args = {
 	],
 };
 
+export const FormattedOptions = Template("filter-checkbox-formatted-options").bind({});
+FormattedOptions.args = {
+	label: "Filter checkbox",
+	referenceKey: "filter-checkbox",
+	options: [
+		{
+			label: `<span style="display: flex; gap: 0.5rem; align-items: center;"><span style="display: block; background: red; height: 0.75rem; width: 0.75rem; border-radius: 50%;"></span>Red</span>`,
+			value: "red",
+		},
+		{
+			label: `<span style="display: flex; gap: 0.5rem; align-items: center;"><span style="display: block; background: blue; height: 0.75rem; width: 0.75rem; border-radius: 50%;"></span>Blue</span>`,
+			value: "blue",
+		},
+	],
+};
+
 export const RevertOnClear = Template("filter-checkbox-revert").bind({});
 RevertOnClear.args = {
 	label: "Filter checkbox",


### PR DESCRIPTION
**Changes**

-  Bump DS to latest canary
    -  fix breaking tests for `hint` due to popover changes
    - fix breaking tests for mobile version of `filter` by mocking media query
-  Add html support for option label in `filter-checkbox`
-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Add html support to `filter-checkbox` option label
