### PR TITLE
[MOL-15190][SW] pass down addressFieldPlaceholder from schema

### DIFF
--- a/src/components/fields/location-field/location-field.tsx
+++ b/src/components/fields/location-field/location-field.tsx
@@ -40,6 +40,7 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 			hasExplicitEdit,
 			locationSelectionMode = "default",
 			disableSearch,
+			addressFieldPlaceholder,
 		},
 		// form values can initially be undefined when passed in via props
 		value: formValue,
@@ -181,6 +182,7 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 						mapBannerText={mapBannerText}
 						locationSelectionMode={locationSelectionMode}
 						disableSearch={disableSearch}
+						addressFieldPlaceholder={addressFieldPlaceholder}
 					/>
 				)}
 			</Suspense>

--- a/src/components/fields/location-field/location-modal/location-modal.tsx
+++ b/src/components/fields/location-field/location-modal/location-modal.tsx
@@ -47,6 +47,7 @@ const LocationModal = ({
 	locationListTitle,
 	locationSelectionMode,
 	disableSearch,
+	addressFieldPlaceholder,
 }: ILocationModalProps) => {
 	// =============================================================================
 	// CONST, STATE, REFS
@@ -450,6 +451,7 @@ const LocationModal = ({
 								restrictLocationSelection={locationSelectionMode === "pins-only"}
 								selectablePins={selectablePins}
 								disableSearch={disableSearch}
+								addressFieldPlaceholder={addressFieldPlaceholder}
 							/>
 							<StyledLocationPicker
 								id={id}

--- a/src/components/fields/location-field/location-modal/types.ts
+++ b/src/components/fields/location-field/location-modal/types.ts
@@ -11,6 +11,7 @@ export interface ILocationModalProps
 			| "mustHavePostalCode"
 			| "gettingCurrentLocationFetchMessage"
 			| "disableSearch"
+			| "addressFieldPlaceholder"
 		> {
 	id: string;
 	className: string;

--- a/src/components/fields/location-field/types.ts
+++ b/src/components/fields/location-field/types.ts
@@ -16,6 +16,7 @@ export interface ILocationFieldSchema<V = undefined>
 			| "gettingCurrentLocationFetchMessage"
 			| "hasExplicitEdit"
 			| "disableSearch"
+			| "addressFieldPlaceholder"
 		>,
 		Pick<ILocationInputProps, "locationInputPlaceholder" | "disabled" | "readOnly">,
 		Pick<IStaticMapProps, "staticMapPinColor">,


### PR DESCRIPTION
**Changes**
`addressFieldPlaceholder` can take in variable values but is not available in the schema typing.
added it to schema props and passed it down to `locationSearch`

-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Add addressFieldPlaceholder to location field schema

**Additional information**

-   You may refer to this [MOL-15190](https://jira.ship.gov.sg/browse/MOL-15190)
