### PR TITLE
[MOL-14960][ES] Add functionality to update search results list title

### DIFF
--- a/src/__tests__/components/fields/location-field/location-field.spec.tsx
+++ b/src/__tests__/components/fields/location-field/location-field.spec.tsx
@@ -1415,4 +1415,56 @@ describe("location-input-group", () => {
 			expect(formIsDirty).toBe(false);
 		});
 	});
+
+	describe("search results list title", () => {
+		beforeEach(async () => {
+			fetchAddressSpy.mockImplementation((queryString, pageNumber, onSuccess) => {
+				onSuccess(mock1PageFetchAddressResponse);
+			});
+			fetchSingleLocationByLatLngSpy.mockImplementation(
+				(_reverseGeoCodeEndpoint, _convertLatLngToXYEndpoint, _lat, _lng, handleResult) => {
+					handleResult(fetchSingleLocationByLatLngSingleReponse);
+				}
+			);
+		});
+
+		it("show default location list title", () => {
+			renderComponent({
+				withEvents: false,
+				overrideSchema: {
+					defaultValues: {
+						[COMPONENT_ID]: {
+							lat: 1.29994179707526,
+							lng: 103.789404349716,
+						},
+					},
+				},
+				overrideField: {
+					reverseGeoCodeEndpoint: "https://www.mock.com/reverse-geo-code",
+				},
+			});
+			const locationListTitle = screen.getByText("Select location");
+			expect(locationListTitle).toBeInTheDocument();
+		});
+
+		it("show updated location list title", () => {
+			renderComponent({
+				withEvents: false,
+				overrideSchema: {
+					defaultValues: {
+						[COMPONENT_ID]: {
+							lat: 1.29994179707526,
+							lng: 103.789404349716,
+						},
+					},
+				},
+				overrideField: {
+					reverseGeoCodeEndpoint: "https://www.mock.com/reverse-geo-code",
+					locationListTitle: "Nearest car parks",
+				},
+			});
+			const locationListTitle = screen.getByText("Nearest car parks");
+			expect(locationListTitle).toBeInTheDocument();
+		});
+	});
 });

--- a/src/__tests__/components/fields/location-field/location-field.spec.tsx
+++ b/src/__tests__/components/fields/location-field/location-field.spec.tsx
@@ -1428,7 +1428,7 @@ describe("location-input-group", () => {
 			);
 		});
 
-		it("show default location list title", () => {
+		it("should show default location list title if locationListTitle is not provided", async () => {
 			renderComponent({
 				withEvents: false,
 				overrideSchema: {
@@ -1443,11 +1443,13 @@ describe("location-input-group", () => {
 					reverseGeoCodeEndpoint: "https://www.mock.com/reverse-geo-code",
 				},
 			});
-			const locationListTitle = screen.getByText("Select location");
-			expect(locationListTitle).toBeInTheDocument();
+			await waitFor(() => {
+				const locationListTitle = screen.getByText("Select location");
+				expect(locationListTitle).toBeInTheDocument();
+			});
 		});
 
-		it("show updated location list title", () => {
+		it("should show location list title according to locationListTitle", async () => {
 			renderComponent({
 				withEvents: false,
 				overrideSchema: {
@@ -1463,8 +1465,10 @@ describe("location-input-group", () => {
 					locationListTitle: "Nearest car parks",
 				},
 			});
-			const locationListTitle = screen.getByText("Nearest car parks");
-			expect(locationListTitle).toBeInTheDocument();
+			await waitFor(() => {
+				const locationListTitle = screen.getByText("Nearest car parks");
+				expect(locationListTitle).toBeInTheDocument();
+			});
 		});
 	});
 });

--- a/src/components/fields/location-field/location-field.tsx
+++ b/src/components/fields/location-field/location-field.tsx
@@ -35,6 +35,7 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 			reverseGeoCodeEndpoint,
 			staticMapPinColor,
 			validation,
+			locationListTitle,
 		},
 		// form values can initially be undefined when passed in via props
 		value: formValue,
@@ -141,6 +142,7 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 						gettingCurrentLocationFetchMessage={gettingCurrentLocationFetchMessage}
 						mustHavePostalCode={mustHavePostalCode}
 						locationModalStyles={locationModalStyles}
+						locationListTitle={locationListTitle}
 					/>
 				)}
 			</Suspense>

--- a/src/components/fields/location-field/location-field.tsx
+++ b/src/components/fields/location-field/location-field.tsx
@@ -28,6 +28,7 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 			interactiveMapPinIconUrl,
 			label: _label,
 			locationInputPlaceholder,
+			locationListTitle,
 			locationModalStyles,
 			mapPanZoom,
 			mustHavePostalCode,
@@ -35,7 +36,6 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 			reverseGeoCodeEndpoint,
 			staticMapPinColor,
 			validation,
-			locationListTitle,
 		},
 		// form values can initially be undefined when passed in via props
 		value: formValue,

--- a/src/components/fields/location-field/location-modal/location-modal.tsx
+++ b/src/components/fields/location-field/location-modal/location-modal.tsx
@@ -42,6 +42,7 @@ const LocationModal = ({
 	onClose,
 	onConfirm,
 	updateFormValues,
+	locationListTitle,
 }: ILocationModalProps) => {
 	// =============================================================================
 	// CONST, STATE, REFS
@@ -393,6 +394,7 @@ const LocationModal = ({
 								convertLatLngToXYEndpoint={convertLatLngToXYEndpoint}
 								gettingCurrentLocationFetchMessage={gettingCurrentLocationFetchMessage}
 								mustHavePostalCode={mustHavePostalCode}
+								locationListTitle={locationListTitle}
 							/>
 							<StyledLocationPicker
 								id={id}

--- a/src/components/fields/location-field/location-modal/types.ts
+++ b/src/components/fields/location-field/location-modal/types.ts
@@ -19,5 +19,5 @@ export interface ILocationModalProps
 	onClose: () => void;
 	onConfirm: (values: ILocationFieldValues) => void;
 	updateFormValues: (values: ILocationFieldValues, shouldDirty?: boolean) => void;
-	locationListTitle?: string;
+	locationListTitle?: string | undefined;
 }

--- a/src/components/fields/location-field/location-modal/types.ts
+++ b/src/components/fields/location-field/location-modal/types.ts
@@ -19,4 +19,5 @@ export interface ILocationModalProps
 	onClose: () => void;
 	onConfirm: (values: ILocationFieldValues) => void;
 	updateFormValues: (values: ILocationFieldValues, shouldDirty?: boolean) => void;
+	locationListTitle?: string;
 }

--- a/src/components/fields/location-field/types.ts
+++ b/src/components/fields/location-field/types.ts
@@ -18,7 +18,7 @@ export interface ILocationFieldSchema<V = undefined>
 		Pick<IStaticMapProps, "staticMapPinColor"> {
 	className?: string;
 	locationModalStyles?: string | undefined;
-	locationListTitle?: string;
+	locationListTitle?: string | undefined;
 }
 
 export type TSinglePanelInputMode = "search" | "map";

--- a/src/components/fields/location-field/types.ts
+++ b/src/components/fields/location-field/types.ts
@@ -18,6 +18,7 @@ export interface ILocationFieldSchema<V = undefined>
 		Pick<IStaticMapProps, "staticMapPinColor"> {
 	className?: string;
 	locationModalStyles?: string | undefined;
+	locationListTitle?: string;
 }
 
 export type TSinglePanelInputMode = "search" | "map";

--- a/src/stories/3-fields/location-field/location-field.stories.tsx
+++ b/src/stories/3-fields/location-field/location-field.stories.tsx
@@ -151,6 +151,7 @@ MustHavePostalCode.args = {
 	reverseGeoCodeEndpoint,
 	convertLatLngToXYEndpoint,
 };
+
 export const Disabled = DefaultStoryTemplate<ILocationFieldSchema>("location-field-disabled").bind({});
 Disabled.args = {
 	uiType: "location-field",
@@ -180,3 +181,14 @@ Overrides.args = {
 	convertLatLngToXYEndpoint,
 };
 Overrides.argTypes = OVERRIDES_ARG_TYPE;
+
+export const LocationListTitle = DefaultStoryTemplate<ILocationFieldSchema>("location-field-location-list-title").bind(
+	{}
+);
+LocationListTitle.args = {
+	uiType: "location-field",
+	label: "Location List Title",
+	locationListTitle: "Nearest car parks",
+	reverseGeoCodeEndpoint,
+	convertLatLngToXYEndpoint,
+};

--- a/src/stories/3-fields/location-field/location-field.stories.tsx
+++ b/src/stories/3-fields/location-field/location-field.stories.tsx
@@ -40,6 +40,18 @@ const meta: Meta = {
 				type: "boolean",
 			},
 		},
+		locationListTitle: {
+			description: "Specifies the search results list title.",
+			table: {
+				type: {
+					summary: "string",
+				},
+				defaultValue: { summary: "Select location" },
+			},
+			control: {
+				type: "text",
+			},
+		},
 	},
 };
 export default meta;


### PR DESCRIPTION
**Changes**

- Add `locationListTitle` prop to support functionality to update search results list title
- Add unit test for `locationListTitle`
- Update location-field stories

**Changelog entry**

-   Ability to change `locationListTitle` from default 'Select location'

**Additional information**

-   You may refer to this [ticket](https://jira.ship.gov.sg/browse/MOL-14960)
