### PR TITLE
Apply file uploadResponse from default value

### DIFF
--- a/src/components/fields/file-upload/file-upload.tsx
+++ b/src/components/fields/file-upload/file-upload.tsx
@@ -119,13 +119,14 @@ export const FileUploadInner = (props: IGenericFieldProps<IFileUploadSchema>) =>
 		// for defaultValue
 		if (!isDirty && Array.isArray(value)) {
 			const newFiles: IFile[] = [];
-			(value as IFileUploadValue[]).forEach(({ dataURL, fileId, fileName, fileUrl }) => {
+			(value as IFileUploadValue[]).forEach(({ dataURL, fileId, fileName, fileUrl, uploadResponse }) => {
 				newFiles.push({
 					addedFrom: "schema",
 					dataURL,
 					fileItem: {
 						id: fileId,
 					} as FileItemProps,
+					uploadResponse,
 					fileUrl,
 					rawFile: {
 						name: fileName,


### PR DESCRIPTION
**Changes**

Ensure `uploadResponse` is populated if file is injected

-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Ensure `uploadResponse` is populated from default value for `file-upload`

**Additional info**

Example for testing:

```
export const MultipartUpload = DefaultStoryTemplate<IFileUploadSchema>("upload-multipart").bind({});
MultipartUpload.args = {
	...COMMON_STORY_ARGS,
	uploadOnAddingFile: {
		type: "multipart",
		url: "http://localhost:8080/file",
	},
	defaultValues: [
		{
			fileId: "iww8edcmbppi0x3vuaezkit770wmz4bbaj8g17mkhd7vx8g3q1ywtc",
			fileName: "test.png",
			fileUrl: "https://picsum.photos/id/237/200/300",
			uploadResponse: {
				data: {
					fileUrl: "https://picsum.photos/id/237/200/300",
					id: "3fe3ef72-1f19-45b4-a310-2d9785b95ad9",
				},
			},
		},
	],
};
```

Without the fix, the changed or submitted value is missing the `uploadResponse` field