### PR TITLE
Render toggle nested fields in composite section

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,13 +29,6 @@
 		}
 	},
 	"rules": {
-		"indent": [
-			"warn",
-			"tab",
-			{
-				"SwitchCase": 1
-			}
-		],
 		"no-empty": "off",
 		"no-console": "off",
 		"no-debugger": "off",

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The intention of frontend engine is to take out the heavy lifting of form develo
 
 Developers are expected to have the following packages installed:
 
--   @lifesg/react-design-system 2.6.0-canary.2
+-   @lifesg/react-design-system 2.7.0-canary.2
 -   @lifesg/react-icons 1.2.0
 -   react 17.0.2 or 18
 -   react-dom 17.0.2 or 18

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 				"@babel/preset-env": "^7.19.3",
 				"@babel/preset-react": "^7.18.6",
 				"@babel/preset-typescript": "^7.18.6",
-				"@lifesg/react-design-system": "^2.6.0-canary.6",
+				"@lifesg/react-design-system": "^2.7.0-canary.2",
 				"@lifesg/react-icons": "^1.6.0",
 				"@rollup/plugin-commonjs": "^22.0.2",
 				"@rollup/plugin-image": "^2.1.1",
@@ -95,7 +95,7 @@
 				"typescript": "^4.8.4"
 			},
 			"peerDependencies": {
-				"@lifesg/react-design-system": "^2.6.0-canary.6",
+				"@lifesg/react-design-system": "^2.7.0-canary.2",
 				"@lifesg/react-icons": "^1.6.0",
 				"react": "^17.0.2 || ^18.0.0",
 				"react-dom": "^17.0.2 || ^18.0.0",
@@ -3646,9 +3646,9 @@
 			"dev": true
 		},
 		"node_modules/@lifesg/react-design-system": {
-			"version": "2.6.0-canary.6",
-			"resolved": "https://registry.npmjs.org/@lifesg/react-design-system/-/react-design-system-2.6.0-canary.6.tgz",
-			"integrity": "sha512-14WV4rUu46DlChOet2bQWddR2NA6mj4/V2B4ob7zIMKD/KLbjcTOeJ/GJuZC3+NWuw4nXJd/Zd7D2TmauHCDwg==",
+			"version": "2.7.0-canary.2",
+			"resolved": "https://registry.npmjs.org/@lifesg/react-design-system/-/react-design-system-2.7.0-canary.2.tgz",
+			"integrity": "sha512-1dth3dDVz/fp6PrTFTeRVy4GnURL+DJY4TogvaLltH0Sw+URICmmbs01f9QBmo4PNUWnm3U3JgYYFIPwur9Ypg==",
 			"dev": true,
 			"dependencies": {
 				"@floating-ui/dom": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"yup": "^0.32.11"
 	},
 	"peerDependencies": {
-		"@lifesg/react-design-system": "^2.6.0-canary.6",
+		"@lifesg/react-design-system": "^2.7.0-canary.2",
 		"@lifesg/react-icons": "^1.6.0",
 		"react": "^17.0.2 || ^18.0.0",
 		"react-dom": "^17.0.2 || ^18.0.0",
@@ -66,7 +66,7 @@
 		"@babel/preset-env": "^7.19.3",
 		"@babel/preset-react": "^7.18.6",
 		"@babel/preset-typescript": "^7.18.6",
-		"@lifesg/react-design-system": "^2.6.0-canary.6",
+		"@lifesg/react-design-system": "^2.7.0-canary.2",
 		"@lifesg/react-icons": "^1.6.0",
 		"@rollup/plugin-commonjs": "^22.0.2",
 		"@rollup/plugin-image": "^2.1.1",

--- a/src/components/fields/checkbox-group/checkbox-group.styles.tsx
+++ b/src/components/fields/checkbox-group/checkbox-group.styles.tsx
@@ -37,11 +37,8 @@ export const ToggleWrapper = styled.div<IToggleWrapperProps>`
 `;
 
 export const StyledToggle = styled(Toggle)`
-	[data-id="toggle-sublabel"] {
-		margin-top: 0;
+	[data-id="toggle-composite-children"] {
+		margin: 0;
+		padding: 0;
 	}
-`;
-
-export const ToggleSublabel = styled.div`
-	pointer-events: auto;
 `;

--- a/src/components/fields/checkbox-group/checkbox-group.tsx
+++ b/src/components/fields/checkbox-group/checkbox-group.tsx
@@ -9,14 +9,7 @@ import { TestHelper } from "../../../utils";
 import { useValidationConfig } from "../../../utils/hooks";
 import { Wrapper } from "../../elements/wrapper";
 import { ERROR_MESSAGES, Sanitize, Warning } from "../../shared";
-import {
-	CheckboxContainer,
-	Label,
-	StyledCheckbox,
-	StyledToggle,
-	ToggleSublabel,
-	ToggleWrapper,
-} from "./checkbox-group.styles";
+import { CheckboxContainer, Label, StyledCheckbox, StyledToggle, ToggleWrapper } from "./checkbox-group.styles";
 import { IToggleOption, TCheckboxGroupSchema } from "./types";
 
 export const CheckboxGroup = (props: IGenericFieldProps<TCheckboxGroupSchema>) => {
@@ -158,12 +151,13 @@ export const CheckboxGroup = (props: IGenericFieldProps<TCheckboxGroupSchema>) =
 								checked={isCheckboxChecked(option.value)}
 								onChange={() => handleChange(option.value, option.none)}
 								error={!!error?.message}
-								subLabel={() =>
-									option.children ? (
-										<ToggleSublabel>
-											<Wrapper>{option.children}</Wrapper>
-										</ToggleSublabel>
-									) : null
+								compositeSection={
+									option.children
+										? {
+												children: <Wrapper>{option.children}</Wrapper>,
+												collapsible: false,
+										  }
+										: null
 								}
 							>
 								{option.label}

--- a/src/components/fields/radio-button/radio-button.styles.tsx
+++ b/src/components/fields/radio-button/radio-button.styles.tsx
@@ -51,11 +51,8 @@ export const FlexToggleWrapper = styled.div<IToggleWrapperProps>`
 `;
 
 export const StyledToggle = styled(Toggle)`
-	[data-id="toggle-sublabel"] {
-		margin-top: 0;
+	[data-id="toggle-composite-children"] {
+		margin: 0;
+		padding: 0;
 	}
-`;
-
-export const ToggleSublabel = styled.div`
-	pointer-events: auto;
 `;

--- a/src/components/fields/radio-button/radio-button.tsx
+++ b/src/components/fields/radio-button/radio-button.tsx
@@ -16,7 +16,6 @@ import {
 	StyledImageButton,
 	StyledRadioButton,
 	StyledToggle,
-	ToggleSublabel,
 } from "./radio-button.styles";
 import { TRadioButtonGroupSchema } from "./types";
 
@@ -131,12 +130,13 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 								checked={isRadioButtonChecked(option.value)}
 								onChange={() => handleChangeOrClick(option.value)}
 								error={!!error?.message}
-								subLabel={() =>
-									option.children ? (
-										<ToggleSublabel>
-											<Wrapper>{option.children}</Wrapper>
-										</ToggleSublabel>
-									) : null
+								compositeSection={
+									option.children
+										? {
+												children: <Wrapper>{option.children}</Wrapper>,
+												collapsible: false,
+										  }
+										: null
 								}
 							>
 								{option.label}

--- a/src/stories/3-fields/checkbox-group/checkbox-toggle-group.stories.tsx
+++ b/src/stories/3-fields/checkbox-group/checkbox-toggle-group.stories.tsx
@@ -255,11 +255,17 @@ NestedFields.args = {
 			label: "Others",
 			value: "Others",
 			children: {
-				otherInput: {
-					uiType: "textarea",
-					label: "",
-					validation: [{ required: true }, { max: 100 }],
+				wrapper: {
+					uiType: "div",
+					style: { padding: "1rem" },
 					showIf: [{ "checkbox-nested": [{ filled: true }, { includes: ["Others"] }] }],
+					children: {
+						otherInput: {
+							uiType: "textarea",
+							label: "",
+							validation: [{ required: true }, { max: 100 }],
+						},
+					},
 				},
 			},
 		},

--- a/src/stories/3-fields/radio-button/radio-toggle-button.stories.tsx
+++ b/src/stories/3-fields/radio-button/radio-toggle-button.stories.tsx
@@ -242,11 +242,17 @@ NestedFields.args = {
 			label: "Others",
 			value: "Others",
 			children: {
-				otherInput: {
-					uiType: "textarea",
-					label: "",
-					validation: [{ required: true }, { max: 100 }],
+				wrapper: {
+					uiType: "div",
+					style: { padding: "1rem" },
 					showIf: [{ "radio-nested": [{ equals: "Others" }] }],
+					children: {
+						otherInput: {
+							uiType: "textarea",
+							label: "",
+							validation: [{ required: true }, { max: 100 }],
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**Changes**

Renders the nested field for checkbox and radio options in the composite section instead of sublabel

However, this is a **breaking change** for styling as the new layout requires the consumer to apply the appropriate padding around the content

-   [delete] branch