### PR TITLE
[MISC][SW] add check to end recursive image compression

### DIFF
--- a/src/components/fields/image-upload/image-review/image-editor/image-editor.tsx
+++ b/src/components/fields/image-upload/image-review/image-editor/image-editor.tsx
@@ -60,7 +60,9 @@ export const ImageEditor = forwardRef((props: IImageEditorProps, ref: ForwardedR
 				}) || "";
 			const filesize = FileHelper.getFilesizeFromBase64(dataURL);
 
-			if (limit && filesize > limit) return toDataURLWithLimit(limit, quality - 0.05);
+			const reducedQuality = quality - 0.05;
+			if (reducedQuality < 0) return dataURL;
+			if (limit && filesize > limit) return toDataURLWithLimit(limit, reducedQuality);
 			return dataURL;
 		}
 		return "";


### PR DESCRIPTION
**Changes**
Had an error on local build where image cannot be compressed further, but the recursive compression kept being run with quality < 0.

according to [docs](https://fabricjs.com/docs/fabric.Canvas.html), `quality` prop value is 0-1.

added a check to stop recursive compression if quality is < 0

-   [delete] branch