### PR TITLE
add validate method to trigger validation

### DIFF
--- a/src/components/frontend-engine/frontend-engine.tsx
+++ b/src/components/frontend-engine/frontend-engine.tsx
@@ -76,6 +76,7 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 		getValues,
 		setValue,
 		setError,
+		trigger,
 		formState,
 		clearErrors,
 	} = formMethods;
@@ -93,6 +94,7 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 		getValues: (payload?: string | string[] | undefined) => getFormValues(payload, stripUnknown),
 		isDirty: formState.isDirty,
 		isValid: checkIsFormValid,
+		validate: trigger,
 		removeFieldEventListener,
 		reset: (values, options) => {
 			reset(values, options);

--- a/src/components/frontend-engine/types.ts
+++ b/src/components/frontend-engine/types.ts
@@ -127,6 +127,10 @@ export interface IFrontendEngineRef
 	isDirty: boolean;
 	/** checks if form is valid */
 	isValid: () => boolean;
+	/**
+	 * triggers validation in the form or for specific field
+	 */
+	validate: (name?: string | string[] | undefined) => Promise<boolean>;
 	/** adds custom validation rule */
 	removeFieldEventListener: <T = any>(
 		type: string,

--- a/src/stories/2-frontend-engine/frontend-engine.stories.tsx
+++ b/src/stories/2-frontend-engine/frontend-engine.stories.tsx
@@ -536,6 +536,34 @@ CheckIsValid.parameters = {
 	controls: { hideNoControlsWarning: true },
 };
 
+export const TriggerValidation: StoryFn<IFrontendEngineProps> = () => {
+	const ref = useRef<IFrontendEngineRef>();
+	const handleClick = (fields?: string | string[] | undefined) => {
+		ref.current.validate(fields);
+	};
+
+	return (
+		<>
+			<FrontendEngine data={DATA} ref={ref} />
+			<br />
+			<Button.Default styleType="secondary" onClick={() => handleClick("name")}>
+				Validate name only
+			</Button.Default>
+			<br />
+			<Button.Default styleType="secondary" onClick={() => handleClick(["name", "email"])}>
+				Validate name and email address only
+			</Button.Default>
+			<br />
+			<Button.Default styleType="secondary" onClick={() => handleClick()}>
+				Validate entire form
+			</Button.Default>
+		</>
+	);
+};
+TriggerValidation.parameters = {
+	controls: { hideNoControlsWarning: true },
+};
+
 export const CheckUserIntervention: StoryFn<IFrontendEngineProps> = () => {
 	const ref = useRef<IFrontendEngineRef>();
 	const handleClick = () => {


### PR DESCRIPTION
**Changes**
- new `validate()` to trigger validation
  - exposes react-hook-form's `trigger()` method
  - can trigger validation for the entire form / multiple fields / specific field

**Additional information**
- this fixes issues in the PCI form's duplicate name / identification number checks
- in the scenario there are 2 validation errors, e.g. format + duplicate errors, fixing the duplicate error is clearing ALL errors now
- with this enhancement, we will trigger validation for that field only in order to bring up the remaining error