### PR TITLE
[VALIDATION][WL] add support for nested conditional validation

### DIFF
--- a/src/components/frontend-engine/yup/types.ts
+++ b/src/components/frontend-engine/yup/types.ts
@@ -56,7 +56,7 @@ export interface IYupValidationRule extends IYupRule {
 		| {
 				[id: string]: {
 					is: string | number | boolean | string[] | number[] | boolean[] | IYupConditionalValidationRule[];
-					then: Omit<IYupValidationRule, "when">[];
+					then: IYupValidationRule[];
 					otherwise?: Omit<IYupValidationRule, "when">[];
 					yupSchema?: Yup.AnySchema | undefined;
 				};

--- a/src/stories/2-frontend-engine/validation/validation-conditional.stories.tsx
+++ b/src/stories/2-frontend-engine/validation/validation-conditional.stories.tsx
@@ -85,3 +85,30 @@ SchemaAsCondition.args = {
 	value: { field2: "something" },
 	extraFields: { field2: { schema: Yup.string(), validationRules: [] } },
 };
+
+export const NestedConditional = Template.bind({});
+NestedConditional.args = {
+	type: "string",
+	rule: {
+		when: {
+			field2: {
+				is: [{ filled: true }],
+				then: [
+					{
+						when: {
+							field3: {
+								is: [{ filled: true }],
+								then: [{ required: true, errorMessage: "Field 1 is required" }],
+							},
+						},
+					},
+				],
+			},
+		},
+	},
+	value: { field2: "hello", field3: "world" },
+	extraFields: {
+		field2: { schema: Yup.string(), validationRules: [] },
+		field3: { schema: Yup.string(), validationRules: [] },
+	},
+};


### PR DESCRIPTION
**Changes**
- add support for nested conditional validation
  - note: this works for the `then` key only and doesn't work for `otherwise` key
- a similar implementation has already been added to validation-schema-generator: https://github.com/LifeSG/validation-schema-generator/pull/40
- delete branch

**Additional information**
- Current implementation only supports `OR` conditional validations
- Having nested conditional validation fulfils the `AND` conditional validations

```

// OR
{
	validation: [
		{
			when: {
				field1: {
					is: "",
					then: "",
					otherwise: "",
				},
				field2: {
					is: "",
					then: "",
					otherwise: "",
				}
			}
		}
	]
}

// OR
{
	validation: [
		{
			when: {
				field1: {
					is: "",
					then: "",
					otherwise: "",
				}
			}
		},
		{
			when: {
				field2: {
					is: "",
					then: "",
					otherwise: "",
				}
			}
		}
	]
}

// AND
{
	validation: [
		{
			when: {
				field1: {
					is: "",
					then: [{
						when: {
							field2: {
								is: "",
								then: "",
								otherwise: "",
							}
						}
					}],
					otherwise: "",
				},
		}
	]
}
```