### PR TITLE
Conditional validation fixes

### DIFF
--- a/src/__tests__/components/frontend-engine/yup/yup-helper.spec.ts
+++ b/src/__tests__/components/frontend-engine/yup/yup-helper.spec.ts
@@ -304,6 +304,31 @@ describe("YupHelper", () => {
 			expect(() => schema.validateSync(value)).not.toThrowError();
 		});
 
+		it("should run non conditional validation rules regardless whether conditional validation is fulfilled or not", () => {
+			const schema = Yup.object().shape({
+				field1: YupHelper.mapRules(YupHelper.mapSchemaType("string"), [
+					{ min: 5, errorMessage: ERROR_MESSAGE },
+					{
+						when: {
+							field2: {
+								is: [{ filled: true }],
+								then: [{ max: 15, errorMessage: ERROR_MESSAGE_2 }],
+								otherwise: [{ max: 10, errorMessage: ERROR_MESSAGE_3 }],
+								yupSchema: YupHelper.mapSchemaType("string"),
+							},
+						},
+					},
+				]),
+			});
+
+			expect(TestHelper.getError(() => schema.validateSync({ field1: "hi", field2: "hi" })).message).toBe(
+				ERROR_MESSAGE
+			);
+			expect(TestHelper.getError(() => schema.validateSync({ field1: "hi", field2: undefined })).message).toBe(
+				ERROR_MESSAGE
+			);
+		});
+
 		it("should be able to support nested conditional validation", () => {
 			const schema = Yup.object().shape({
 				field1: YupHelper.mapRules(YupHelper.mapSchemaType("string"), [

--- a/src/components/fields/types.ts
+++ b/src/components/fields/types.ts
@@ -106,7 +106,7 @@ export interface IBaseFieldSchema<T, V = undefined, U = undefined> {
 	 * - in order for an object to be valid, need to fulfil all conditions in that object (AND condition) */
 	showIf?: TRenderRules[] | undefined;
 	/** validation config, can be customised by passing generics */
-	validation?: (V | U | IYupValidationRule)[];
+	validation?: (V | U | IYupValidationRule<V, U>)[];
 	/** escape hatch for other form / frontend engines to have unsupported attributes */
 	customOptions?: Record<string, unknown> | undefined;
 	/** set responsive columns */

--- a/src/context-providers/yup/helper.ts
+++ b/src/context-providers/yup/helper.ts
@@ -200,13 +200,9 @@ export namespace YupHelper {
 					{
 						Object.keys(rule.when).forEach((fieldId) => {
 							const isRule = rule.when[fieldId].is;
-							const thenRule = mapRules(
-								mapSchemaType(yupSchema.type as TYupSchemaType),
-								rule.when[fieldId].then
-							);
+							const thenRule = mapRules(yupSchema, rule.when[fieldId].then);
 							const otherwiseRule =
-								rule.when[fieldId].otherwise &&
-								mapRules(mapSchemaType(yupSchema.type as TYupSchemaType), rule.when[fieldId].otherwise);
+								rule.when[fieldId].otherwise && mapRules(yupSchema, rule.when[fieldId].otherwise);
 
 							if (Array.isArray(isRule) && (isRule as unknown[]).every((r) => typeof r === "object")) {
 								yupSchema = yupSchema.when(fieldId, (value: unknown) => {

--- a/src/context-providers/yup/types.ts
+++ b/src/context-providers/yup/types.ts
@@ -50,14 +50,19 @@ interface IYupRule {
 	equalsField?: unknown | undefined;
 }
 
-export interface IYupValidationRule extends IYupRule {
+/**
+ * V and U generics are needed here to be passed into `then` and `otherwise` conditional validation
+ * `V` - custom validation rules
+ * `U` - custom validation rules defined by components, for internal use, prevents getting overwritten by custom validation rules
+ */
+export interface IYupValidationRule<V = undefined, U = undefined> extends IYupRule {
 	required?: boolean | undefined;
 	when?:
 		| {
 				[id: string]: {
 					is: string | number | boolean | string[] | number[] | boolean[] | IYupConditionalValidationRule[];
-					then: IYupValidationRule[];
-					otherwise?: Omit<IYupValidationRule, "when">[];
+					then: (IYupValidationRule<V, U> | V | U)[];
+					otherwise?: (Omit<IYupValidationRule<V, U>, "when"> | V | U)[];
 					yupSchema?: Yup.AnySchema | undefined;
 				};
 		  }


### PR DESCRIPTION
**Changes**
- added generics to `IYupValidationRule` to inherit custom validation typings for `then` and `otherwise` rules
- fixed issue with non-conditional validation rules not running when there are conditional validation rules
- delete branch

**Changelog entry**
-   `then` and `otherwise` conditional validation typings now inherits custom validation typings
-   Ensure non-conditional validation rules can still work together with conditional validation rules  

