### PR TITLE
Reimplement previous fixes for location field

### DIFF
--- a/src/components/fields/location-field/location-modal/location-modal.tsx
+++ b/src/components/fields/location-field/location-modal/location-modal.tsx
@@ -1,6 +1,6 @@
 import { MediaWidths, Modal } from "@lifesg/react-design-system";
 import { isEmpty } from "lodash";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { OneMapError } from "../../../../services/onemap/types";
 import { GeoLocationHelper, TestHelper } from "../../../../utils";
 import { useFieldEvent } from "../../../../utils/hooks";
@@ -74,8 +74,6 @@ const LocationModal = ({
 	// map picked value can be falsy/ no address found
 	// selectedAddressInfo have valid addresses from one map
 	const [mapPickedLatLng, setMapPickedLatLng] = useState<ILocationCoord>();
-
-	const hasLoadedOnModalOpen = useRef(false);
 
 	// =============================================================================
 	// HELPER FUNCTIONS
@@ -315,10 +313,7 @@ const LocationModal = ({
 				});
 			}
 		};
-		if (!hasLoadedOnModalOpen.current) {
-			recenterAndTriggerEvent();
-		}
-		hasLoadedOnModalOpen.current = true;
+		recenterAndTriggerEvent();
 	}, [dispatchFieldEvent, formValues, getCurrentLocation, id, panelInputMode, showLocationModal]);
 
 	/**

--- a/src/components/fields/location-field/location-modal/location-modal.tsx
+++ b/src/components/fields/location-field/location-modal/location-modal.tsx
@@ -78,10 +78,15 @@ const LocationModal = ({
 	// =============================================================================
 	// HELPER FUNCTIONS
 	// =============================================================================
-	const setSinglePanelMode = (inputMode: TPanelInputMode) => {
-		if (panelInputMode === "double") return;
-		setPanelInputMode(inputMode);
-	};
+	const setSinglePanelMode = useCallback((inputMode: TPanelInputMode, onlyHandleIfStateIs?: TPanelInputMode) => {
+		setPanelInputMode((prev) => {
+			if (prev === "double" || (!!onlyHandleIfStateIs && prev !== onlyHandleIfStateIs)) {
+				return prev;
+			}
+
+			return inputMode;
+		});
+	}, []);
 
 	const getCurrentLocation = useCallback(async () => {
 		setGettingCurrentLocation(true);
@@ -323,10 +328,10 @@ const LocationModal = ({
 	 * - prefill
 	 */
 	useEffect(() => {
-		if (!isEmpty(selectedAddressInfo) && panelInputMode === "search") {
-			setSinglePanelMode("map");
+		if (!isEmpty(selectedAddressInfo)) {
+			setSinglePanelMode("map", "search");
 		}
-	}, [selectedAddressInfo, gettingCurrentLocation]);
+	}, [selectedAddressInfo, gettingCurrentLocation, setSinglePanelMode]);
 
 	// =============================================================================
 	// RENDER FUNCTIONS

--- a/src/components/fields/location-field/location-modal/location-modal.tsx
+++ b/src/components/fields/location-field/location-modal/location-modal.tsx
@@ -1,6 +1,6 @@
 import { MediaWidths, Modal } from "@lifesg/react-design-system";
 import { isEmpty } from "lodash";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { OneMapError } from "../../../../services/onemap/types";
 import { GeoLocationHelper, TestHelper } from "../../../../utils";
 import { useFieldEvent } from "../../../../utils/hooks";
@@ -75,6 +75,8 @@ const LocationModal = ({
 	// selectedAddressInfo have valid addresses from one map
 	const [mapPickedLatLng, setMapPickedLatLng] = useState<ILocationCoord>();
 
+	const shouldCallGetSelectablePins = useRef(true);
+
 	// =============================================================================
 	// HELPER FUNCTIONS
 	// =============================================================================
@@ -128,6 +130,7 @@ const LocationModal = ({
 	// EVENT HANDLERS
 	// =============================================================================
 	const handleCloseLocationModal = useCallback(() => {
+		shouldCallGetSelectablePins.current = true;
 		onClose();
 	}, [onClose]);
 
@@ -312,12 +315,13 @@ const LocationModal = ({
 			const { lat, lng } = formValues || {};
 			if (!lat && !lng) {
 				await getCurrentLocation();
-			} else {
+			} else if (shouldCallGetSelectablePins.current) {
 				dispatchFieldEvent<ILocationCoord>("get-selectable-pins", id, {
 					lat: lat,
 					lng: lng,
 				});
 			}
+			shouldCallGetSelectablePins.current = false;
 		};
 		recenterAndTriggerEvent();
 	}, [dispatchFieldEvent, formValues, getCurrentLocation, id, showLocationModal]);

--- a/src/components/fields/location-field/location-modal/location-modal.tsx
+++ b/src/components/fields/location-field/location-modal/location-modal.tsx
@@ -1,6 +1,6 @@
 import { MediaWidths, Modal } from "@lifesg/react-design-system";
 import { isEmpty } from "lodash";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { OneMapError } from "../../../../services/onemap/types";
 import { GeoLocationHelper, TestHelper } from "../../../../utils";
 import { useFieldEvent } from "../../../../utils/hooks";
@@ -76,6 +76,135 @@ const LocationModal = ({
 	const [mapPickedLatLng, setMapPickedLatLng] = useState<ILocationCoord>();
 
 	// =============================================================================
+	// HELPER FUNCTIONS
+	// =============================================================================
+	const setSinglePanelMode = (inputMode: TPanelInputMode) => {
+		if (panelInputMode === "double") return;
+		setPanelInputMode(inputMode);
+	};
+
+	const getCurrentLocation = useCallback(async () => {
+		setGettingCurrentLocation(true);
+
+		// TODO add documentation for how to cancel events and handle default
+		const shouldPreventDefault = !dispatchFieldEvent("get-current-location", id);
+
+		if (!shouldPreventDefault) {
+			const detail: TSetCurrentLocationDetail = {};
+
+			try {
+				detail.payload = await GeoLocationHelper.getCurrentLocation();
+			} catch (error) {
+				detail.errors = error;
+			}
+
+			dispatchFieldEvent<TSetCurrentLocationDetail>("set-current-location", id, detail);
+			return detail.payload;
+		}
+	}, [dispatchFieldEvent, id]);
+
+	// Manually refresh network if auto refresh has any issue
+	const refreshNetwork = () => {
+		try {
+			if (navigator.onLine) {
+				setHasInternetConnectivity(true);
+			}
+		} catch (error) {
+			// silent error
+		}
+	};
+
+	const restoreFormvalues = useCallback(() => {
+		// Retain current form values
+		setSelectedAddressInfo(formValues || {});
+	}, [formValues]);
+
+	// =============================================================================
+	// EVENT HANDLERS
+	// =============================================================================
+	const handleCloseLocationModal = useCallback(() => {
+		onClose();
+	}, [onClose]);
+
+	const handleGetLocationCallback = () => {
+		setGettingCurrentLocation(false);
+		setLocationAvailable(true);
+	};
+
+	const handleApiErrors = (error?: any) => {
+		const handleError = (errorType: TErrorType["errorType"], defaultHandle: () => void) => {
+			const shouldPreventDefault = !dispatchFieldEvent<TLocationFieldErrorDetail>("error", id, {
+				payload: {
+					errorType,
+				},
+				errors: error,
+			});
+
+			if (shouldPreventDefault) return;
+			defaultHandle();
+		};
+
+		setGettingCurrentLocation(false);
+
+		if (error instanceof OneMapError) {
+			handleError("OneMapError", () => {
+				restoreFormvalues();
+				setShowOneMapError(true);
+			});
+
+			return;
+		}
+
+		setLocationAvailable(false);
+
+		if (
+			error instanceof GeolocationPositionErrorWrapper &&
+			error?.code?.toString() === GeolocationPositionError.TIMEOUT.toString()
+		) {
+			handleError("GetLocationTimeoutError", () => {
+				setShowGetLocationTimeoutError(true);
+			});
+			return;
+		}
+
+		handleError("GetLocationError", () => {
+			setShowGetLocationError(true);
+		});
+	};
+
+	const handleCancel = useCallback(() => {
+		restoreFormvalues();
+		handleCloseLocationModal();
+	}, [handleCloseLocationModal, restoreFormvalues]);
+
+	const handleClickConfirm = () => {
+		const shouldPreventDefault = !dispatchFieldEvent("click-confirm-location", id, selectedAddressInfo);
+		if (!shouldPreventDefault) {
+			handleConfirm();
+		}
+	};
+
+	const handleConfirm = useCallback(
+		(e?: CustomEvent | undefined) => {
+			const addressInfo = !isEmpty(e?.detail) ? e?.detail : selectedAddressInfo;
+			onConfirm(addressInfo);
+			handleCloseLocationModal();
+		},
+		[handleCloseLocationModal, onConfirm, selectedAddressInfo]
+	);
+
+	const handleCloseLocationPermissionModal = () => {
+		const shouldPreventDefault = !dispatchFieldEvent("before-hide-permission-modal", id);
+		if (!shouldPreventDefault) {
+			setShowGetLocationError(false);
+		}
+	};
+
+	const handleMapClick = (latlng: ILocationCoord) => {
+		setMapPickedLatLng(latlng);
+	};
+
+	// =============================================================================
 	// EFFECTS
 	// =============================================================================
 	useEffect(() => {
@@ -126,7 +255,15 @@ const LocationModal = ({
 				removeFieldEventListener(event, id, callback);
 			});
 		};
-	}, []);
+	}, [
+		addFieldEventListener,
+		getCurrentLocation,
+		handleCancel,
+		handleCloseLocationModal,
+		handleConfirm,
+		id,
+		removeFieldEventListener,
+	]);
 
 	useEffect(() => {
 		if (!window) return;
@@ -155,7 +292,7 @@ const LocationModal = ({
 	useEffect(() => {
 		if (!showLocationModal) {
 			// Reset to map when one single panel view
-			panelInputMode !== "double" && setPanelInputMode("map");
+			setPanelInputMode((prev) => (prev !== "double" ? "map" : prev));
 			return;
 		}
 
@@ -167,17 +304,18 @@ const LocationModal = ({
 			 *
 			 * This is meant for first entry
 			 */
-			if (!formValues?.lat && !formValues?.lng) {
+			const { lat, lng } = formValues || {};
+			if (!lat && !lng) {
 				await getCurrentLocation();
 			} else {
 				dispatchFieldEvent<ILocationCoord>("get-selectable-pins", id, {
-					lat: formValues.lat,
-					lng: formValues.lng,
+					lat: lat,
+					lng: lng,
 				});
 			}
 		};
 		recenterAndTriggerEvent();
-	}, [showLocationModal]);
+	}, [dispatchFieldEvent, formValues, getCurrentLocation, id, showLocationModal]);
 
 	/**
 	 * triggers when
@@ -189,132 +327,6 @@ const LocationModal = ({
 			setSinglePanelMode("map");
 		}
 	}, [selectedAddressInfo, gettingCurrentLocation]);
-
-	// =============================================================================
-	// EVENT HANDLERS
-	// =============================================================================
-	const handleCloseLocationModal = () => {
-		onClose();
-	};
-
-	const handleGetLocationCallback = () => {
-		setGettingCurrentLocation(false);
-		setLocationAvailable(true);
-	};
-
-	const handleApiErrors = (error?: any) => {
-		const handleError = (errorType: TErrorType["errorType"], defaultHandle: () => void) => {
-			const shouldPreventDefault = !dispatchFieldEvent<TLocationFieldErrorDetail>("error", id, {
-				payload: {
-					errorType,
-				},
-				errors: error,
-			});
-
-			if (shouldPreventDefault) return;
-			defaultHandle();
-		};
-
-		setGettingCurrentLocation(false);
-
-		if (error instanceof OneMapError) {
-			handleError("OneMapError", () => {
-				restoreFormvalues();
-				setShowOneMapError(true);
-			});
-
-			return;
-		}
-
-		setLocationAvailable(false);
-
-		if (
-			error instanceof GeolocationPositionErrorWrapper &&
-			error?.code?.toString() === GeolocationPositionError.TIMEOUT.toString()
-		) {
-			handleError("GetLocationTimeoutError", () => {
-				setShowGetLocationTimeoutError(true);
-			});
-			return;
-		}
-
-		handleError("GetLocationError", () => {
-			setShowGetLocationError(true);
-		});
-	};
-
-	const handleCancel = () => {
-		restoreFormvalues();
-		handleCloseLocationModal();
-	};
-
-	const handleClickConfirm = () => {
-		const shouldPreventDefault = !dispatchFieldEvent("click-confirm-location", id, selectedAddressInfo);
-		if (!shouldPreventDefault) {
-			handleConfirm();
-		}
-	};
-
-	const handleConfirm = (e?: CustomEvent | undefined) => {
-		const addressInfo = !isEmpty(e?.detail) ? e?.detail : selectedAddressInfo;
-		onConfirm(addressInfo);
-		handleCloseLocationModal();
-	};
-
-	const handleCloseLocationPermissionModal = () => {
-		const shouldPreventDefault = !dispatchFieldEvent("before-hide-permission-modal", id);
-		if (!shouldPreventDefault) {
-			setShowGetLocationError(false);
-		}
-	};
-
-	const handleMapClick = (latlng: ILocationCoord) => {
-		setMapPickedLatLng(latlng);
-	};
-
-	// =============================================================================
-	// HELPER FUNCTIONS
-	// =============================================================================
-	const setSinglePanelMode = (inputMode: TPanelInputMode) => {
-		if (panelInputMode === "double") return;
-		setPanelInputMode(inputMode);
-	};
-
-	const getCurrentLocation = async () => {
-		setGettingCurrentLocation(true);
-
-		// TODO add documentation for how to cancel events and handle default
-		const shouldPreventDefault = !dispatchFieldEvent("get-current-location", id);
-
-		if (!shouldPreventDefault) {
-			const detail: TSetCurrentLocationDetail = {};
-
-			try {
-				detail.payload = await GeoLocationHelper.getCurrentLocation();
-			} catch (error) {
-				detail.errors = error;
-			}
-
-			dispatchFieldEvent<TSetCurrentLocationDetail>("set-current-location", id, detail);
-			return detail.payload;
-		}
-	};
-
-	// Manually refresh network if auto refresh has any issue
-	const refreshNetwork = () => {
-		try {
-			if (navigator.onLine) {
-				setHasInternetConnectivity(true);
-			}
-		} catch (error) {
-			// silent error
-		}
-	};
-
-	const restoreFormvalues = () => {
-		// Retain current form values
-		setSelectedAddressInfo(formValues || {});
-	};
 
 	// =============================================================================
 	// RENDER FUNCTIONS

--- a/src/utils/hooks/use-field-event.ts
+++ b/src/utils/hooks/use-field-event.ts
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useCallback, useContext } from "react";
 import { EventContext } from "../../context-providers";
 
 /**
@@ -10,32 +10,41 @@ import { EventContext } from "../../context-providers";
 export const useFieldEvent = () => {
 	const { eventManagerRef } = useContext(EventContext);
 
-	const addFieldEventListener = <T = any>(
-		type: string,
-		id: string,
-		listener: (ev: CustomEvent<T>) => void,
-		options?: boolean | AddEventListenerOptions
-	) => {
-		eventManagerRef.current?.addEventListener(`${id}:${type}`, listener, options);
-	};
+	const addFieldEventListener = useCallback(
+		<T = any>(
+			type: string,
+			id: string,
+			listener: (ev: CustomEvent<T>) => void,
+			options?: boolean | AddEventListenerOptions
+		) => {
+			eventManagerRef.current?.addEventListener(`${id}:${type}`, listener, options);
+		},
+		[eventManagerRef]
+	);
 
-	const removeFieldEventListener = <T = any>(
-		type: string,
-		id: string,
-		listener: (ev: CustomEvent<T>) => void,
-		options?: boolean | EventListenerOptions
-	) => {
-		eventManagerRef.current?.removeEventListener(`${id}:${type}`, listener, options);
-	};
+	const removeFieldEventListener = useCallback(
+		<T = any>(
+			type: string,
+			id: string,
+			listener: (ev: CustomEvent<T>) => void,
+			options?: boolean | EventListenerOptions
+		) => {
+			eventManagerRef.current?.removeEventListener(`${id}:${type}`, listener, options);
+		},
+		[eventManagerRef]
+	);
 
 	/**
 	 * Dispatches a custom event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
 	 */
-	const dispatchFieldEvent = <T = any>(type: string, id: string, detail?: T): boolean => {
-		return eventManagerRef.current?.dispatchEvent(
-			new CustomEvent(`${id}:${type}`, { cancelable: true, detail: { id, ...detail } })
-		);
-	};
+	const dispatchFieldEvent = useCallback(
+		<T = any>(type: string, id: string, detail?: T): boolean => {
+			return eventManagerRef.current?.dispatchEvent(
+				new CustomEvent(`${id}:${type}`, { cancelable: true, detail: { id, ...detail } })
+			);
+		},
+		[eventManagerRef]
+	);
 
 	return { addFieldEventListener, dispatchFieldEvent, removeFieldEventListener };
 };

--- a/src/utils/hooks/use-field-event.ts
+++ b/src/utils/hooks/use-field-event.ts
@@ -1,4 +1,4 @@
-import { useCallback, useContext } from "react";
+import { useContext } from "react";
 import { EventContext } from "../../context-providers";
 
 /**
@@ -10,41 +10,32 @@ import { EventContext } from "../../context-providers";
 export const useFieldEvent = () => {
 	const { eventManagerRef } = useContext(EventContext);
 
-	const addFieldEventListener = useCallback(
-		<T = any>(
-			type: string,
-			id: string,
-			listener: (ev: CustomEvent<T>) => void,
-			options?: boolean | AddEventListenerOptions
-		) => {
-			eventManagerRef.current?.addEventListener(`${id}:${type}`, listener, options);
-		},
-		[eventManagerRef]
-	);
+	const addFieldEventListener = <T = any>(
+		type: string,
+		id: string,
+		listener: (ev: CustomEvent<T>) => void,
+		options?: boolean | AddEventListenerOptions
+	) => {
+		eventManagerRef.current?.addEventListener(`${id}:${type}`, listener, options);
+	};
 
-	const removeFieldEventListener = useCallback(
-		<T = any>(
-			type: string,
-			id: string,
-			listener: (ev: CustomEvent<T>) => void,
-			options?: boolean | EventListenerOptions
-		) => {
-			eventManagerRef.current?.removeEventListener(`${id}:${type}`, listener, options);
-		},
-		[eventManagerRef]
-	);
+	const removeFieldEventListener = <T = any>(
+		type: string,
+		id: string,
+		listener: (ev: CustomEvent<T>) => void,
+		options?: boolean | EventListenerOptions
+	) => {
+		eventManagerRef.current?.removeEventListener(`${id}:${type}`, listener, options);
+	};
 
 	/**
 	 * Dispatches a custom event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
 	 */
-	const dispatchFieldEvent = useCallback(
-		<T = any>(type: string, id: string, detail?: T): boolean => {
-			return eventManagerRef.current?.dispatchEvent(
-				new CustomEvent(`${id}:${type}`, { cancelable: true, detail: { id, ...detail } })
-			);
-		},
-		[eventManagerRef]
-	);
+	const dispatchFieldEvent = <T = any>(type: string, id: string, detail?: T): boolean => {
+		return eventManagerRef.current?.dispatchEvent(
+			new CustomEvent(`${id}:${type}`, { cancelable: true, detail: { id, ...detail } })
+		);
+	};
 
 	return { addFieldEventListener, dispatchFieldEvent, removeFieldEventListener };
 };


### PR DESCRIPTION
**Changes**
1. retriggering of `get-selectable-pins` when selecting pin
- previous fix caused location modal to NOT trigger getCurrentLocation when opening a second time (ie on edit)
- new fix is a flag for tracking if `get-selectable-pins` should be triggered instead of whether or not modal has loaded
(`get-selectable-pins` should be triggered only when modal opens, not when it closes as was the original bug)

2. `formValues` being undefined in event 
- previous fix caused the location list to not show up due to the newly populated dependency array
- added correct dependency logic for handling of `panelInputMode`

-   [delete] branch
