### PR TITLE
Manually set soft validation errors (warnings)

### DIFF
--- a/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
+++ b/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
@@ -713,6 +713,42 @@ describe("frontend-engine", () => {
 		});
 	});
 
+	describe("setWarnings", () => {
+		it("should support setting of warnings", async () => {
+			const handleSetWarnings = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
+				try {
+					throw new Error("API error");
+				} catch (error) {
+					ref.current.setWarnings({
+						[FIELD_ONE_ID]: ERROR_MESSAGE,
+					});
+				}
+			};
+
+			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleSetWarnings} />);
+			await waitFor(() => fireEvent.click(getCustomButton()));
+
+			expect(screen.getByTestId(`${FIELD_ONE_ID}__warning`)).toHaveTextContent(ERROR_MESSAGE);
+		});
+
+		it("should support setting of warnings for nested fields", async () => {
+			const handleSetWarnings = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
+				try {
+					throw new Error("API error");
+				} catch (error) {
+					ref.current.setWarnings({
+						[FIELD_TWO_ID]: ERROR_MESSAGE,
+					});
+				}
+			};
+
+			render(<FrontendEngineWithCustomButton data={NESTED_JSON_SCHEMA} onClick={handleSetWarnings} />);
+			await waitFor(() => fireEvent.click(getCustomButton()));
+
+			expect(screen.getByTestId(`${FIELD_TWO_ID}__warning`)).toHaveTextContent(ERROR_MESSAGE);
+		});
+	});
+
 	describe("validationMode", () => {
 		it("should support validate on touched by default", async () => {
 			renderComponent();

--- a/src/components/elements/section/types.ts
+++ b/src/components/elements/section/types.ts
@@ -12,5 +12,4 @@ export interface ISectionSchema<V = undefined, C = undefined>
 export interface ISectionProps {
 	id: string;
 	sectionSchema: ISectionSchema;
-	warnings?: Record<string, string> | undefined;
 }

--- a/src/components/elements/sections/sections.tsx
+++ b/src/components/elements/sections/sections.tsx
@@ -18,7 +18,7 @@ export const Sections = (props: ISectionsProps) => {
 	// =============================================================================
 	// CONST, STATE, REF
 	// =============================================================================
-	const { schema, warnings } = props;
+	const { schema } = props;
 	const {
 		formSchema: { overrides },
 		overrideSchema,
@@ -31,7 +31,7 @@ export const Sections = (props: ISectionsProps) => {
 		const overriddenSchema = overrideSchema(schema, overrides);
 		if (overriddenSchema) {
 			return Object.entries(overriddenSchema).map(([id, section], i) => (
-				<Section key={`section-${i}`} id={id} sectionSchema={section} warnings={warnings} />
+				<Section key={`section-${i}`} id={id} sectionSchema={section} />
 			));
 		} else {
 			return (

--- a/src/components/elements/sections/types.ts
+++ b/src/components/elements/sections/types.ts
@@ -2,5 +2,4 @@ import { ISectionSchema } from "../section";
 
 export interface ISectionsProps {
 	schema?: Record<string, ISectionSchema> | undefined;
-	warnings?: Record<string, string> | undefined;
 }

--- a/src/components/elements/wrapper/types.ts
+++ b/src/components/elements/wrapper/types.ts
@@ -21,5 +21,4 @@ export interface IWrapperProps {
 		| Record<string, TFrontendEngineFieldSchema>
 		| Record<string, IFilterItemSchema | IFilterCheckboxSchema>
 		| undefined;
-	warnings?: Record<string, string> | undefined;
 }

--- a/src/components/elements/wrapper/wrapper.tsx
+++ b/src/components/elements/wrapper/wrapper.tsx
@@ -127,7 +127,11 @@ export const Wrapper = (props: IWrapperProps): JSX.Element | null => {
 		return (
 			<ColWrapper id={childId} childSchema={childSchema}>
 				<FieldWrapper id={childId} schema={childSchema} Field={Field} />
-				{warning && <DSAlert type="warning">{warning}</DSAlert>}
+				{warning && (
+					<DSAlert type="warning" data-testid={TestHelper.generateId(childId, "warning")}>
+						{warning}
+					</DSAlert>
+				)}
 			</ColWrapper>
 		);
 	};

--- a/src/components/elements/wrapper/wrapper.tsx
+++ b/src/components/elements/wrapper/wrapper.tsx
@@ -3,7 +3,12 @@ import React, { Fragment, ReactNode, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import * as FrontendEngineElements from "..";
 import { TestHelper } from "../../../utils";
-import { useCustomComponents, useFormSchema, useIsomorphicDeepLayoutEffect } from "../../../utils/hooks";
+import {
+	useCustomComponents,
+	useFormSchema,
+	useIsomorphicDeepLayoutEffect,
+	useValidationSchema,
+} from "../../../utils/hooks";
 import * as FrontendEngineCustomComponents from "../../custom";
 import { ECustomElementType, ECustomFieldType } from "../../custom";
 import { EElementType } from "../../elements";
@@ -24,8 +29,9 @@ export const Wrapper = (props: IWrapperProps): JSX.Element | null => {
 	// =============================================================================
 	// CONST, STATE, REF
 	// =============================================================================
-	const { id, schema, children, warnings } = props;
+	const { id, schema, children } = props;
 	const { showIf: _showIf, uiType, children: schemaChildren, ...otherSchema } = schema || {};
+	const { warnings } = useValidationSchema();
 
 	const [components, setComponents] = useState<React.ReactNode>(null);
 	const { control } = useFormContext();

--- a/src/components/frontend-engine/frontend-engine.tsx
+++ b/src/components/frontend-engine/frontend-engine.tsx
@@ -15,7 +15,14 @@ import {
 	useValidationSchema,
 } from "../../utils/hooks";
 import { Sections } from "../elements/sections";
-import { IFrontendEngineProps, IFrontendEngineRef, TErrorPayload, TFrontendEngineValues, TNoInfer } from "./types";
+import {
+	IFrontendEngineProps,
+	IFrontendEngineRef,
+	TErrorPayload,
+	TFrontendEngineValues,
+	TNoInfer,
+	TWarningPayload,
+} from "./types";
 
 const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>((props, ref) => {
 	// =============================================================================
@@ -34,7 +41,7 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 
 	const { addFieldEventListener, dispatchFieldEvent, removeFieldEventListener } = useFieldEvent();
 	const { setCustomComponents } = useCustomComponents();
-	const { warnings, performSoftValidation, softValidationSchema, hardValidationSchema } = useValidationSchema();
+	const { addWarnings, performSoftValidation, softValidationSchema, hardValidationSchema } = useValidationSchema();
 	const { formValidationConfig } = useValidationConfig();
 	const formMethods = useForm({
 		mode: validationMode,
@@ -82,6 +89,7 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 			}
 		},
 		setErrors,
+		setWarnings,
 		setValue,
 		submit: reactFormHookSubmit(handleSubmit, handleSubmitError),
 	}));
@@ -128,6 +136,19 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 				}
 			}
 		});
+	};
+
+	const setWarnings = (warningPayload: TWarningPayload) => {
+		const newWarnings: TWarningPayload = {};
+		Object.entries(warningPayload).forEach(([key, value]) => {
+			const isValidFieldKey = !!ObjectHelper.getNestedValueByKey(sections, key);
+			if (!isValidFieldKey) {
+				return;
+			}
+
+			newWarnings[key] = value;
+		});
+		addWarnings(newWarnings);
 	};
 
 	// =============================================================================
@@ -229,7 +250,7 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 				onSubmit={reactFormHookSubmit(handleSubmit, handleSubmitError)}
 				ref={ref}
 			>
-				<Sections warnings={warnings} schema={sections} />
+				<Sections schema={sections} />
 			</form>
 		</FormProvider>
 	);

--- a/src/components/frontend-engine/types.ts
+++ b/src/components/frontend-engine/types.ts
@@ -81,6 +81,7 @@ export type TValidationMode = keyof ValidationMode;
 export type TRestoreMode = "none" | "default-value" | "user-input";
 export type TErrorMessage = string | string[] | Record<string, string | string[]>;
 export type TErrorPayload = Record<string, TErrorMessage>;
+export type TWarningPayload = Record<string, string>;
 
 export interface IFrontendEngineRef extends HTMLFormElement {
 	addCustomValidation: (
@@ -120,8 +121,10 @@ export interface IFrontendEngineRef extends HTMLFormElement {
 	) => void;
 	/** resets the form to the default state */
 	reset: UseFormReset<TFrontendEngineValues>;
-	/** allows setting of custom errors thrown by endpoints */
+	/** allows setting of custom errors */
 	setErrors: (errors: TErrorPayload) => void;
+	/** allows setting of custom warnings */
+	setWarnings: (warnings: TWarningPayload) => void;
 	/** sets field value by id */
 	setValue: UseFormSetValue<TFrontendEngineValues>;
 	/** triggers form submission */

--- a/src/context-providers/yup/context-provider.tsx
+++ b/src/context-providers/yup/context-provider.tsx
@@ -1,9 +1,12 @@
 import { Dispatch, ReactElement, SetStateAction, createContext, useMemo, useState } from "react";
 import { TFormYupConfig } from "./types";
+import { TWarningPayload } from "../../components/frontend-engine";
 
 interface IYupContext {
 	formValidationConfig: TFormYupConfig;
 	setFormValidationConfig: Dispatch<SetStateAction<TFormYupConfig>>;
+	warnings: TWarningPayload;
+	setWarnings: Dispatch<SetStateAction<TWarningPayload>>;
 }
 
 interface IProps {
@@ -13,11 +16,17 @@ interface IProps {
 export const YupContext = createContext<IYupContext>({
 	formValidationConfig: null,
 	setFormValidationConfig: () => null,
+	warnings: null,
+	setWarnings: () => null,
 });
 
 export const YupProvider = ({ children }: IProps) => {
 	const [formValidationConfig, setFormValidationConfig] = useState<TFormYupConfig>();
-	const values = useMemo(() => ({ formValidationConfig, setFormValidationConfig }), [formValidationConfig]);
+	const [warnings, setWarnings] = useState<TWarningPayload>();
+	const values = useMemo(
+		() => ({ formValidationConfig, setFormValidationConfig, warnings, setWarnings }),
+		[formValidationConfig, warnings]
+	);
 
 	return <YupContext.Provider value={values}>{children}</YupContext.Provider>;
 };

--- a/src/stories/2-frontend-engine/frontend-engine.stories.tsx
+++ b/src/stories/2-frontend-engine/frontend-engine.stories.tsx
@@ -605,12 +605,49 @@ export const SetCustomErrors: StoryFn<IFrontendEngineProps> = () => {
 			/>
 			<br />
 			<Button.Default styleType="secondary" onClick={handleClick}>
-				Trigger API error upon submission
+				Trigger API error upon click
 			</Button.Default>
 		</>
 	);
 };
 SetCustomErrors.parameters = {
+	controls: { hideNoControlsWarning: true },
+};
+
+export const SetWarnings: StoryFn<IFrontendEngineProps> = () => {
+	const ref = useRef<IFrontendEngineRef>();
+	const handleClick = () => {
+		ref.current.setWarnings({ name: "Warning" });
+	};
+
+	return (
+		<>
+			<FrontendEngine
+				data={{
+					sections: {
+						section: {
+							uiType: "section",
+							children: {
+								name: {
+									label: "What is your name",
+									uiType: "text-field",
+								},
+								...SUBMIT_BUTTON_SCHEMA,
+							},
+						},
+					},
+					validationMode: "onSubmit",
+				}}
+				ref={ref}
+			/>
+			<br />
+			<Button.Default styleType="secondary" onClick={handleClick}>
+				Trigger warning upon click
+			</Button.Default>
+		</>
+	);
+};
+SetWarnings.parameters = {
 	controls: { hideNoControlsWarning: true },
 };
 

--- a/src/utils/hooks/use-validation-schema.ts
+++ b/src/utils/hooks/use-validation-schema.ts
@@ -2,7 +2,7 @@ import isEmpty from "lodash/isEmpty";
 import { useContext, useEffect, useState } from "react";
 import * as Yup from "yup";
 import { ObjectShape } from "yup/lib/object";
-import { TFrontendEngineValues } from "../../components/frontend-engine/types";
+import { TFrontendEngineValues, TWarningPayload } from "../../components/frontend-engine/types";
 import { IFieldYupConfig, TFormYupConfig, YupContext, YupHelper } from "../../context-providers";
 import { ObjectHelper } from "../object-helper";
 
@@ -10,10 +10,9 @@ import { ObjectHelper } from "../object-helper";
  * Hook that handles the generation of the validationSchema
  */
 export const useValidationSchema = () => {
-	const { formValidationConfig } = useContext(YupContext);
+	const { formValidationConfig, warnings, setWarnings } = useContext(YupContext);
 	const [hardValidationSchema, setHardValidationSchema] = useState<Yup.ObjectSchema<ObjectShape>>(Yup.object());
 	const [softValidationSchema, setSoftValidationSchema] = useState<Yup.ObjectSchema<ObjectShape>>(Yup.object());
-	const [warnings, setWarnings] = useState<Record<string, string>>({});
 
 	useEffect(() => {
 		if (formValidationConfig) {
@@ -76,10 +75,15 @@ export const useValidationSchema = () => {
 		}
 	};
 
+	const addWarnings = (warningPayload: TWarningPayload) => {
+		setWarnings({ ...warnings, ...warningPayload });
+	};
+
 	return {
 		warnings,
 		softValidationSchema,
 		hardValidationSchema,
 		performSoftValidation,
+		addWarnings,
 	};
 };


### PR DESCRIPTION
**Changes**
- new `setWarnings()` function to set soft validation errors manually
- store warnings in yup context provider to share its value to nested children
- delete branch

**Changelog entry**

-   New `setWarnings()` function to set soft validation errors manually

**Additional information**

- Meant to display warning for illegal parking use case where there is a 250m proximity requirement for photos
