### PR TITLE
fix heic / heif compression

### DIFF
--- a/src/components/fields/image-upload/image-manager/image-manager.ts
+++ b/src/components/fields/image-upload/image-manager/image-manager.ts
@@ -30,7 +30,7 @@ export const ImageManager = (props: IProps) => {
 	const previousImages = usePrevious(images);
 	const [managerErrorCount, setManagerErrorCount] = useState(0);
 	const previousValue = usePrevious(value);
-	const { setValue, getFieldState } = useFormContext();
+	const { setValue } = useFormContext();
 	const sessionId = useRef<string>();
 
 	// =============================================================================
@@ -223,7 +223,10 @@ export const ImageManager = (props: IProps) => {
 
 	const compressImage = async (index: number, imageToCompress: IImage) => {
 		try {
-			const dataURL = await FileHelper.fileToDataUrl(imageToCompress.file);
+			const dataURL = await ImageHelper.convertBlob(
+				imageToCompress.file,
+				FileHelper.fileExtensionToMimeType(outputType)
+			);
 			const image = await ImageHelper.dataUrlToImage(dataURL);
 			const origDim = { w: image.naturalWidth, h: image.naturalHeight };
 			const scale = getScale(origDim.w, origDim.h);


### PR DESCRIPTION
**Changes**
- ensure base64 is of supported image type before compressing
- delete branch

**Additional information**
- compression is failing when heic / heif files are added
- this is happening because the files are converted to base64 directly
- as these formats are not supported by browsers yet, the compression fails when they are converted to the image object
- fix is to generate base64 of a supported type first before converting to an image object