### PR TITLE
Style HTML content

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The intention of frontend engine is to take out the heavy lifting of form develo
 
 Developers are expected to have the following packages installed:
 
--   @lifesg/react-design-system 2.5.0-canary.5
+-   @lifesg/react-design-system 2.6.0-canary.2
 -   @lifesg/react-icons 1.2.0
 -   react 17.0.2 or 18
 -   react-dom 17.0.2 or 18

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 				"@babel/preset-env": "^7.19.3",
 				"@babel/preset-react": "^7.18.6",
 				"@babel/preset-typescript": "^7.18.6",
-				"@lifesg/react-design-system": "^2.5.0-canary.5",
+				"@lifesg/react-design-system": "^2.6.0-canary.2",
 				"@lifesg/react-icons": "^1.2.0",
 				"@rollup/plugin-commonjs": "^22.0.2",
 				"@rollup/plugin-image": "^2.1.1",
@@ -95,7 +95,7 @@
 				"typescript": "^4.8.4"
 			},
 			"peerDependencies": {
-				"@lifesg/react-design-system": "^2.5.0-canary.5",
+				"@lifesg/react-design-system": "^2.6.0-canary.2",
 				"@lifesg/react-icons": "^1.2.0",
 				"react": "^17.0.2 || ^18.0.0",
 				"react-dom": "^17.0.2 || ^18.0.0",
@@ -3646,9 +3646,9 @@
 			"dev": true
 		},
 		"node_modules/@lifesg/react-design-system": {
-			"version": "2.5.0-canary.5",
-			"resolved": "https://registry.npmjs.org/@lifesg/react-design-system/-/react-design-system-2.5.0-canary.5.tgz",
-			"integrity": "sha512-SiAf5fB1ZM8rfT3uYxNEjuv1vF/RJP1iuWqy0Usa16Otz+3rqj5odXRzLkcHFQerlPG0QywgpqTMx5NTD0RQgg==",
+			"version": "2.6.0-canary.2",
+			"resolved": "https://registry.npmjs.org/@lifesg/react-design-system/-/react-design-system-2.6.0-canary.2.tgz",
+			"integrity": "sha512-0dhnMERnWzvqUl5E8gmHORT2VaWZ+fVj05VfqAVdZct+/U4rmabAJu9sfs6MPn9jp6YXFlHLgdasyJjewTHAbw==",
 			"dev": true,
 			"dependencies": {
 				"@floating-ui/dom": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"yup": "^0.32.11"
 	},
 	"peerDependencies": {
-		"@lifesg/react-design-system": "^2.5.0-canary.5",
+		"@lifesg/react-design-system": "^2.6.0-canary.2",
 		"@lifesg/react-icons": "^1.2.0",
 		"react": "^17.0.2 || ^18.0.0",
 		"react-dom": "^17.0.2 || ^18.0.0",
@@ -66,7 +66,7 @@
 		"@babel/preset-env": "^7.19.3",
 		"@babel/preset-react": "^7.18.6",
 		"@babel/preset-typescript": "^7.18.6",
-		"@lifesg/react-design-system": "^2.5.0-canary.5",
+		"@lifesg/react-design-system": "^2.6.0-canary.2",
 		"@lifesg/react-icons": "^1.2.0",
 		"@rollup/plugin-commonjs": "^22.0.2",
 		"@rollup/plugin-image": "^2.1.1",

--- a/src/__tests__/components/elements/alert/alert.spec.tsx
+++ b/src/__tests__/components/elements/alert/alert.spec.tsx
@@ -33,6 +33,15 @@ const renderComponent = (overrideField?: TOverrideField<IAlertSchema>, overrideS
 describe(UI_TYPE, () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
+		window.ResizeObserver = jest.fn().mockImplementation(() => ({
+			observe: jest.fn(),
+			unobserve: jest.fn(),
+			disconnect: jest.fn(),
+		}));
+	});
+
+	afterEach(() => {
+		window.ResizeObserver = ResizeObserver;
 	});
 
 	it("should be able to render the field", () => {

--- a/src/__tests__/components/fields/image-upload/image-upload.spec.tsx
+++ b/src/__tests__/components/fields/image-upload/image-upload.spec.tsx
@@ -142,6 +142,16 @@ describe("image-upload", () => {
 
 		jest.spyOn(FileHelper, "truncateFileName").mockImplementation((fileName) => fileName);
 		uploadSpy = jest.spyOn(AxiosApiClient.prototype, "post").mockResolvedValue({ id: 1 });
+
+		window.ResizeObserver = jest.fn().mockImplementation(() => ({
+			observe: jest.fn(),
+			unobserve: jest.fn(),
+			disconnect: jest.fn(),
+		}));
+	});
+
+	afterEach(() => {
+		window.ResizeObserver = ResizeObserver;
 	});
 
 	it("should be able to render the field", async () => {

--- a/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
+++ b/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
@@ -121,6 +121,15 @@ const renderComponent = (
 describe("frontend-engine", () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
+		window.ResizeObserver = jest.fn().mockImplementation(() => ({
+			observe: jest.fn(),
+			unobserve: jest.fn(),
+			disconnect: jest.fn(),
+		}));
+	});
+
+	afterEach(() => {
+		window.ResizeObserver = ResizeObserver;
 	});
 
 	it("should render a form with JSON provided", () => {

--- a/src/components/custom/filter/filter-checkbox/filter-checkbox.tsx
+++ b/src/components/custom/filter/filter-checkbox/filter-checkbox.tsx
@@ -60,7 +60,11 @@ export const FilterCheckbox = (props: IGenericCustomFieldProps<IFilterCheckboxSc
 			expanded={expandedState}
 			onExpandChange={setExpandedState}
 			onSelect={handleChange}
-			labelExtractor={(item) => <Sanitize sanitizeOptions={{ allowedAttributes: false }}>{item.label}</Sanitize>}
+			labelExtractor={(item) => (
+				<Sanitize inline sanitizeOptions={{ allowedAttributes: false }}>
+					{item.label}
+				</Sanitize>
+			)}
 		></Filter.Checkbox>
 	);
 };

--- a/src/components/elements/list/list-item.tsx
+++ b/src/components/elements/list/list-item.tsx
@@ -17,7 +17,7 @@ export const ListItem = (props: IGenericElementProps<IListItemSchema>) => {
 	// =============================================================================
 	const renderText = (): JSX.Element[] | JSX.Element => {
 		if (typeof children === "string") {
-			return <Sanitize>{children}</Sanitize>;
+			return <Sanitize inline>{children}</Sanitize>;
 		}
 		return <Wrapper>{children}</Wrapper>;
 	};

--- a/src/components/elements/list/list.tsx
+++ b/src/components/elements/list/list.tsx
@@ -24,7 +24,7 @@ export const List = (props: IGenericElementProps<IUnorderedListSchema | IOrdered
 			if (typeof childSchema === "string") {
 				return (
 					<li key={index}>
-						<Sanitize>{childSchema}</Sanitize>
+						<Sanitize inline>{childSchema}</Sanitize>
 					</li>
 				);
 			}

--- a/src/components/elements/text/text.tsx
+++ b/src/components/elements/text/text.tsx
@@ -64,7 +64,9 @@ export const Text = (props: IGenericElementProps<ITextSchema>) => {
 
 				return (
 					<Element key={index} id={childrenId} data-testid={getTestId(childrenId)}>
-						<Sanitize id={childrenId}>{text}</Sanitize>
+						<Sanitize id={childrenId} inline>
+							{text}
+						</Sanitize>
 					</Element>
 				);
 			});
@@ -87,7 +89,9 @@ export const Text = (props: IGenericElementProps<ITextSchema>) => {
 				// NOTE: Parent text body should be transformed into <div> to prevent validateDOMNesting error
 				{...(hasNestedFields() && { as: "div" })}
 			>
-				<Sanitize sanitizeOptions={{ allowedAttributes: false }}>{renderText()}</Sanitize>
+				<Sanitize inline sanitizeOptions={{ allowedAttributes: false }}>
+					{renderText()}
+				</Sanitize>
 			</Element>
 
 			{showExpandButton && (

--- a/src/components/elements/wrapper/field-wrapper.tsx
+++ b/src/components/elements/wrapper/field-wrapper.tsx
@@ -81,11 +81,11 @@ export const FieldWrapper = ({ Field, id, schema }: IProps) => {
 		const label: string | IComplexLabel = schema["label"];
 		if (typeof label === "string") {
 			return {
-				children: <Sanitize>{label}</Sanitize>,
+				children: <Sanitize inline>{label}</Sanitize>,
 			};
 		} else if (!!label && typeof label === "object" && label.mainLabel) {
 			return {
-				children: <Sanitize>{label.mainLabel}</Sanitize>,
+				children: <Sanitize inline>{label.mainLabel}</Sanitize>,
 				subtitle: <StyledSublabel className="sub-label">{label.subLabel}</StyledSublabel>,
 				// acccept tooltip type when it's ready
 				addon: label.hint?.content

--- a/src/components/fields/checkbox-group/checkbox-group.tsx
+++ b/src/components/fields/checkbox-group/checkbox-group.tsx
@@ -124,7 +124,7 @@ export const CheckboxGroup = (props: IGenericFieldProps<TCheckboxGroupSchema>) =
 							onChange={() => handleChange(option.value)}
 						/>
 						<Label as="label" htmlFor={checkboxId} disabled={disabled ?? option.disabled}>
-							<Sanitize>{option.label}</Sanitize>
+							<Sanitize inline>{option.label}</Sanitize>
 						</Label>
 					</CheckboxContainer>
 				);

--- a/src/components/fields/image-upload/image-input/image-input.styles.ts
+++ b/src/components/fields/image-upload/image-input/image-input.styles.ts
@@ -2,7 +2,7 @@ import { Alert } from "@lifesg/react-design-system/alert";
 import { Button } from "@lifesg/react-design-system/button";
 import { Color } from "@lifesg/react-design-system/color";
 import { MediaQuery } from "@lifesg/react-design-system/media";
-import { Text } from "@lifesg/react-design-system/text";
+import { Text, TextStyleHelper } from "@lifesg/react-design-system/text";
 import styled from "styled-components";
 
 export interface SubtitleProps {
@@ -26,7 +26,8 @@ export const Subtitle = styled(Text.Body)<SubtitleProps>`
 	margin-bottom: ${(props) => (props.$hasDescription ? "0.5rem" : "1rem")};
 `;
 
-export const Content = styled(Text.BodySmall)`
+export const Content = styled.div`
+	${TextStyleHelper.getTextStyle("BodySmall", "regular")}
 	margin-bottom: 1.5rem;
 	color: ${Color.Neutral[4]};
 `;

--- a/src/components/fields/radio-button/radio-button.tsx
+++ b/src/components/fields/radio-button/radio-button.tsx
@@ -96,7 +96,7 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 							onChange={() => handleChangeOrClick(option.value)}
 						/>
 						<Label as="label" htmlFor={radioButtonId} disabled={disabled ?? option.disabled}>
-							<Sanitize>{option.label}</Sanitize>
+							<Sanitize inline>{option.label}</Sanitize>
 						</Label>
 					</RadioContainer>
 				);

--- a/src/components/shared/sanitize/sanitize.tsx
+++ b/src/components/shared/sanitize/sanitize.tsx
@@ -1,11 +1,15 @@
+import { Markup, MarkupProps } from "@lifesg/react-design-system/markup";
 import { renderToStaticMarkup } from "react-dom/server";
 import sanitize, { IOptions } from "sanitize-html";
 import { TestHelper } from "../../../utils";
 
 interface IProps {
+	baseTextColor?: MarkupProps["baseTextColor"] | undefined;
+	baseTextSize?: MarkupProps["baseTextSize"] | undefined;
 	children: string | React.ReactNode;
 	className?: string | undefined;
 	id?: string | undefined;
+	inline?: boolean | undefined;
 	sanitizeOptions?: IOptions;
 }
 
@@ -13,7 +17,7 @@ export const Sanitize = (props: IProps) => {
 	// =============================================================================
 	// CONST, STATE, REF
 	// =============================================================================
-	const { children, className, id, sanitizeOptions } = props;
+	const { baseTextColor, baseTextSize, children, className, id, inline, sanitizeOptions } = props;
 
 	// =============================================================================
 	// HELPER FUNCTIONS
@@ -40,7 +44,10 @@ export const Sanitize = (props: IProps) => {
 	// RENDER FUNCTIONS
 	// =============================================================================
 	return (
-		<span
+		<Markup
+			baseTextColor={baseTextColor}
+			baseTextSize={baseTextSize}
+			inline={inline}
 			id={formatId()}
 			className={className}
 			data-testid={formatId()}

--- a/src/stories/3-fields/image-upload/image-upload.stories.tsx
+++ b/src/stories/3-fields/image-upload/image-upload.stories.tsx
@@ -219,7 +219,7 @@ export const HTMLDescription = DefaultStoryTemplate<IImageUploadSchema>("upload-
 HTMLDescription.args = {
 	label: "Provide images",
 	uiType: "image-upload",
-	description: "<span>Testing<br>&#x2022; Testing<br>&#x2022; Testing</span>",
+	description: "Testing<ul><li>Testing</li><li>Testing</li></span>",
 };
 
 export const Dimensions = DefaultStoryTemplate<IImageUploadSchema>("upload-dimensions").bind({});


### PR DESCRIPTION
**Changes**

- use `Markup` to style parsed HTML content using the sanitize component
- this supports theming for link color etc.
-  [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Apply default styling for HTML string children

**Additional information**

-   You may refer to this [ticket](https://jira.ship.gov.sg/browse/CCUBE-1360)