### PR TITLE
[MISC][WL] downgrade react-hook-form to 7.47.0 to fix isDirty bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19375,9 +19375,9 @@
 			"dev": true
 		},
 		"node_modules/react-hook-form": {
-			"version": "7.50.1",
-			"resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.50.1.tgz",
-			"integrity": "sha512-3PCY82oE0WgeOgUtIr3nYNNtNvqtJ7BZjsbxh6TnYNbXButaD5WpjOmTjdxZfheuHKR68qfeFnEDVYoSSFPMTQ==",
+			"version": "7.47.0",
+			"resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.47.0.tgz",
+			"integrity": "sha512-F/TroLjTICipmHeFlMrLtNLceO2xr1jU3CyiNla5zdwsGUGu2UOxxR4UyJgLlhMwLW/Wzp4cpJ7CPfgJIeKdSg==",
 			"engines": {
 				"node": ">=12.22.0"
 			},


### PR DESCRIPTION
**Changes**
- downgrade react-hook-form to 7.47.0
- latest version is causing form to be dirty when `setValue()` is used
- this happens even if `shouldDirty: false` is set
-  delete branch
