### PR TITLE
Wrap in form

### DIFF
--- a/src/components/fields/submit-button/submit-button.tsx
+++ b/src/components/fields/submit-button/submit-button.tsx
@@ -4,7 +4,7 @@ import { useWatch } from "react-hook-form";
 import useDeepCompareEffect from "use-deep-compare-effect";
 import * as Yup from "yup";
 import { IGenericFieldProps } from "..";
-import { useValidationConfig, useValidationSchema } from "../../../utils/hooks";
+import { useFrontendEngineForm, useValidationConfig, useValidationSchema } from "../../../utils/hooks";
 import { ISubmitButtonSchema } from "./types";
 
 export const SubmitButton = (props: IGenericFieldProps<ISubmitButtonSchema>) => {
@@ -16,6 +16,7 @@ export const SubmitButton = (props: IGenericFieldProps<ISubmitButtonSchema>) => 
 		schema: { disabled, label, ...otherSchema },
 		...otherProps
 	} = props;
+	const { submitHandler, wrapInForm } = useFrontendEngineForm();
 	const { setFieldValidationConfig } = useValidationConfig();
 	const { hardValidationSchema } = useValidationSchema();
 	const formValues = useWatch({ disabled: disabled !== "invalid-form" });
@@ -41,10 +42,29 @@ export const SubmitButton = (props: IGenericFieldProps<ISubmitButtonSchema>) => 
 	}, [formValues, hardValidationSchema]);
 
 	// =============================================================================
+	// EVENT HANDLERS
+	// =============================================================================
+	const handleClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+		// perform manual submission only if FEE does not render the <form>
+		if (!wrapInForm) {
+			e.preventDefault();
+			submitHandler?.();
+		}
+	};
+
+	// =============================================================================
 	// RENDER FUNCTIONS
 	// =============================================================================
 	return (
-		<Button.Default {...otherSchema} {...otherProps} disabled={isDisabled} data-testid={id} id={id} type="submit">
+		<Button.Default
+			{...otherSchema}
+			{...otherProps}
+			disabled={isDisabled}
+			data-testid={id}
+			id={id}
+			onClick={handleClick}
+			type="submit"
+		>
 			{label}
 		</Button.Default>
 	);

--- a/src/components/frontend-engine/frontend-engine.tsx
+++ b/src/components/frontend-engine/frontend-engine.tsx
@@ -28,7 +28,7 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 	// =============================================================================
 	// CONST, STATE, REFS
 	// =============================================================================
-	const { data, className = null, components, onChange, onSubmit, onSubmitError } = props;
+	const { data, className = null, components, onChange, onSubmit, onSubmitError, wrapInForm = true } = props;
 	const {
 		className: dataClassName = null,
 		defaultValues,
@@ -231,6 +231,7 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 	// =============================================================================
 	const formId = id ? `frontend-engine-${id}` : "frontend-engine";
 	const formClassNames = [className, dataClassName].join(" ").trim();
+	const InnerElement = wrapInForm ? "form" : "div";
 
 	if (!data) {
 		return (
@@ -242,16 +243,16 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 
 	return (
 		<FormProvider {...formMethods}>
-			<form
+			<InnerElement
 				id={formId}
-				data-testid={TestHelper.generateId(id, "frontend-engine")}
+				data-testid={id ? TestHelper.generateId(id, "frontend-engine") : formId}
 				className={formClassNames}
 				noValidate
 				onSubmit={reactFormHookSubmit(handleSubmit, handleSubmitError)}
 				ref={ref}
 			>
 				<Sections schema={sections} />
-			</form>
+			</InnerElement>
 		</FormProvider>
 	);
 });

--- a/src/components/frontend-engine/types.ts
+++ b/src/components/frontend-engine/types.ts
@@ -32,6 +32,14 @@ export interface IFrontendEngineProps<V = undefined, C = undefined> {
 	onSubmit?: (values: TFrontendEngineValues) => unknown | undefined;
 	/** Submit error event handler, invoked when form fails validation on submissiohn. Will receive validation errors */
 	onSubmitError?: (errors: TFrontendEngineValues) => unknown | undefined;
+	/** Indicates whether to wrap Frontend Engine fields within the `<form>` element, by default, fields will be rendered within the `<form>` element
+	 *
+	 * When false, the fields will be rendered within the `<div>` element instead
+	 *
+	 * This is for instances where Frontend Engine needs to be rendered within another <form> element
+	 *
+	 * Default: true */
+	wrapInForm?: boolean | undefined;
 }
 
 /**
@@ -83,7 +91,9 @@ export type TErrorMessage = string | string[] | Record<string, string | string[]
 export type TErrorPayload = Record<string, TErrorMessage>;
 export type TWarningPayload = Record<string, string>;
 
-export interface IFrontendEngineRef extends HTMLFormElement {
+export interface IFrontendEngineRef
+	extends Omit<HTMLDivElement, "addEventListener" | "removeEventListener">,
+		HTMLFormElement {
 	addCustomValidation: (
 		type: TYupSchemaType | "mixed",
 		name: string,

--- a/src/context-providers/context-providers.tsx
+++ b/src/context-providers/context-providers.tsx
@@ -3,6 +3,7 @@ import { CustomComponentsProvider } from "./custom-components";
 import { EventProvider } from "./event";
 import { FormSchemaProvider } from "./form-schema";
 import { FormValuesProvider } from "./form-values";
+import { FrontendEngineFormProvider } from "./frontend-engine-form";
 import { YupProvider } from "./yup";
 
 interface IProps {
@@ -15,7 +16,9 @@ export const ContextProviders = ({ children }: IProps) => {
 			<EventProvider>
 				<FormSchemaProvider>
 					<FormValuesProvider>
-						<CustomComponentsProvider>{children}</CustomComponentsProvider>
+						<CustomComponentsProvider>
+							<FrontendEngineFormProvider>{children}</FrontendEngineFormProvider>
+						</CustomComponentsProvider>
 					</FormValuesProvider>
 				</FormSchemaProvider>
 			</EventProvider>

--- a/src/context-providers/frontend-engine-form/context-provider.tsx
+++ b/src/context-providers/frontend-engine-form/context-provider.tsx
@@ -1,0 +1,30 @@
+import { Dispatch, ReactElement, SetStateAction, createContext, useState } from "react";
+
+interface IFrontendEngineFormContext {
+	submitHandler: () => void;
+	setSubmitHandler: Dispatch<SetStateAction<() => void>>;
+	wrapInForm: boolean;
+	setWrapInForm: Dispatch<SetStateAction<boolean>>;
+}
+
+interface IProps {
+	children: ReactElement;
+}
+
+export const FrontendEngineFormContext = createContext<IFrontendEngineFormContext>({
+	submitHandler: null,
+	setSubmitHandler: null,
+	wrapInForm: true,
+	setWrapInForm: null,
+});
+
+export const FrontendEngineFormProvider = ({ children }: IProps) => {
+	const [submitHandler, setSubmitHandler] = useState<() => void>(null);
+	const [wrapInForm, setWrapInForm] = useState(true);
+
+	return (
+		<FrontendEngineFormContext.Provider value={{ submitHandler, setSubmitHandler, wrapInForm, setWrapInForm }}>
+			{children}
+		</FrontendEngineFormContext.Provider>
+	);
+};

--- a/src/context-providers/frontend-engine-form/index.ts
+++ b/src/context-providers/frontend-engine-form/index.ts
@@ -1,0 +1,1 @@
+export * from "./context-provider";

--- a/src/context-providers/index.ts
+++ b/src/context-providers/index.ts
@@ -3,4 +3,5 @@ export * from "./custom-components";
 export * from "./event";
 export * from "./form-schema";
 export * from "./form-values";
+export * from "./frontend-engine-form";
 export * from "./yup";

--- a/src/stories/2-frontend-engine/frontend-engine.stories.tsx
+++ b/src/stories/2-frontend-engine/frontend-engine.stories.tsx
@@ -821,15 +821,6 @@ const MyCustomComponent: TCustomComponent<MyCustomSchema> = (props: TCustomCompo
 	};
 
 	return (
-		<FrontendEngine
-			data={DATA}
-			onChange={() => console.log("change")}
-			onSubmit={() => console.log("submit")}
-			wrapInForm={false}
-		/>
-	);
-
-	return (
 		<>
 			<Text.BodySmall style={{ marginBottom: "2rem" }}>{description}</Text.BodySmall>
 			<Form.Input

--- a/src/stories/2-frontend-engine/frontend-engine.stories.tsx
+++ b/src/stories/2-frontend-engine/frontend-engine.stories.tsx
@@ -10,7 +10,7 @@ import { TCustomComponentProps, TCustomComponentSchema } from "../../components"
 import { IFrontendEngineData, IFrontendEngineProps, IFrontendEngineRef } from "../../components/frontend-engine";
 import { TCustomComponent } from "../../context-providers";
 import { useFrontendEngineComponent } from "../../utils/hooks";
-import { FrontendEngine, SUBMIT_BUTTON_SCHEMA } from "../common";
+import { FrontendEngine, RESET_BUTTON_SCHEMA, SUBMIT_BUTTON_SCHEMA } from "../common";
 
 const meta: Meta = {
 	title: "Form/Frontend Engine",
@@ -47,6 +47,16 @@ const meta: Meta = {
 					summary: "string",
 				},
 			},
+		},
+		components: {
+			description:
+				"Custom components defined outside Frontend Engine. Key denotes referenceKey in schema while value is the component to be used",
+			table: {
+				type: {
+					summary: "TCustomComponents",
+				},
+			},
+			type: { name: "object", value: {} },
 		},
 		"data.className": {
 			description: "HTML class attribute that is applied on the `<form>` element",
@@ -181,6 +191,21 @@ const meta: Meta = {
 				type: "boolean",
 			},
 		},
+		wrapInForm: {
+			description:
+				"Indicates whether to wrap Frontend Engine fields within the `<form>` element, by default, fields will be rendered within the `<form>` element<br>When false, the fields will be rendered within the `<div>` element instead<br>This is for instances where Frontend Engine needs to be rendered within another <form> element",
+			table: {
+				type: {
+					summary: "boolean",
+				},
+				defaultValue: {
+					summary: "true",
+				},
+			},
+			control: {
+				type: "boolean",
+			},
+		},
 	},
 };
 export default meta;
@@ -239,6 +264,7 @@ const DATA: IFrontendEngineData = {
 					chipTexts: ["Best", "Good", "Bad", "Horrible"],
 				},
 				...SUBMIT_BUTTON_SCHEMA,
+				...RESET_BUTTON_SCHEMA,
 			},
 		},
 	},
@@ -306,7 +332,7 @@ export const ExternalSubmit: StoryFn<IFrontendEngineProps> = () => {
 
 	return (
 		<>
-			<FrontendEngine data={DATA} ref={ref} />
+			<FrontendEngine data={DATA} ref={ref} wrapInForm={false} />
 			<br />
 			<Button.Default styleType="secondary" onClick={handleClick}>
 				My custom submit button
@@ -795,6 +821,15 @@ const MyCustomComponent: TCustomComponent<MyCustomSchema> = (props: TCustomCompo
 	};
 
 	return (
+		<FrontendEngine
+			data={DATA}
+			onChange={() => console.log("change")}
+			onSubmit={() => console.log("submit")}
+			wrapInForm={false}
+		/>
+	);
+
+	return (
 		<>
 			<Text.BodySmall style={{ marginBottom: "2rem" }}>{description}</Text.BodySmall>
 			<Form.Input
@@ -836,6 +871,7 @@ export const CustomComponent: StoryFn<IFrontendEngineProps> = () => {
 						validation: [{ required: true }],
 					},
 					...SUBMIT_BUTTON_SCHEMA,
+					...RESET_BUTTON_SCHEMA,
 				},
 			},
 		},
@@ -847,9 +883,37 @@ export const CustomComponent: StoryFn<IFrontendEngineProps> = () => {
 			}}
 			data={json}
 			ref={ref}
+			onChange={(v) => console.log("outer change", v)}
+			onSubmit={(v) => console.log("outer submit", v)}
 		/>
 	);
 };
 CustomComponent.parameters = {
+	controls: { hideNoControlsWarning: true },
+};
+
+export const RenderWithoutForm: StoryFn<IFrontendEngineProps> = () => {
+	return (
+		<FrontendEngine
+			data={{
+				sections: {
+					section: {
+						uiType: "section",
+						children: {
+							intro: {
+								uiType: "div",
+								className: "margin--bottom",
+								children: "These fields are not rendered within the <form> element.",
+							},
+							...DATA.sections.section.children,
+						},
+					},
+				},
+			}}
+			wrapInForm={false}
+		/>
+	);
+};
+RenderWithoutForm.parameters = {
 	controls: { hideNoControlsWarning: true },
 };

--- a/src/utils/hooks/index.ts
+++ b/src/utils/hooks/index.ts
@@ -4,6 +4,7 @@ export * from "./use-field-event";
 export * from "./use-form-schema";
 export * from "./use-form-values";
 export * from "./use-frontend-engine-component";
+export * from "./use-frontend-engine-form";
 export * from "./use-previous";
 export * from "./use-validation-config";
 export * from "./use-validation-schema";

--- a/src/utils/hooks/use-frontend-engine-form.ts
+++ b/src/utils/hooks/use-frontend-engine-form.ts
@@ -1,0 +1,13 @@
+import { useContext } from "react";
+import { FrontendEngineFormContext } from "../../context-providers";
+
+export const useFrontendEngineForm = () => {
+	const { submitHandler, setSubmitHandler, wrapInForm, setWrapInForm } = useContext(FrontendEngineFormContext);
+
+	return {
+		submitHandler,
+		setSubmitHandler,
+		wrapInForm,
+		setWrapInForm,
+	};
+};


### PR DESCRIPTION
**Changes**
- new `wrapInForm` prop to indicate whether to wrap Frontend Engine fields within the `<form>` element (defaults to true)
- ensure submit button can submit values without the <form> element
- new `FrontendEngineFormProvider` to share props with the submit button to perform manual submission
- refactored to use `describe.each` test suite to cover events in various `wrapInForm` values
- delete branch

**Additional information**
- this is to support rendering `FrontendEngine` instances nested in other `FrontendEngine` instances
- because having nested `<form` element is not allowed, there is a need to prevent the rendering of form element
