### PR TITLE
add ability to pass error as object in setErrors

### DIFF
--- a/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
+++ b/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
@@ -889,36 +889,11 @@ describe("frontend-engine", () => {
 	});
 
 	describe("setErrors", () => {
-		const handleClickDefault = async (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			try {
-				throw new Error("API error");
-			} catch (error) {
-				ref.current.setErrors({
-					[FIELD_ONE_ID]: ERROR_MESSAGE,
-				});
-			}
+		const handleClickDefault = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
+			ref.current.setErrors({ [FIELD_ONE_ID]: ERROR_MESSAGE });
 		};
-
-		const handleClickArray = async (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			try {
-				throw new Error("API error");
-			} catch (error) {
-				ref.current.setErrors({
-					[FIELD_ONE_ID]: [ERROR_MESSAGE],
-				});
-			}
-		};
-
-		const handleClickNested = async (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			try {
-				throw new Error("API error");
-			} catch (error) {
-				ref.current.setErrors({
-					[FIELD_ONE_ID]: {
-						[FIELD_TWO_ID]: ERROR_MESSAGE,
-					},
-				});
-			}
+		const handleClickArray = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
+			ref.current.setErrors({ [FIELD_ONE_ID]: [ERROR_MESSAGE] });
 		};
 
 		it("should support setting of custom errors", async () => {
@@ -929,10 +904,31 @@ describe("frontend-engine", () => {
 		});
 
 		it("should support setting of custom errors for nested fields", async () => {
+			const handleClickNested = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
+				ref.current.setErrors({ [FIELD_ONE_ID]: { [FIELD_TWO_ID]: ERROR_MESSAGE } });
+			};
 			render(<FrontendEngineWithCustomButton data={NESTED_JSON_SCHEMA} onClick={handleClickNested} />);
 			await waitFor(() => fireEvent.click(getCustomButton()));
 
 			expect(getFieldTwo().parentElement.nextSibling.textContent).toMatch(ERROR_MESSAGE);
+		});
+
+		it("should convert error object to string if the direct descendants don't match any fields", async () => {
+			const handleClickNested = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
+				ref.current.setErrors({
+					[FIELD_ONE_ID]: {
+						something: "else",
+					},
+				});
+			};
+			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClickNested} />);
+			await waitFor(() => fireEvent.click(getCustomButton()));
+
+			expect(getFieldOne().parentElement.nextSibling.textContent).toMatch(
+				JSON.stringify({
+					something: "else",
+				})
+			);
 		});
 
 		it("should clear the error message related to API when the user edits the field", async () => {

--- a/src/components/frontend-engine/frontend-engine.tsx
+++ b/src/components/frontend-engine/frontend-engine.tsx
@@ -165,7 +165,16 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 			if (Array.isArray(value)) {
 				setError(key, { type: "api", message: value[0] });
 			} else if (typeof value === "object") {
-				setErrors(value as TErrorPayload);
+				const fieldSchema = ObjectHelper.getNestedValueByKey(data.sections, key);
+				const childKeys = Object.keys(value);
+				const haveNestedErrors = childKeys.every(
+					(childKey) => !isEmpty(ObjectHelper.getNestedValueByKey(fieldSchema, childKey))
+				);
+				if (!haveNestedErrors) {
+					setError(key, { type: "api", message: JSON.stringify(value) });
+				} else {
+					setErrors(value as TErrorPayload);
+				}
 			} else {
 				const errorObject = ObjectHelper.getNestedValueByKey(errors, key);
 				if (!isEmpty(errorObject)) {


### PR DESCRIPTION
- update `setErrors()` to allow passing of error as object
- object is stringified to fit RHF's setError signature
- it will be up to component to parse error object
- delete branch

**Additional information**
- this is for an upcoming enhancement to set error for individual image in `image-upload`