### PR TITLE
[MOL-15190][SW] add option to display different icon on location search bar

### DIFF
--- a/src/components/fields/location-field/location-field.tsx
+++ b/src/components/fields/location-field/location-field.tsx
@@ -41,6 +41,7 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 			locationSelectionMode = "default",
 			disableSearch,
 			addressFieldPlaceholder,
+			searchBarIcon,
 		},
 		// form values can initially be undefined when passed in via props
 		value: formValue,
@@ -185,6 +186,7 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 						locationSelectionMode={locationSelectionMode}
 						disableSearch={disableSearch}
 						addressFieldPlaceholder={addressFieldPlaceholder}
+						searchBarIcon={searchBarIcon}
 					/>
 				)}
 			</Suspense>

--- a/src/components/fields/location-field/location-modal/location-modal.tsx
+++ b/src/components/fields/location-field/location-modal/location-modal.tsx
@@ -48,6 +48,7 @@ const LocationModal = ({
 	locationSelectionMode,
 	disableSearch,
 	addressFieldPlaceholder,
+	searchBarIcon,
 }: ILocationModalProps) => {
 	// =============================================================================
 	// CONST, STATE, REFS
@@ -473,6 +474,7 @@ const LocationModal = ({
 								selectablePins={selectablePins}
 								disableSearch={disableSearch}
 								addressFieldPlaceholder={addressFieldPlaceholder}
+								searchBarIcon={searchBarIcon}
 							/>
 							<StyledLocationPicker
 								id={id}

--- a/src/components/fields/location-field/location-modal/location-search/location-search.data.ts
+++ b/src/components/fields/location-field/location-modal/location-search/location-search.data.ts
@@ -1,2 +1,3 @@
 export const LOCATION_PIN_BLACK = "https://assets.life.gov.sg/web-frontend-engine/img/icons/location-pin-black.svg";
 export const SEARCH_SVG = "https://assets.life.gov.sg/web-frontend-engine/img/icons/search.svg";
+export const LOCATION_PIN_GREY = "https://assets.life.gov.sg/web-frontend-engine/img/icons/location-pin-grey.svg";

--- a/src/components/fields/location-field/location-modal/location-search/location-search.tsx
+++ b/src/components/fields/location-field/location-modal/location-search/location-search.tsx
@@ -17,7 +17,7 @@ import {
 } from "../../types";
 import { InfiniteScrollList } from "../infinite-scroll";
 import { boldResultsWithQuery, pagination } from "./helper";
-import { LOCATION_PIN_BLACK, SEARCH_SVG } from "./location-search.data";
+import { LOCATION_PIN_BLACK, LOCATION_PIN_GREY, SEARCH_SVG } from "./location-search.data";
 import {
 	ButtonItem,
 	ButtonWrapper,
@@ -75,6 +75,7 @@ export const LocationSearch = ({
 	updateFormValues,
 	restrictLocationSelection,
 	selectablePins,
+	searchBarIcon = "search",
 }: ILocationSearchProps) => {
 	// =============================================================================
 	// CONST, STATE, REFS
@@ -112,6 +113,11 @@ export const LocationSearch = ({
 		hasGotPinLocationValue,
 		checkAndSetPinLocationAsResult,
 	} = LocationHelper;
+
+	const iconPath: Record<typeof searchBarIcon, string> = {
+		search: SEARCH_SVG,
+		"location-pin": LOCATION_PIN_GREY,
+	};
 
 	// =============================================================================
 	// EFFECTS
@@ -642,7 +648,7 @@ export const LocationSearch = ({
 						data-testid={TestHelper.generateId(id, "location-search-modal-search")}
 						disabled={!!disableSearch}
 					>
-						<SearchBarIcon src={SEARCH_SVG} alt="Search" />
+						<SearchBarIcon src={iconPath[searchBarIcon]} alt="Search" />
 					</SearchBarIconButton>
 					<SearchBarInput
 						id={TestHelper.generateId(id, "location-search-modal-input")}

--- a/src/components/fields/location-field/location-modal/location-search/types.ts
+++ b/src/components/fields/location-field/location-modal/location-search/types.ts
@@ -33,4 +33,5 @@ export interface ILocationSearchProps {
 	restrictLocationSelection?: boolean | undefined;
 	selectablePins: IMapPin[];
 	disableSearch?: "disabled" | "readonly" | undefined;
+	searchBarIcon?: "search" | "location-pin";
 }

--- a/src/components/fields/location-field/location-modal/types.ts
+++ b/src/components/fields/location-field/location-modal/types.ts
@@ -12,6 +12,7 @@ export interface ILocationModalProps
 			| "gettingCurrentLocationFetchMessage"
 			| "disableSearch"
 			| "addressFieldPlaceholder"
+			| "searchBarIcon"
 		> {
 	id: string;
 	className: string;

--- a/src/components/fields/location-field/types.ts
+++ b/src/components/fields/location-field/types.ts
@@ -17,6 +17,7 @@ export interface ILocationFieldSchema<V = undefined>
 			| "hasExplicitEdit"
 			| "disableSearch"
 			| "addressFieldPlaceholder"
+			| "searchBarIcon"
 		>,
 		Pick<ILocationInputProps, "locationInputPlaceholder" | "disabled" | "readOnly">,
 		Pick<IStaticMapProps, "staticMapPinColor">,


### PR DESCRIPTION
**Changes**
Add option to location schema for the search bar to show the `location pin grey` icon.
Icon will default to the existing search icon

-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Location schema now takes in `searchBarIcon` prop
