### PR TITLE
[MOL-15191][SW] only handle default values for images  and files on f…

### DIFF
--- a/src/__tests__/components/fields/image-upload/image-upload.spec.tsx
+++ b/src/__tests__/components/fields/image-upload/image-upload.spec.tsx
@@ -214,6 +214,10 @@ describe("image-upload", () => {
 							fileName: FILE_1.name,
 							dataURL: JPG_BASE64,
 						},
+						{
+							fileName: FILE_2.name,
+							dataURL: JPG_BASE64,
+						},
 					],
 				},
 			},
@@ -223,7 +227,7 @@ describe("image-upload", () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 		});
 
-		expect(SUBMIT_FN).toBeCalledWith(
+		expect(SUBMIT_FN).toHaveBeenCalledWith(
 			expect.objectContaining({
 				field: expect.arrayContaining([
 					expect.objectContaining({
@@ -287,7 +291,7 @@ describe("image-upload", () => {
 			it("should submit as many base64 and upload response", async () => {
 				await waitFor(() => fireEvent.click(getSubmitButton()));
 
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({
 						field: expect.arrayContaining([
 							expect.objectContaining({
@@ -330,7 +334,7 @@ describe("image-upload", () => {
 			it("should submit base64 and upload response up to max number of images", async () => {
 				await waitFor(() => fireEvent.click(getSubmitButton()));
 
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({
 						field: expect.arrayContaining([
 							expect.objectContaining({
@@ -363,7 +367,7 @@ describe("image-upload", () => {
 
 			it("should submit only the valid files", async () => {
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({
 						field: expect.arrayContaining([
 							expect.objectContaining({
@@ -393,7 +397,7 @@ describe("image-upload", () => {
 			it("should submit only the valid files", async () => {
 				await waitFor(() => fireEvent.click(getSubmitButton()));
 
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({
 						field: expect.arrayContaining([
 							expect.objectContaining({
@@ -428,7 +432,7 @@ describe("image-upload", () => {
 			it("should submit only the valid files", async () => {
 				await waitFor(() => fireEvent.click(getSubmitButton()));
 
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({
 						field: expect.arrayContaining([
 							expect.objectContaining({
@@ -943,7 +947,7 @@ describe("image-upload", () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 			expect(screen.queryByText(FILE_1.name)).not.toBeInTheDocument();
 			expect(screen.queryByText(FILE_2.name)).not.toBeInTheDocument();
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
 		});
 
 		it("should revert to default value on reset", async () => {
@@ -972,7 +976,7 @@ describe("image-upload", () => {
 
 			expect(screen.getByText(FILE_1.name)).toBeInTheDocument();
 			expect(screen.queryByText(FILE_2.name)).not.toBeInTheDocument();
-			expect(SUBMIT_FN).toBeCalledWith(
+			expect(SUBMIT_FN).toHaveBeenCalledWith(
 				expect.objectContaining({
 					field: expect.arrayContaining([
 						expect.objectContaining({

--- a/src/components/fields/file-upload/file-upload-manager.ts
+++ b/src/components/fields/file-upload/file-upload-manager.ts
@@ -61,6 +61,7 @@ const FileUploadManager = (props: IProps) => {
 			// track / update values
 			const uploadedFiles = files.filter(({ status }) => status === EFileStatus.UPLOADED);
 			const notPrefilledFiles = uploadedFiles.filter(({ addedFrom }) => addedFrom !== "schema");
+			const hasNotPrefilledFiles = notPrefilledFiles.length > 0;
 			const gotDeleteFiles = files.filter(({ status }) => status === EFileStatus.TO_DELETE).length > 0;
 
 			/**
@@ -69,7 +70,7 @@ const FileUploadManager = (props: IProps) => {
 			 * - there are non-prefilled files
 			 * - user deleted file (differentiated from reset)
 			 */
-			const shouldDirty = notPrefilledFiles.length > 0 || gotDeleteFiles;
+			const shouldDirty = hasNotPrefilledFiles || gotDeleteFiles;
 
 			setValue(
 				id,
@@ -80,7 +81,7 @@ const FileUploadManager = (props: IProps) => {
 					fileUrl,
 					uploadResponse,
 				})),
-				{ shouldDirty }
+				{ shouldDirty, shouldTouch: hasNotPrefilledFiles }
 			);
 		}, // eslint-disable-next-line react-hooks/exhaustive-deps
 		[files.map(({ fileItem, status }) => `${fileItem?.id}-${status}`).join(",")]

--- a/src/components/fields/file-upload/file-upload-manager.ts
+++ b/src/components/fields/file-upload/file-upload-manager.ts
@@ -74,12 +74,13 @@ const FileUploadManager = (props: IProps) => {
 
 			setValue(
 				id,
-				uploadedFiles.map(({ dataURL, fileItem, fileUrl, uploadResponse }) => ({
+				uploadedFiles.map(({ dataURL, fileItem, fileUrl, uploadResponse, addedFrom }) => ({
 					...(upload.type === "base64" ? { dataURL } : {}),
 					fileId: fileItem.id,
 					fileName: fileItem.name,
 					fileUrl,
 					uploadResponse,
+					handledFromDefault: addedFrom === "schema",
 				})),
 				{ shouldDirty, shouldTouch: hasNotPrefilledFiles }
 			);
@@ -92,8 +93,7 @@ const FileUploadManager = (props: IProps) => {
 		if (previousValue !== undefined && value === undefined && files.length) {
 			setFiles([]);
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [previousValue === undefined, value === undefined, files.length]);
+	}, [files, previousValue, setFiles, value]);
 
 	// =============================================================================
 	// HELPER FUNCTIONS

--- a/src/components/fields/file-upload/file-upload.tsx
+++ b/src/components/fields/file-upload/file-upload.tsx
@@ -140,9 +140,13 @@ export const FileUploadInner = (props: IGenericFieldProps<IFileUploadSchema>) =>
 
 	useEffect(() => {
 		// for defaultValue
-		if (!isDirty && !isTouched && Array.isArray(value) && value.length > 0) {
+		const filesToHandle = Array.isArray(value)
+			? (value as IFileUploadValue[]).filter(({ handledFromDefault }) => !handledFromDefault)
+			: [];
+
+		if (!isDirty && filesToHandle.length > 0) {
 			const newFiles: IFile[] = [];
-			(value as IFileUploadValue[]).forEach(({ dataURL, fileId, fileName, fileUrl, uploadResponse }) => {
+			filesToHandle.forEach(({ dataURL, fileId, fileName, fileUrl, uploadResponse }) => {
 				newFiles.push({
 					addedFrom: "schema",
 					dataURL,
@@ -160,7 +164,7 @@ export const FileUploadInner = (props: IGenericFieldProps<IFileUploadSchema>) =>
 			});
 			handleNewFiles(newFiles, []);
 		}
-	}, [handleNewFiles, isDirty, isTouched, value]);
+	}, [handleNewFiles, isDirty, value]);
 
 	// =============================================================================
 	// EVENT HANDLERS

--- a/src/components/fields/file-upload/types.ts
+++ b/src/components/fields/file-upload/types.ts
@@ -52,4 +52,10 @@ export interface IFileUploadValue {
 	fileName: string;
 	fileUrl?: string | undefined;
 	uploadResponse?: unknown | undefined;
+	/**
+	 * for internal use only. DO NOT pass this into default schema
+	 *
+	 * this is so that the form hook can differentiate the default from current value
+	 */
+	handledFromDefault?: boolean;
 }

--- a/src/components/fields/image-upload/image-manager/image-manager.ts
+++ b/src/components/fields/image-upload/image-manager/image-manager.ts
@@ -183,7 +183,8 @@ export const ImageManager = (props: IProps) => {
 		 * - there are non-prefilled images
 		 * - user deleted image (differentiated from reset)
 		 */
-		const shouldDirty = notPrefilledImages.length > 0 || gotDeleteImages;
+		const hasNotPrefilledImages = notPrefilledImages.length > 0;
+		const shouldDirty = hasNotPrefilledImages || gotDeleteImages;
 
 		setValue(
 			id,
@@ -192,7 +193,7 @@ export const ImageManager = (props: IProps) => {
 				dataURL: drawingDataURL || dataURL,
 				uploadResponse,
 			})),
-			{ shouldDirty }
+			{ shouldDirty, shouldTouch: hasNotPrefilledImages }
 		);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [images.map((image) => image.status).join(",")]);

--- a/src/components/fields/image-upload/image-manager/image-manager.ts
+++ b/src/components/fields/image-upload/image-manager/image-manager.ts
@@ -61,7 +61,7 @@ export const ImageManager = (props: IProps) => {
 
 		addFieldEventListener("update-image-status", id, handleUpdateImageStatus);
 		return () => removeFieldEventListener("update-image-status", id, handleUpdateImageStatus);
-	}, []);
+	}, [addFieldEventListener, id, removeFieldEventListener, setImages]);
 
 	// generate pseudo-random session id
 	useEffect(() => {

--- a/src/components/fields/image-upload/image-manager/image-manager.ts
+++ b/src/components/fields/image-upload/image-manager/image-manager.ts
@@ -35,10 +35,10 @@ export const ImageManager = (props: IProps) => {
 	const { accepts, compress, dimensions, editImage, id, maxSizeInKb, outputType, upload, value } = props;
 	const { images, setImages, setErrorCount } = useContext(ImageContext);
 	const previousImages = usePrevious(images);
-	const [managerErrorCount, setManagerErrorCount] = useState(0);
 	const previousValue = usePrevious(value);
 	const { setValue } = useFormContext();
 	const sessionId = useRef<string>();
+	const managerErrorCount = useRef(0);
 
 	const { dispatchFieldEvent, addFieldEventListener, removeFieldEventListener } = useFieldEvent();
 
@@ -168,8 +168,8 @@ export const ImageManager = (props: IProps) => {
 				updatedManagerErrorCount++;
 			}
 		});
-		setErrorCount((prev) => Math.max(0, prev + updatedManagerErrorCount - managerErrorCount));
-		setManagerErrorCount(updatedManagerErrorCount);
+		setErrorCount((prev) => Math.max(0, prev + updatedManagerErrorCount - managerErrorCount.current));
+		managerErrorCount.current = updatedManagerErrorCount;
 
 		const uploadedImages = images.filter(
 			({ status }) => status === EImageStatus.UPLOADED || status === EImageStatus.ERROR_CUSTOM_MUTED
@@ -188,15 +188,15 @@ export const ImageManager = (props: IProps) => {
 
 		setValue(
 			id,
-			uploadedImages.map(({ dataURL, drawingDataURL, name, uploadResponse }) => ({
+			uploadedImages.map(({ dataURL, drawingDataURL, name, uploadResponse, addedFrom }) => ({
 				fileName: name,
 				dataURL: drawingDataURL || dataURL,
 				uploadResponse,
+				handledFromDefault: addedFrom === "schema",
 			})),
 			{ shouldDirty, shouldTouch: hasNotPrefilledImages }
 		);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [images.map((image) => image.status).join(",")]);
+	}, [accepts, id, images, setErrorCount, setValue]);
 
 	useEffect(() => {
 		if (previousValue !== undefined && value === undefined && images.length) {

--- a/src/components/fields/image-upload/image-upload.tsx
+++ b/src/components/fields/image-upload/image-upload.tsx
@@ -40,7 +40,6 @@ export const ImageUploadInner = (props: IGenericFieldProps<IImageUploadSchema>) 
 		},
 		id,
 		isDirty,
-		isTouched,
 		value,
 		...otherProps
 	} = props;
@@ -65,9 +64,12 @@ export const ImageUploadInner = (props: IGenericFieldProps<IImageUploadSchema>) 
 
 	useEffect(() => {
 		// for `defaultValue`
-		if (!isDirty && !isTouched && Array.isArray(value) && value.length > 0) {
+		const valuesToHandle = Array.isArray(value)
+			? (value as IUploadedImage[]).filter(({ handledFromDefault }) => !handledFromDefault)
+			: [];
+		if (!isDirty && valuesToHandle.length > 0) {
 			const newImages: IImage[] = [];
-			(value as IUploadedImage[]).forEach(({ fileName, dataURL, uploadResponse }, i) => {
+			valuesToHandle.forEach(({ fileName, dataURL, uploadResponse }, i) => {
 				const newImage: IImage = {
 					id: generateRandomId(),
 					file: {} as File,
@@ -84,7 +86,7 @@ export const ImageUploadInner = (props: IGenericFieldProps<IImageUploadSchema>) 
 			});
 			setImages(newImages);
 		}
-	}, [isDirty, isTouched, setImages, value]);
+	}, [isDirty, setImages, value]);
 
 	useEffect(() => {
 		const isRequiredRule = validation?.find((rule) => "required" in rule);

--- a/src/components/fields/image-upload/image-upload.tsx
+++ b/src/components/fields/image-upload/image-upload.tsx
@@ -40,6 +40,7 @@ export const ImageUploadInner = (props: IGenericFieldProps<IImageUploadSchema>) 
 		},
 		id,
 		isDirty,
+		isTouched,
 		value,
 		...otherProps
 	} = props;
@@ -60,11 +61,11 @@ export const ImageUploadInner = (props: IGenericFieldProps<IImageUploadSchema>) 
 	// =============================================================================
 	useEffect(() => {
 		dispatchFieldEvent("mount", id);
-	}, []);
+	}, [dispatchFieldEvent, id]);
 
 	useEffect(() => {
 		// for `defaultValue`
-		if (!isDirty && Array.isArray(value)) {
+		if (!isDirty && !isTouched && Array.isArray(value) && value.length > 0) {
 			const newImages: IImage[] = [];
 			(value as IUploadedImage[]).forEach(({ fileName, dataURL, uploadResponse }, i) => {
 				const newImage: IImage = {
@@ -83,8 +84,7 @@ export const ImageUploadInner = (props: IGenericFieldProps<IImageUploadSchema>) 
 			});
 			setImages(newImages);
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [isDirty]);
+	}, [isDirty, isTouched, setImages, value]);
 
 	useEffect(() => {
 		const isRequiredRule = validation?.find((rule) => "required" in rule);

--- a/src/components/fields/image-upload/types.ts
+++ b/src/components/fields/image-upload/types.ts
@@ -94,6 +94,12 @@ export interface IUploadedImage {
 	dataURL: string;
 	fileName: string;
 	uploadResponse?: any;
+	/**
+	 * for internal use only. DO NOT pass this into default schema
+	 *
+	 * this is so that the form hook can differentiate the default from current value
+	 */
+	handledFromDefault?: boolean;
 }
 
 export interface IDismissReviewModalEvent {


### PR DESCRIPTION
`useEffect` to handle default values is supposed to only run on first load (if `is not dirty`)
however, if default value is exactly the same as the current form value, it is treated as not dirty even if there were new images added and removed.

solution is to add a new key to the value to determine if it has already been handled as default. (it also ensures that the handled value and the default value are never congruent)

* previous solution was to set `touched` status on adding new images (on top of the default) and only run the initial `useEffect` if not dirty and not touched. however, with the above fix, there is no need to check for `touched` status anymore. however, left in setting of `touched` just as 'correctness'

since file upload is implemented with the same logic, have applied the changes there too

**Changes**
Description of changes...

-   [delete] branch

<!-- Remove if not required -->
