### PR TITLE
[MOL-15109][CWH] Add field event to confirm location button

### DIFF
--- a/src/__tests__/components/fields/location-field/location-field.spec.tsx
+++ b/src/__tests__/components/fields/location-field/location-field.spec.tsx
@@ -712,6 +712,10 @@ describe("location-input-group", () => {
 				within(getCurrentLocationErrorModal()).getByRole("button").click();
 			});
 
+			afterEach(() => {
+				jest.useRealTimers();
+			});
+
 			it("should show confirm location prompt when confirm location", async () => {
 				fetchAddressSpy.mockImplementation((queryString, pageNumber, onSuccess) => {
 					onSuccess(mock1PageFetchAddressResponse);

--- a/src/__tests__/components/fields/location-field/location-field.spec.tsx
+++ b/src/__tests__/components/fields/location-field/location-field.spec.tsx
@@ -687,6 +687,7 @@ describe("location-input-group", () => {
 		//Confirm Location Events
 		describe("Confirm Location events", () => {
 			beforeEach(async () => {
+				jest.useFakeTimers();
 				getCurrentLocationSpy.mockRejectedValue({
 					code: 1,
 				});
@@ -705,10 +706,10 @@ describe("location-input-group", () => {
 				getLocationInput().focus();
 
 				await waitFor(() => {
-					expect(getCurrentLocationErrorModal(true)).toBeInTheDocument();
+					expect(getCurrentLocationErrorModal()).toBeInTheDocument();
 				});
 
-				within(getCurrentLocationErrorModal(true)).getByRole("button").click();
+				within(getCurrentLocationErrorModal()).getByRole("button").click();
 			});
 
 			it("should show confirm location prompt when confirm location", async () => {
@@ -737,9 +738,9 @@ describe("location-input-group", () => {
 
 				await waitFor(() => {
 					expect(confirmLocationOnClickSpy).toBeCalled();
-					expect(getConfirmLocationModal(true)).toBeInTheDocument();
+					expect(getConfirmLocationModal()).toBeInTheDocument();
 				});
-				await new Promise((resolve) => setTimeout(resolve, 3500));
+				jest.advanceTimersByTime(3500);
 				await waitFor(() => {
 					expect(getConfirmLocationModal(true)).not.toBeInTheDocument();
 					expect(getLocationModal(true)).not.toBeInTheDocument();

--- a/src/components/fields/location-field/location-modal/location-modal.tsx
+++ b/src/components/fields/location-field/location-modal/location-modal.tsx
@@ -210,14 +210,14 @@ const LocationModal = ({
 		handleCloseLocationModal();
 	};
 
-	const handleOnConfirm = () => {
+	const handleClickConfirm = () => {
 		const shouldPreventDefault = !dispatchFieldEvent("click-confirm-location", id, selectedAddressInfo);
 		if (!shouldPreventDefault) {
 			handleConfirm();
 		}
 	};
 
-	const handleConfirm = (e?: CustomEvent) => {
+	const handleConfirm = (e?: CustomEvent | undefined) => {
 		const addressInfo = !isEmpty(e?.detail) ? e?.detail : selectedAddressInfo;
 		onConfirm(addressInfo);
 		handleCloseLocationModal();
@@ -389,7 +389,7 @@ const LocationModal = ({
 								id={id}
 								className={className}
 								onCancel={handleCancel}
-								onConfirm={handleOnConfirm}
+								onConfirm={handleClickConfirm}
 								updateFormValues={updateFormValues}
 								gettingCurrentLocation={gettingCurrentLocation}
 								panelInputMode={panelInputMode}

--- a/src/components/fields/location-field/location-modal/location-modal.tsx
+++ b/src/components/fields/location-field/location-modal/location-modal.tsx
@@ -91,9 +91,11 @@ const LocationModal = ({
 		};
 
 		addFieldEventListener("error-end", id, handleError);
+		addFieldEventListener("confirm-location", id, handleConfirm);
 
 		return () => {
 			removeFieldEventListener("error-end", id, handleError);
+			removeFieldEventListener("confirm-location", id, handleConfirm);
 		};
 	}, []);
 
@@ -208,8 +210,16 @@ const LocationModal = ({
 		handleCloseLocationModal();
 	};
 
-	const handleConfirm = () => {
-		onConfirm(selectedAddressInfo);
+	const handleOnConfirm = () => {
+		const shouldPreventDefault = !dispatchFieldEvent("click-confirm-location", id, selectedAddressInfo);
+		if (!shouldPreventDefault) {
+			handleConfirm();
+		}
+	};
+
+	const handleConfirm = (e?: CustomEvent) => {
+		const addressInfo = !isEmpty(e?.detail) ? e?.detail : selectedAddressInfo;
+		onConfirm(addressInfo);
 		handleCloseLocationModal();
 	};
 
@@ -379,7 +389,7 @@ const LocationModal = ({
 								id={id}
 								className={className}
 								onCancel={handleCancel}
-								onConfirm={handleConfirm}
+								onConfirm={handleOnConfirm}
 								updateFormValues={updateFormValues}
 								gettingCurrentLocation={gettingCurrentLocation}
 								panelInputMode={panelInputMode}

--- a/src/components/fields/location-field/location-modal/location-search/location-search.tsx
+++ b/src/components/fields/location-field/location-modal/location-search/location-search.tsx
@@ -667,6 +667,8 @@ export const LocationSearch = ({
 						Cancel
 					</ButtonItem>
 					<ButtonItem
+						id={TestHelper.generateId(id, "location-search-controls-confirm")}
+						data-testid={TestHelper.generateId(id, "location-search-controls-confirm")}
 						buttonType="confirm"
 						onClick={onConfirm}
 						disabled={selectedIndex < 0 || resultState !== "found"}

--- a/src/stories/3-fields/location-field/location-field-events.stories.tsx
+++ b/src/stories/3-fields/location-field/location-field-events.stories.tsx
@@ -188,6 +188,62 @@ const GeolocationTemplate = (detail: TSetCurrentLocationDetail) =>
 	}) as StoryFn<ILocationFieldSchema>;
 /* eslint-enable react-hooks/rules-of-hooks */
 
+/* eslint-disable react-hooks/rules-of-hooks */
+const ConfirmLocationPromptTemplate = () =>
+	((args) => {
+		const [showConfirmLocationPrompt, setShowConfirmLocationPrompt] = useState<boolean>(false);
+		const id = "location-search-controls-confirm";
+		const formRef = useRef<IFrontendEngineRef>();
+
+		useEffect(() => {
+			const currentFormRef = formRef.current;
+			currentFormRef.addFieldEventListener("click-confirm-location", id, handleShowConfirmLocationPrompt);
+
+			return () => {
+				currentFormRef.removeFieldEventListener("click-confirm-location", id, handleShowConfirmLocationPrompt);
+			};
+		}, []);
+
+		const handleShowConfirmLocationPrompt = async (e) => {
+			e.preventDefault();
+			setShowConfirmLocationPrompt(true);
+			await new Promise(() =>
+				setTimeout(() => {
+					setShowConfirmLocationPrompt(false);
+					formRef.current.dispatchFieldEvent("confirm-location", id, e.detail);
+				}, 3000)
+			);
+			return action("click-confirm-location")(e);
+		};
+
+		return (
+			<>
+				<FrontendEngine
+					ref={formRef}
+					data={{
+						sections: {
+							section: {
+								uiType: "section",
+								children: {
+									[id]: args,
+									...SUBMIT_BUTTON_SCHEMA,
+								},
+							},
+						},
+					}}
+				/>
+				<Prompt
+					id="location-confirm-location-prompt"
+					title="Confirm Location"
+					size="large"
+					show={showConfirmLocationPrompt}
+					description="Timeout"
+				/>
+			</>
+		);
+	}) as StoryFn<ILocationFieldSchema>;
+/* eslint-enable react-hooks/rules-of-hooks */
+
 export const ShowModal = Template("show-location-modal").bind({});
 ShowModal.args = {
 	uiType: "location-field",
@@ -215,6 +271,12 @@ export const GeolocationWithErrors = GeolocationTemplate({
 GeolocationWithErrors.args = {
 	uiType: "location-field",
 	label: "Geolocation with errors",
+};
+
+export const ConfirmLocation = ConfirmLocationPromptTemplate().bind({});
+ConfirmLocation.args = {
+	uiType: "location-field",
+	label: "Confirm Location",
 };
 
 interface HotlineContent {


### PR DESCRIPTION
**Changes**

- dispatch field event `click-confirm-location` when click on confirm button in location modal
- add in event listener in location picker to handle the `confirm-location` which suppose to be trigger as a signal of finish of the `click-confirm-location` event
- Add unit test for confirm location button
- Update location-field stories

**Changelog entry**

-   Add field event to confirm location button in location-picker modal

**Additional information**

- refer to [MOL-15109](https://jira.ship.gov.sg/browse/MOL-15109)
