### PR TITLE
Ensure custom schema typing is still inherited when nested in other schemas

### DIFF
--- a/src/components/custom/filter/filter-item/types.ts
+++ b/src/components/custom/filter/filter-item/types.ts
@@ -3,9 +3,9 @@ import { ICustomElementJsonSchema } from "../../types";
 import { TClearBehavior } from "../filter/types";
 import { IFilterItemLabel } from "../types";
 
-export interface IFilterItemSchema<V = undefined> extends ICustomElementJsonSchema<"filter-item"> {
+export interface IFilterItemSchema<V = undefined, C = undefined> extends ICustomElementJsonSchema<"filter-item"> {
 	label: string | IFilterItemLabel;
-	children: Record<string, TFrontendEngineFieldSchema<V>>;
+	children: Record<string, TFrontendEngineFieldSchema<V, C>>;
 	collapsible?: boolean | undefined;
 	showDivider?: boolean | undefined;
 	showMobileDivider?: boolean | undefined;

--- a/src/components/custom/filter/filter/types.ts
+++ b/src/components/custom/filter/filter/types.ts
@@ -2,10 +2,10 @@ import { ICustomElementJsonSchema } from "../../types";
 import { IFilterCheckboxSchema } from "../filter-checkbox/types";
 import { IFilterItemSchema } from "../filter-item/types";
 
-export interface IFilterSchema extends ICustomElementJsonSchema<"filter"> {
+export interface IFilterSchema<V = undefined, C = undefined> extends ICustomElementJsonSchema<"filter"> {
 	label?: string | undefined;
 	toggleFilterButtonLabel?: string | undefined;
-	children: Record<string, IFilterItemSchema | IFilterCheckboxSchema>;
+	children: Record<string, IFilterItemSchema<V, C> | IFilterCheckboxSchema>;
 	clearButtonDisabled?: boolean | undefined;
 }
 

--- a/src/components/custom/types.ts
+++ b/src/components/custom/types.ts
@@ -28,7 +28,11 @@ export enum ECustomFieldType {
 /**
  * union type to represent all custom elements / fields schema
  */
-export type TCustomSchema<C = undefined> = ICustomElementJsonSchema<string> | IFilterSchema | TReviewSchema | C;
+export type TCustomSchema<V = undefined, C = undefined> =
+	| ICustomElementJsonSchema<string>
+	| IFilterSchema<V, C>
+	| TReviewSchema
+	| C;
 
 /**
  * base schema for custom elements

--- a/src/components/elements/grid/types.ts
+++ b/src/components/elements/grid/types.ts
@@ -2,8 +2,8 @@ import { ContainerProps } from "@lifesg/react-design-system/layout";
 import { TComponentOmitProps, TFrontendEngineFieldSchema } from "../../frontend-engine";
 import { IBaseElementSchema } from "../types";
 
-export interface IGridSchema<V = undefined>
+export interface IGridSchema<V = undefined, C = undefined>
 	extends Omit<IBaseElementSchema<"grid">, "label">,
 		TComponentOmitProps<ContainerProps, "children" | "stretch" | "type"> {
-	children: Record<string, TFrontendEngineFieldSchema<V>>;
+	children: Record<string, TFrontendEngineFieldSchema<V, C>>;
 }

--- a/src/components/elements/list/types.ts
+++ b/src/components/elements/list/types.ts
@@ -3,20 +3,20 @@ import { TComponentOmitProps, TFrontendEngineFieldSchema } from "../../frontend-
 import { IBaseElementSchema } from "../types";
 import { IWrapperSchema } from "../wrapper";
 
-export interface IUnorderedListSchema<V = undefined>
+export interface IUnorderedListSchema<V = undefined, C = undefined>
 	extends IBaseElementSchema<"unordered-list">,
 		TComponentOmitProps<UnorderedListProps, "children"> {
-	children: (string | Record<string, IListItemSchema<V>>)[];
+	children: (string | Record<string, IListItemSchema<V, C>>)[];
 }
 
-export interface IOrderedListSchema<V = undefined>
+export interface IOrderedListSchema<V = undefined, C = undefined>
 	extends IBaseElementSchema<"ordered-list">,
 		TComponentOmitProps<OrderedListProps, "children"> {
-	children: (string | Record<string, IListItemSchema<V>>)[];
+	children: (string | Record<string, IListItemSchema<V, C>>)[];
 }
 
-export interface IListItemSchema<V = undefined>
+export interface IListItemSchema<V = undefined, C = undefined>
 	extends IBaseElementSchema<"list-item">,
 		TComponentOmitProps<IWrapperSchema> {
-	children: string | Record<string, TFrontendEngineFieldSchema<V>>;
+	children: string | Record<string, TFrontendEngineFieldSchema<V, C>>;
 }

--- a/src/components/elements/tab/types.ts
+++ b/src/components/elements/tab/types.ts
@@ -2,14 +2,16 @@ import { TComponentOmitProps, TFrontendEngineFieldSchema } from "../../frontend-
 import { IBaseElementSchema } from "../types";
 import { IWrapperSchema } from "../wrapper";
 
-export interface ITabSchema<V = undefined> extends IBaseElementSchema<"tab">, TComponentOmitProps<IWrapperSchema> {
-	children: Record<string, ITabItemSchema<V>>;
+export interface ITabSchema<V = undefined, C = undefined>
+	extends IBaseElementSchema<"tab">,
+		TComponentOmitProps<IWrapperSchema> {
+	children: Record<string, ITabItemSchema<V, C>>;
 	currentActiveTabId?: string | undefined;
 }
 
-export interface ITabItemSchema<V = undefined>
+export interface ITabItemSchema<V = undefined, C = undefined>
 	extends IBaseElementSchema<"tab-item">,
 		TComponentOmitProps<IWrapperSchema> {
-	children: Record<string, TFrontendEngineFieldSchema<V>>;
+	children: Record<string, TFrontendEngineFieldSchema<V, C>>;
 	title: string;
 }

--- a/src/components/elements/types.ts
+++ b/src/components/elements/types.ts
@@ -52,17 +52,17 @@ export enum EElementType {
 /**
  * union type to represent all element schemas
  */
-export type TElementSchema<V = undefined> =
-	| IAccordionSchema<V>
+export type TElementSchema<V = undefined, C = undefined> =
+	| IAccordionSchema<V, C>
 	| IAlertSchema
 	| IDividerSchema
-	| IGridSchema<V>
-	| IOrderedListSchema<V>
-	| ITabItemSchema<V>
-	| ITabSchema<V>
+	| IGridSchema<V, C>
+	| IOrderedListSchema<V, C>
+	| ITabItemSchema<V, C>
+	| ITabSchema<V, C>
 	| ITextSchema
-	| IUnorderedListSchema<V>
-	| IWrapperSchema<V>;
+	| IUnorderedListSchema<V, C>
+	| IWrapperSchema<V, C>;
 
 /**
  * common element schema for element schemas to extend from

--- a/src/components/elements/wrapper/types.ts
+++ b/src/components/elements/wrapper/types.ts
@@ -6,11 +6,11 @@ import { IListItemSchema } from "../list";
 
 export type TWrapperType = "div" | "span" | "header" | "footer" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p";
 
-export interface IWrapperSchema<V = undefined>
+export interface IWrapperSchema<V = undefined, C = undefined>
 	extends TComponentOmitProps<React.HTMLAttributes<HTMLElement>, "children"> {
 	uiType: TWrapperType;
 	showIf?: TRenderRules[] | undefined;
-	children: Record<string, TFrontendEngineFieldSchema<V>> | string;
+	children: Record<string, TFrontendEngineFieldSchema<V, C>> | string;
 	/** set responsive columns */
 	columns?: IColumns | undefined;
 }

--- a/src/components/fields/checkbox-group/types.ts
+++ b/src/components/fields/checkbox-group/types.ts
@@ -8,9 +8,9 @@ export interface IOption {
 	disabled?: boolean | undefined;
 }
 
-export interface IToggleOption extends IOption {
+export interface IToggleOption<V = undefined, C = undefined> extends IOption {
 	none?: boolean | undefined;
-	children?: Record<string, TFrontendEngineFieldSchema> | undefined;
+	children?: Record<string, TFrontendEngineFieldSchema<V, C>> | undefined;
 }
 
 export type TCheckboxToggleLayoutType = "horizontal" | "vertical";
@@ -19,17 +19,13 @@ interface ICheckboxGroupDefaultSchema<V = undefined>
 	extends IBaseFieldSchema<"checkbox", V>,
 		TComponentOmitProps<CheckboxProps> {
 	options: IOption[];
-	customOptions?:
-		| {
-				styleType: "default";
-		  }
-		| undefined;
+	customOptions?: { styleType: "default" } | undefined;
 }
 
-interface ICheckboxGroupToggleSchema<V = undefined>
+interface ICheckboxGroupToggleSchema<V = undefined, C = undefined>
 	extends IBaseFieldSchema<"checkbox", V>,
 		TComponentOmitProps<CheckboxProps> {
-	options: IToggleOption[];
+	options: IToggleOption<V, C>[];
 	customOptions: {
 		styleType: "toggle";
 		indicator?: boolean | undefined;
@@ -38,7 +34,11 @@ interface ICheckboxGroupToggleSchema<V = undefined>
 	};
 }
 
-export type TCheckboxGroupSchema<V = undefined> = ICheckboxGroupDefaultSchema<V> | ICheckboxGroupToggleSchema<V>;
+export type TCheckboxGroupSchema<V = undefined, C = undefined> =
+	| ICheckboxGroupDefaultSchema<V>
+	| ICheckboxGroupToggleSchema<V, C>;
 
 /** @deprecated will be removed in a future release. Use `TCheckboxGroupSchema` instead */
-export type ICheckboxGroupSchema<V = undefined> = ICheckboxGroupDefaultSchema<V> | ICheckboxGroupToggleSchema<V>;
+export type ICheckboxGroupSchema<V = undefined, C = undefined> =
+	| ICheckboxGroupDefaultSchema<V>
+	| ICheckboxGroupToggleSchema<V, C>;

--- a/src/components/fields/radio-button/types.ts
+++ b/src/components/fields/radio-button/types.ts
@@ -8,8 +8,8 @@ interface IOption {
 	disabled?: boolean | undefined;
 }
 
-interface IToggleOption extends IOption {
-	children?: Record<string, TFrontendEngineFieldSchema> | undefined;
+interface IToggleOption<V = undefined, C = undefined> extends IOption {
+	children?: Record<string, TFrontendEngineFieldSchema<V, C>> | undefined;
 }
 
 interface IImageButtonOption extends IOption {
@@ -29,10 +29,10 @@ interface IRadioButtonDefaultSchema<V = undefined>
 		| undefined;
 }
 
-interface IRadioButtonToggleSchema<V = undefined>
+interface IRadioButtonToggleSchema<V = undefined, C = undefined>
 	extends IBaseFieldSchema<"radio", V>,
 		TComponentOmitProps<RadioButtonProps> {
-	options: IToggleOption[];
+	options: IToggleOption<V, C>[];
 	customOptions: {
 		styleType: "toggle";
 		indicator?: boolean | undefined;
@@ -50,13 +50,13 @@ interface IRadioButtonImageButtonSchema<V = undefined>
 	};
 }
 
-export type TRadioButtonGroupSchema<V = undefined> =
+export type TRadioButtonGroupSchema<V = undefined, C = undefined> =
 	| IRadioButtonDefaultSchema<V>
-	| IRadioButtonToggleSchema<V>
+	| IRadioButtonToggleSchema<V, C>
 	| IRadioButtonImageButtonSchema<V>;
 
 /** @deprecated will be removed in a future release. Use `TRadioButtonGroupSchema` instead */
-export type IRadioButtonGroupSchema<V = undefined> =
+export type IRadioButtonGroupSchema<V = undefined, C = undefined> =
 	| IRadioButtonDefaultSchema<V>
-	| IRadioButtonToggleSchema<V>
+	| IRadioButtonToggleSchema<V, C>
 	| IRadioButtonImageButtonSchema<V>;

--- a/src/components/fields/types.ts
+++ b/src/components/fields/types.ts
@@ -66,7 +66,7 @@ export enum EFieldType {
 /**
  * union type to represent all field schemas
  */
-export type TFieldSchema<V = undefined> =
+export type TFieldSchema<V = undefined, C = undefined> =
 	| IButtonSchema
 	| IChipsSchema<V>
 	| IContactFieldSchema<V>
@@ -91,9 +91,9 @@ export type TFieldSchema<V = undefined> =
 	| ITextFieldSchema<V>
 	| ITimeFieldSchema<V>
 	| IUnitNumberFieldSchema<V>
-	| TCheckboxGroupSchema<V>
+	| TCheckboxGroupSchema<V, C>
 	| TDateRangeFieldSchema<V>
-	| TRadioButtonGroupSchema<V>;
+	| TRadioButtonGroupSchema<V, C>;
 
 // NOTE: U generic is for internal use, prevents getting overwritten by custom validation types
 export interface IBaseFieldSchema<T, V = undefined, U = undefined> {

--- a/src/components/frontend-engine/types.ts
+++ b/src/components/frontend-engine/types.ts
@@ -157,9 +157,9 @@ export interface IFrontendEngineRef
 // =============================================================================
 // contains all schema types except for sections schema
 export type TFrontendEngineFieldSchema<V = undefined, C = undefined> =
-	| TFieldSchema<V>
-	| TCustomSchema<C>
-	| TElementSchema<V>;
+	| TFieldSchema<V, C>
+	| TCustomSchema<V, C>
+	| TElementSchema<V, C>;
 
 type MobileCol = 1 | 2 | 3 | 4;
 type MobileColRange = MobileCol | 5;


### PR DESCRIPTION
**Changes**
- when custom schema interface is passed as a generic to frontend engine, ensure the typing is inherited in all other schemas
-   delete branch

Example
```ts
interface MyCustomSchema extends TCustomComponentSchema<"my-custom-component", MyCustomRule> {
	myCustomKey: string;
}

const JSON_SCHEMA: IFrontendEngineData<undefined, MyCustomSchema> = {
	sections: {
		section: {
			uiType: "section",
			children: {
				wrapper: {
					uiType: "div",
					children: {
						custom: {
							referenceKey: "my-custom-component", // <-- this should be supported
							myCustomKey: "hello", // <-- this should be supported
						},
					},
				}
			},
		},
	},
};```