### PR TITLE
[MOL-14931][CWH] Add explicit edit to location

### DIFF
--- a/src/components/fields/location-field/location-field.tsx
+++ b/src/components/fields/location-field/location-field.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@lifesg/react-design-system/button";
 import { Suspense, lazy, useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import * as Yup from "yup";
@@ -36,12 +37,15 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 			reverseGeoCodeEndpoint,
 			staticMapPinColor,
 			validation,
+			hasExplicitEdit,
+			onEditPrompt,
 		},
 		// form values can initially be undefined when passed in via props
 		value: formValue,
 	} = props;
 
 	const [showLocationModal, setShowLocationModal] = useState<boolean>(false);
+	const [showEditPrompt, setShowEditPrompt] = useState<boolean>(false);
 	const { setValue } = useFormContext();
 	const { setFieldValidationConfig } = useValidationConfig();
 	const { dispatchFieldEvent } = useFieldEvent();
@@ -97,6 +101,16 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 		setShowLocationModal(false);
 		dispatchFieldEvent("hide-location-modal", id);
 	};
+
+	const handleLocationModalShow = () => {
+		setShowLocationModal(true);
+		setShowEditPrompt(false);
+	};
+
+	const handleEditPromptClose = () => {
+		setShowEditPrompt(false);
+	};
+
 	// =============================================================================
 	// RENDER FUNCTIONS
 	// =============================================================================
@@ -111,9 +125,19 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 				onFocus={handleFocus}
 				value={formValue?.address || ""}
 				errorMessage={error?.message}
-				disabled={disabled}
+				disabled={(hasExplicitEdit === "explicit" && formValue?.address) || disabled}
 				readOnly={readOnly}
 			/>
+			{hasExplicitEdit && formValue?.address && (
+				<Button.Default
+					id={TestHelper.generateId(id, "edit-button")}
+					data-testid={TestHelper.generateId(id, "edit-button")}
+					styleType="secondary"
+					onClick={() => (onEditPrompt ? setShowEditPrompt(true) : setShowLocationModal(true))}
+				>
+					Edit
+				</Button.Default>
+			)}
 			{!!formValue?.lat && !!formValue?.lng && (
 				<StaticMap
 					id={id}
@@ -147,6 +171,7 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 					/>
 				)}
 			</Suspense>
+			{showEditPrompt && <>{onEditPrompt({ onEdit: handleLocationModalShow, onClose: handleEditPromptClose })}</>}
 		</div>
 	);
 };

--- a/src/components/fields/location-field/location-modal/location-search/types.ts
+++ b/src/components/fields/location-field/location-modal/location-search/types.ts
@@ -1,4 +1,11 @@
-import { ILocationCoord, ILocationFieldValues, TPanelInputMode, TSinglePanelInputMode } from "../../types";
+import {
+	IEditPrompt,
+	ILocationCoord,
+	ILocationFieldValues,
+	TExplicitEditMode,
+	TPanelInputMode,
+	TSinglePanelInputMode,
+} from "../../types";
 
 export interface ILocationSearchProps {
 	id?: string | undefined;
@@ -22,4 +29,6 @@ export interface ILocationSearchProps {
 	formValues?: ILocationFieldValues | undefined;
 	updateFormValues: (values: ILocationFieldValues, shouldDirty?: boolean) => void;
 	setSinglePanelMode: (panelMode: TSinglePanelInputMode) => void;
+	hasExplicitEdit?: TExplicitEditMode | undefined;
+	onEditPrompt?: (editPrompt: IEditPrompt) => void;
 }

--- a/src/components/fields/location-field/types.ts
+++ b/src/components/fields/location-field/types.ts
@@ -13,6 +13,8 @@ export interface ILocationFieldSchema<V = undefined>
 			| "convertLatLngToXYEndpoint"
 			| "mustHavePostalCode"
 			| "gettingCurrentLocationFetchMessage"
+			| "hasExplicitEdit"
+			| "onEditPrompt"
 		>,
 		Pick<ILocationInputProps, "locationInputPlaceholder" | "disabled" | "readOnly">,
 		Pick<IStaticMapProps, "staticMapPinColor"> {
@@ -23,6 +25,7 @@ export interface ILocationFieldSchema<V = undefined>
 }
 
 export type TSinglePanelInputMode = "search" | "map";
+export type TExplicitEditMode = "show" | "explicit";
 
 // search and map will implicitly mean single panel can only show one view at a time: search or map
 // double means both search and map will be seen
@@ -58,6 +61,11 @@ export interface IResultsMetaData {
 export interface IDisplayResultListParams extends IResultsMetaData {
 	queryString?: string | undefined;
 	boldResults?: boolean | undefined;
+}
+
+export interface IEditPrompt {
+	onEdit?: () => void;
+	onClose?: () => void;
 }
 
 export type TErrorType = {

--- a/src/stories/3-fields/location-field/location-field.stories.tsx
+++ b/src/stories/3-fields/location-field/location-field.stories.tsx
@@ -2,9 +2,37 @@ import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "
 import { Meta } from "@storybook/react";
 import { ILocationFieldSchema, ILocationFieldValues } from "../../../components/fields";
 import { CommonFieldStoryProps, DefaultStoryTemplate, OVERRIDES_ARG_TYPE, OverrideStoryTemplate } from "../../common";
+import { Prompt } from "../../../components/shared";
+import { ERROR_SVG } from "../../../components/fields/location-field/location-modal/location-modal.data";
+import { ErrorImage } from "../../../components/fields/location-field/location-modal/location-modal.styles";
 
 const reverseGeoCodeEndpoint = "https://www.dev.lifesg.io/oneservice/api/v1/one-map/reverse-geo-code";
 const convertLatLngToXYEndpoint = "https://www.dev.lifesg.io/oneservice/api/v1/one-map/convert-latlng-to-xy";
+const editPrompt = ({ onEdit, onClose }) => {
+	return (
+		<Prompt
+			id="location-edit-prompt"
+			title="Edit Location?"
+			size="large"
+			show={true}
+			image={<ErrorImage src={ERROR_SVG} />}
+			description="sample prompt message"
+			buttons={[
+				{
+					id: "edit",
+					title: "Edit location",
+					onClick: onEdit,
+				},
+				{
+					id: "cancel",
+					title: "Cancel",
+					onClick: onClose,
+					buttonStyle: "secondary",
+				},
+			]}
+		/>
+	);
+};
 const meta: Meta = {
 	title: "Field/LocationField",
 	parameters: {
@@ -52,7 +80,7 @@ const meta: Meta = {
 				type: "text",
 			},
 		},
-    locationListTitle: {
+		locationListTitle: {
 			description: "Specifies the search results list title.",
 			table: {
 				type: {
@@ -214,4 +242,19 @@ LocationListTitle.args = {
 	locationListTitle: "Nearest car parks",
 	reverseGeoCodeEndpoint,
 	convertLatLngToXYEndpoint,
+};
+
+export const hasExplicitEdit = DefaultStoryTemplate<ILocationFieldSchema, ILocationFieldValues>(
+	"location-field-explicit-edit"
+).bind({});
+hasExplicitEdit.args = {
+	uiType: "location-field",
+	label: "hasExplicitEdit",
+	defaultValues: {
+		address: "Fusionopolis View",
+	},
+	reverseGeoCodeEndpoint,
+	convertLatLngToXYEndpoint,
+	hasExplicitEdit: "explicit",
+	onEditPrompt: editPrompt,
 };


### PR DESCRIPTION
**Changes**

- Add hasExplicitEdit & onEditPrompt prop to support display of edit button & edit prompt in the location-picker component
- Add unit test for edit prompt
- Update location-field stories

**Changelog entry**

- Add edit prompt to location-picker

**Additional information**

- refer to [MOL-14931](https://jira.ship.gov.sg/browse/MOL-14931) 