### PR TITLE
Allow overriding z-index of field label hint

### DIFF
--- a/src/components/elements/wrapper/field-wrapper.tsx
+++ b/src/components/elements/wrapper/field-wrapper.tsx
@@ -95,6 +95,7 @@ export const FieldWrapper = ({ Field, id, schema, warning }: IProps) => {
 							type: "popover",
 							content: <StyledHint className="label-hint">{label.hint?.content}</StyledHint>,
 							"data-testid": (schema["data-testid"] || id) + "-popover",
+							zIndex: label.hint?.zIndex,
 					  }
 					: /* eslint-enable indent */
 					  undefined,

--- a/src/components/fields/types.ts
+++ b/src/components/fields/types.ts
@@ -127,6 +127,7 @@ export interface IComplexLabel {
 
 interface IComplexLabelHint {
 	content: string;
+	zIndex?: number | undefined;
 }
 // =============================================================================
 // FIELD PROPS

--- a/src/stories/common.tsx
+++ b/src/stories/common.tsx
@@ -66,7 +66,8 @@ export const CommonFieldStoryProps = (uiType: string, isElement = false): ArgTyp
 				"<div>A name/description of the purpose of the form element which may include an optional sub-label and popover feature.<br>If string is provided, the entire label will be rendered.<br>If object is provided:<ul><li>mainLabel: Primary text to display.</li><li>subLabel: Secondary text to display below the mainLabel.</li><li>hint.content: Displays an info icon and brings up the content as a popover on click.</li></ul></div>",
 			table: {
 				type: {
-					summary: "string | { mainLabel: string, subLabel?: string, hint?: { content: string } }",
+					summary:
+						"string | { mainLabel: string, subLabel?: string, hint?: { content: string; zIndex?: number } }",
 				},
 			},
 		},


### PR DESCRIPTION
**Changes**

This is to cater for places that render FEE in a container with higher z-index. The popover appears to be missing because it shows behind the parent container

Can reproduce by wrapping the `DefaultStoryTemplate` with this and viewing any story with `Label Customisation`:
```
<div style={{ zIndex: 9, position: "relative", background: "pink", padding: "3rem" }}>
</div>
```

-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Allow overriding z-index of hint in the field label
