### PR TITLE
Remove `handledFromDefault` from file and image upload field values

### DIFF
--- a/src/components/fields/file-upload/file-upload-context.tsx
+++ b/src/components/fields/file-upload/file-upload-context.tsx
@@ -4,6 +4,8 @@ import { IFile } from "./types";
 interface IFileUploadContext {
 	files: IFile[];
 	setFiles: Dispatch<SetStateAction<IFile[]>>;
+	currentFileIds: string[];
+	setCurrentFileIds: Dispatch<SetStateAction<string[]>>;
 }
 
 interface Props {
@@ -13,11 +15,14 @@ interface Props {
 export const FileUploadContext = createContext<IFileUploadContext>({
 	files: [],
 	setFiles: () => null,
+	currentFileIds: [],
+	setCurrentFileIds: () => null,
 });
 
 export const FileUploadProvider = ({ children }: Props) => {
 	const [files, setFiles] = useState<IFile[]>([]);
-	const values = useMemo(() => ({ files, setFiles }), [files]);
+	const [currentFileIds, setCurrentFileIds] = useState<string[]>([]);
+	const values = useMemo(() => ({ files, setFiles, currentFileIds, setCurrentFileIds }), [files, currentFileIds]);
 
 	return <FileUploadContext.Provider value={values}>{children}</FileUploadContext.Provider>;
 };

--- a/src/components/fields/file-upload/file-upload-manager.ts
+++ b/src/components/fields/file-upload/file-upload-manager.ts
@@ -22,7 +22,7 @@ const FileUploadManager = (props: IProps) => {
 	// CONST, STATE, REFS
 	// =============================================================================
 	const { compressImages, fileTypeRule, id, maxFileSizeRule, upload, value } = props;
-	const { files, setFiles } = useContext(FileUploadContext);
+	const { files, setFiles, setCurrentFileIds } = useContext(FileUploadContext);
 	const previousValue = usePrevious(value);
 	const { setValue } = useFormContext();
 	const sessionId = useRef<string>();
@@ -72,15 +72,16 @@ const FileUploadManager = (props: IProps) => {
 			 */
 			const shouldDirty = hasNotPrefilledFiles || gotDeleteFiles;
 
+			setCurrentFileIds(uploadedFiles.map(({ fileItem }) => fileItem.id));
+
 			setValue(
 				id,
-				uploadedFiles.map(({ dataURL, fileItem, fileUrl, uploadResponse, addedFrom }) => ({
+				uploadedFiles.map(({ dataURL, fileItem, fileUrl, uploadResponse }) => ({
 					...(upload.type === "base64" ? { dataURL } : {}),
 					fileId: fileItem.id,
 					fileName: fileItem.name,
 					fileUrl,
 					uploadResponse,
-					handledFromDefault: addedFrom === "schema",
 				})),
 				{ shouldDirty, shouldTouch: hasNotPrefilledFiles }
 			);

--- a/src/components/fields/file-upload/types.ts
+++ b/src/components/fields/file-upload/types.ts
@@ -52,10 +52,4 @@ export interface IFileUploadValue {
 	fileName: string;
 	fileUrl?: string | undefined;
 	uploadResponse?: unknown | undefined;
-	/**
-	 * for internal use only. DO NOT pass this into default schema
-	 *
-	 * this is so that the form hook can differentiate the default from current value
-	 */
-	handledFromDefault?: boolean;
 }

--- a/src/components/fields/image-upload/image-context/image-context.tsx
+++ b/src/components/fields/image-upload/image-context/image-context.tsx
@@ -6,6 +6,8 @@ interface IImageContext {
 	setImages: Dispatch<SetStateAction<IImage[]>>;
 	errorCount: number;
 	setErrorCount: Dispatch<SetStateAction<number>>;
+	currentFileIds: string[];
+	setCurrentFileIds: Dispatch<SetStateAction<string[]>>;
 }
 
 interface Props {
@@ -17,11 +19,14 @@ export const ImageContext = createContext<IImageContext>({
 	setImages: () => null,
 	errorCount: 0,
 	setErrorCount: () => null,
+	currentFileIds: [],
+	setCurrentFileIds: () => null,
 });
 
 export const ImageProvider = ({ children }: Props) => {
 	const [images, setImages] = useState<IImage[]>([]);
 	const [errorCount, setErrorCount] = useState(0);
+	const [currentFileIds, setCurrentFileIds] = useState<string[]>([]);
 
 	return (
 		<ImageContext.Provider
@@ -30,6 +35,8 @@ export const ImageProvider = ({ children }: Props) => {
 				setImages,
 				errorCount,
 				setErrorCount,
+				currentFileIds,
+				setCurrentFileIds,
 			}}
 		>
 			{children}

--- a/src/components/fields/image-upload/image-manager/image-manager.ts
+++ b/src/components/fields/image-upload/image-manager/image-manager.ts
@@ -33,7 +33,7 @@ export const ImageManager = (props: IProps) => {
 	// CONST, STATE, REFS
 	// =============================================================================
 	const { accepts, compress, dimensions, editImage, id, maxSizeInKb, outputType, upload, value } = props;
-	const { images, setImages, setErrorCount } = useContext(ImageContext);
+	const { images, setImages, setErrorCount, setCurrentFileIds } = useContext(ImageContext);
 	const previousImages = usePrevious(images);
 	const previousValue = usePrevious(value);
 	const { setValue } = useFormContext();
@@ -186,13 +186,15 @@ export const ImageManager = (props: IProps) => {
 		const hasNotPrefilledImages = notPrefilledImages.length > 0;
 		const shouldDirty = hasNotPrefilledImages || gotDeleteImages;
 
+		setCurrentFileIds(uploadedImages.map(({ id }) => id));
+
 		setValue(
 			id,
-			uploadedImages.map(({ dataURL, drawingDataURL, name, uploadResponse, addedFrom }) => ({
+			uploadedImages.map(({ id, dataURL, drawingDataURL, name, uploadResponse }) => ({
+				fileId: id,
 				fileName: name,
 				dataURL: drawingDataURL || dataURL,
 				uploadResponse,
-				handledFromDefault: addedFrom === "schema",
 			})),
 			{ shouldDirty, shouldTouch: hasNotPrefilledImages }
 		);

--- a/src/components/fields/image-upload/types.ts
+++ b/src/components/fields/image-upload/types.ts
@@ -92,14 +92,9 @@ export interface IUpdateImageStatus {
 
 export interface IUploadedImage {
 	dataURL: string;
+	fileId: string;
 	fileName: string;
 	uploadResponse?: any;
-	/**
-	 * for internal use only. DO NOT pass this into default schema
-	 *
-	 * this is so that the form hook can differentiate the default from current value
-	 */
-	handledFromDefault?: boolean;
 }
 
 export interface IDismissReviewModalEvent {


### PR DESCRIPTION
**Changes**

- The `handledFromDefault` flag is set in the field value, so it can leak across sessions and cause the file to be filtered out

```
// it's equivalent to doing this and the file is not reflected
DefaultValue.args = {
	...COMMON_STORY_ARGS,
	defaultValues: [
		{
			fileId: "file-1",
			fileName: "test.jpg",
			dataURL: jpgDataURL,
			handledFromDefault: true,
		},
	],
};
```

- Had to find an alternative approach:
  - First, using `isDirty` and `isTouched` to determine if default values should be handled
  - Second, detect value changes. So the current uploaded files still need to be tracked
- Some issues with this
  - Need a way to uniquely identify files - the file id seems to do the job (`generateRandomId` should be good enough?)
  - `image-upload` does not track the id - have to generate for older fields
- [delete] branch