### PR TITLE
Add popover to filter item

### DIFF
--- a/src/__tests__/components/custom/filter/filter-checkbox.spec.tsx
+++ b/src/__tests__/components/custom/filter/filter-checkbox.spec.tsx
@@ -95,6 +95,19 @@ describe(REFERENCE_KEY, () => {
 		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
 	});
 
+	it("should be able to render hint", () => {
+		renderComponent({
+			label: {
+				mainLabel: "Main label",
+				hint: { content: "Hint" },
+			},
+		});
+		fireEvent.click(screen.getByTestId("field-popover"));
+
+		expect(screen.getByText("Main label")).toBeInTheDocument();
+		expect(screen.getByText("Hint")).toBeVisible();
+	});
+
 	it("should be able to toggle the checkboxes", async () => {
 		renderComponent();
 		const checkboxes = getCheckboxes();

--- a/src/__tests__/components/custom/filter/filter-item.spec.tsx
+++ b/src/__tests__/components/custom/filter/filter-item.spec.tsx
@@ -101,6 +101,19 @@ describe(REFERENCE_KEY, () => {
 		expect(getTextfield()).toBeDisabled();
 	});
 
+	it("should be able to render hint", () => {
+		renderComponent({
+			label: {
+				mainLabel: "Main label",
+				hint: { content: "Hint" },
+			},
+		});
+		fireEvent.click(screen.getByTestId("field-popover"));
+
+		expect(screen.getByText("Main label")).toBeInTheDocument();
+		expect(screen.getByText("Hint")).toBeVisible();
+	});
+
 	it("should support validation schema", async () => {
 		renderComponent({ validation: [{ required: true, errorMessage: ERROR_MESSAGE }] });
 

--- a/src/components/custom/filter/filter-checkbox/filter-checkbox.tsx
+++ b/src/components/custom/filter/filter-checkbox/filter-checkbox.tsx
@@ -5,6 +5,7 @@ import useDeepCompareEffect from "use-deep-compare-effect";
 import { TestHelper } from "../../../../utils";
 import { Sanitize } from "../../../shared";
 import { IGenericCustomFieldProps } from "../../types";
+import { FilterHelper } from "../filter-helper";
 import { IFilterCheckboxSchema, IOption } from "./types";
 
 export const FilterCheckbox = (props: IGenericCustomFieldProps<IFilterCheckboxSchema>) => {
@@ -21,6 +22,7 @@ export const FilterCheckbox = (props: IGenericCustomFieldProps<IFilterCheckboxSc
 	const { setValue } = useFormContext();
 	const [selectedOptions, setSelectedOptions] = useState<IOption[]>(); // Current selected value state
 	const [expandedState, setExpandedState] = useState(expanded);
+	const { title, addon } = FilterHelper.constructFormattedLabel(label, id);
 	// =============================================================================
 	// EFFECTS
 	// =============================================================================
@@ -51,7 +53,8 @@ export const FilterCheckbox = (props: IGenericCustomFieldProps<IFilterCheckboxSc
 			id={id}
 			{...otherSchema}
 			data-testid={TestHelper.generateId(id, "filter-checkbox")}
-			title={label}
+			title={title}
+			addon={addon}
 			selectedOptions={selectedOptions}
 			options={options}
 			expanded={expandedState}

--- a/src/components/custom/filter/filter-checkbox/types.ts
+++ b/src/components/custom/filter/filter-checkbox/types.ts
@@ -1,9 +1,10 @@
 import { IBaseCustomFieldSchema } from "../../types";
 import { TClearBehavior } from "../filter/types";
+import { IFilterItemLabel } from "../types";
 
 export interface IFilterCheckboxSchema<V = undefined>
 	extends Omit<IBaseCustomFieldSchema<"filter-checkbox", V>, "validation"> {
-	label: string;
+	label: string | IFilterItemLabel;
 	options: IOption[];
 	collapsible?: boolean | undefined;
 	showDivider?: boolean | undefined;

--- a/src/components/custom/filter/filter-helper.tsx
+++ b/src/components/custom/filter/filter-helper.tsx
@@ -1,4 +1,6 @@
+import { Color } from "@lifesg/react-design-system/color";
 import { FormLabelAddonProps } from "@lifesg/react-design-system/form/types";
+import styled from "styled-components";
 import { Sanitize } from "../../shared";
 import { IFilterItemLabel } from "./types";
 
@@ -18,7 +20,7 @@ export namespace FilterHelper {
 					? /* eslint-disable indent */
 					  {
 							type: "popover",
-							content: <Sanitize>{label.hint?.content}</Sanitize>,
+							content: <StyledHint className="label-hint">{label.hint?.content}</StyledHint>,
 							"data-testid": id + "-popover",
 					  }
 					: /* eslint-enable indent */
@@ -27,3 +29,9 @@ export namespace FilterHelper {
 		}
 	};
 }
+
+const StyledHint = styled(Sanitize)`
+	&.label-hint {
+		color: ${Color.Neutral[1]};
+	}
+`;

--- a/src/components/custom/filter/filter-helper.tsx
+++ b/src/components/custom/filter/filter-helper.tsx
@@ -1,0 +1,29 @@
+import { FormLabelAddonProps } from "@lifesg/react-design-system/form/types";
+import { Sanitize } from "../../shared";
+import { IFilterItemLabel } from "./types";
+
+export namespace FilterHelper {
+	export const constructFormattedLabel = (
+		label: string | IFilterItemLabel,
+		id: string
+	): { title: string; addon?: FormLabelAddonProps } => {
+		if (typeof label === "string") {
+			return {
+				title: label,
+			};
+		} else if (!!label && typeof label === "object" && label.mainLabel) {
+			return {
+				title: label.mainLabel,
+				addon: label.hint?.content
+					? /* eslint-disable indent */
+					  {
+							type: "popover",
+							content: <Sanitize>{label.hint?.content}</Sanitize>,
+							"data-testid": id + "-popover",
+					  }
+					: /* eslint-enable indent */
+					  undefined,
+			};
+		}
+	};
+}

--- a/src/components/custom/filter/filter-item/filter-item.tsx
+++ b/src/components/custom/filter/filter-item/filter-item.tsx
@@ -1,9 +1,10 @@
 import { Filter } from "@lifesg/react-design-system/filter";
+import { useEffect, useState } from "react";
 import { TestHelper } from "../../../../utils";
 import { Wrapper } from "../../../elements/wrapper";
 import { IGenericCustomElementProps } from "../../types";
+import { FilterHelper } from "../filter-helper";
 import { IFilterItemSchema } from "./types";
-import { useEffect, useState } from "react";
 
 export const FilterItem = (props: IGenericCustomElementProps<IFilterItemSchema>) => {
 	// =============================================================================
@@ -15,6 +16,7 @@ export const FilterItem = (props: IGenericCustomElementProps<IFilterItemSchema>)
 	} = props;
 
 	const [expandedState, setExpandedState] = useState(expanded);
+	const { title, addon } = FilterHelper.constructFormattedLabel(label, id);
 
 	// =========================================================================
 	// EFFECTS
@@ -29,7 +31,8 @@ export const FilterItem = (props: IGenericCustomElementProps<IFilterItemSchema>)
 	return (
 		<Filter.Item
 			data-testid={TestHelper.generateId(id, "filter-item")}
-			title={label}
+			title={title}
+			addon={addon}
 			collapsible={collapsible}
 			showDivider={showDivider}
 			showMobileDivider={showMobileDivider}

--- a/src/components/custom/filter/filter-item/types.ts
+++ b/src/components/custom/filter/filter-item/types.ts
@@ -1,9 +1,10 @@
 import { TFrontendEngineFieldSchema } from "../../../frontend-engine";
 import { ICustomElementJsonSchema } from "../../types";
 import { TClearBehavior } from "../filter/types";
+import { IFilterItemLabel } from "../types";
 
 export interface IFilterItemSchema<V = undefined> extends ICustomElementJsonSchema<"filter-item"> {
-	label: string;
+	label: string | IFilterItemLabel;
 	children: Record<string, TFrontendEngineFieldSchema<V>>;
 	collapsible?: boolean | undefined;
 	showDivider?: boolean | undefined;

--- a/src/components/custom/filter/types.ts
+++ b/src/components/custom/filter/types.ts
@@ -1,0 +1,4 @@
+export interface IFilterItemLabel {
+	mainLabel: string;
+	hint?: { content: string } | undefined;
+}

--- a/src/stories/5-custom/filter/filter-checkbox-item.stories.tsx
+++ b/src/stories/5-custom/filter/filter-checkbox-item.stories.tsx
@@ -179,6 +179,19 @@ WithDefaultValues.argTypes = {
 	},
 };
 
+export const LabelCustomisation = Template("filter-checkbox-label-customisation").bind({});
+LabelCustomisation.args = {
+	label: {
+		mainLabel: "Filter item",
+		hint: { content: "A helpful tip<br>Another helpful tip on next line" },
+	},
+	referenceKey: "filter-checkbox",
+	options: [
+		{ label: "Red", value: "red" },
+		{ label: "Blue", value: "blue" },
+	],
+};
+
 export const Collapsible = Template("filter-checkbox-collapsible").bind({});
 Collapsible.args = {
 	label: "Filter checkbox",

--- a/src/stories/5-custom/filter/filter-item.stories.tsx
+++ b/src/stories/5-custom/filter/filter-item.stories.tsx
@@ -144,6 +144,21 @@ WithDefaultValues.argTypes = {
 	},
 };
 
+export const LabelCustomisation = Template("filter-item-label-customisation").bind({});
+LabelCustomisation.args = {
+	label: {
+		mainLabel: "Filter item",
+		hint: { content: "A helpful tip<br>Another helpful tip on next line" },
+	},
+	referenceKey: "filter-item",
+	children: {
+		text: {
+			uiType: "text-body",
+			children: "This is a filter item",
+		},
+	},
+};
+
 export const Collapsible = Template("filter-item-expanded").bind({});
 Collapsible.args = {
 	label: "Filter item",


### PR DESCRIPTION
**Changes**

- Add hint prop to filter item label to support tooltip popovers
- [This PR](https://github.com/LifeSG/web-frontend-engine/pull/217) should be merged first
-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Add popover to `filter-item`
