### PR TITLE
Support icon or label add-on in text field

### DIFF
--- a/src/__tests__/components/fields/text-field/email-field.spec.tsx
+++ b/src/__tests__/components/fields/text-field/email-field.spec.tsx
@@ -180,6 +180,39 @@ describe(UI_TYPE, () => {
 		expect(event).toBe(true);
 	});
 
+	describe("addOn", () => {
+		it("should be able to render the icon add on", async () => {
+			renderComponent({
+				customOptions: {
+					addOn: { type: "icon", icon: "TicketIcon" },
+				},
+			});
+
+			fireEvent.change(getEmailField(), { target: { value: "john@doe.com" } });
+
+			const startIcon = document.querySelector("svg");
+			expect(startIcon).toBeInTheDocument();
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: "john@doe.com" }));
+		});
+
+		it("should be able to render the label add on", async () => {
+			renderComponent({
+				customOptions: {
+					addOn: { type: "label", value: "#" },
+				},
+			});
+
+			fireEvent.change(getEmailField(), { target: { value: "john@doe.com" } });
+
+			expect(screen.getByText("#")).toBeInTheDocument();
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: "john@doe.com" }));
+		});
+	});
+
 	describe("reset", () => {
 		it("should clear selection on reset", async () => {
 			renderComponent();

--- a/src/__tests__/components/fields/text-field/numeric-field.spec.tsx
+++ b/src/__tests__/components/fields/text-field/numeric-field.spec.tsx
@@ -169,6 +169,39 @@ describe(UI_TYPE, () => {
 		expect(event).toBe(true);
 	});
 
+	describe("addOn", () => {
+		it("should be able to render the icon add on", async () => {
+			renderComponent({
+				customOptions: {
+					addOn: { type: "icon", icon: "TicketIcon" },
+				},
+			});
+
+			fireEvent.change(getNumericField(), { target: { value: 1 } });
+
+			const startIcon = document.querySelector("svg");
+			expect(startIcon).toBeInTheDocument();
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: "1" }));
+		});
+
+		it("should be able to render the label add on", async () => {
+			renderComponent({
+				customOptions: {
+					addOn: { type: "label", value: "$" },
+				},
+			});
+
+			fireEvent.change(getNumericField(), { target: { value: 1 } });
+
+			expect(screen.getByText("$")).toBeInTheDocument();
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: "1" }));
+		});
+	});
+
 	describe("reset", () => {
 		it("should clear selection on reset", async () => {
 			renderComponent();

--- a/src/__tests__/components/fields/text-field/text-field.spec.tsx
+++ b/src/__tests__/components/fields/text-field/text-field.spec.tsx
@@ -179,6 +179,41 @@ describe(UI_TYPE, () => {
 		expect(getTextfield()).toHaveValue("HELLO");
 	});
 
+	describe("addOn", () => {
+		it("should be able to render the icon add on", async () => {
+			renderComponent({
+				customOptions: {
+					addOn: { type: "icon", icon: "TicketIcon" },
+				},
+			});
+
+			fireEvent.change(getTextfield(), { target: { value: "hello" } });
+
+			const startIcon = document.querySelector("svg");
+			expect(startIcon).toBeInTheDocument();
+			expect(getTextfield()).toHaveValue("hello");
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: "hello" }));
+		});
+
+		it("should be able to render the label add on", async () => {
+			renderComponent({
+				customOptions: {
+					addOn: { type: "label", value: "$" },
+				},
+			});
+
+			fireEvent.change(getTextfield(), { target: { value: "hello" } });
+
+			expect(screen.getByText("$")).toBeInTheDocument();
+			expect(getTextfield()).toHaveValue("hello");
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: "hello" }));
+		});
+	});
+
 	describe("reset", () => {
 		it("should clear selection on reset", async () => {
 			renderComponent();

--- a/src/components/fields/text-field/text-field.tsx
+++ b/src/components/fields/text-field/text-field.tsx
@@ -158,11 +158,11 @@ export const TextField = (props: IGenericFieldProps<ITextFieldSchema | IEmailFie
 	};
 
 	const hasAddOn = () => {
-		return uiType === "text-field" && !!customOptions?.addOn;
+		return !!customOptions?.addOn;
 	};
 
 	const buildAddOn = (): AddonProps<undefined, undefined> => {
-		if (uiType !== "text-field" || !customOptions?.addOn) {
+		if (!hasAddOn()) {
 			return undefined;
 		}
 

--- a/src/components/fields/text-field/text-field.tsx
+++ b/src/components/fields/text-field/text-field.tsx
@@ -1,6 +1,9 @@
 import { Form } from "@lifesg/react-design-system/form";
 import { FormInputProps } from "@lifesg/react-design-system/form/types";
+import { AddonProps } from "@lifesg/react-design-system/input-group";
+import * as Icons from "@lifesg/react-icons";
 import React, { HTMLInputTypeAttribute, useEffect, useRef, useState } from "react";
+import styled from "styled-components";
 import * as Yup from "yup";
 import { IGenericFieldProps } from "..";
 import { TestHelper } from "../../../utils";
@@ -154,12 +157,46 @@ export const TextField = (props: IGenericFieldProps<ITextFieldSchema | IEmailFie
 		}
 	};
 
+	const hasAddOn = () => {
+		return uiType === "text-field" && !!customOptions?.addOn;
+	};
+
+	const buildAddOn = (): AddonProps<undefined, undefined> => {
+		if (uiType !== "text-field" || !customOptions?.addOn) {
+			return undefined;
+		}
+
+		if (customOptions.addOn.type === "label") {
+			return {
+				type: "label",
+				position: customOptions.addOn.position,
+				attributes: {
+					value: customOptions.addOn.value,
+				},
+			};
+		}
+
+		if (customOptions.addOn.type === "icon") {
+			const { icon, position, color } = customOptions.addOn;
+			const Element = Icons[icon];
+			return {
+				type: "custom",
+				position: position,
+				attributes: {
+					children: <CustomIcon as={Element} $color={color} />,
+				},
+			};
+		}
+	};
+
 	// =============================================================================
 	// RENDER FUNCTIONS
 	// =============================================================================
+	const InputElement = hasAddOn() ? Form.InputGroup : Form.Input;
+
 	return (
 		<>
-			<Form.Input
+			<InputElement
 				{...otherSchema}
 				{...otherProps}
 				{...derivedAttributes}
@@ -174,8 +211,17 @@ export const TextField = (props: IGenericFieldProps<ITextFieldSchema | IEmailFie
 				onChange={handleChange}
 				value={stateValue}
 				errorMessage={error?.message}
+				addon={buildAddOn()}
 			/>
 			<Warning id={id} message={warning} />
 		</>
 	);
 };
+
+interface CustomIconStyleProps {
+	$color?: string;
+}
+
+const CustomIcon = styled.div<CustomIconStyleProps>`
+	${({ $color }) => $color && `color: ${$color};`}
+`;

--- a/src/components/fields/text-field/types.ts
+++ b/src/components/fields/text-field/types.ts
@@ -7,6 +7,7 @@ import { IBaseFieldSchema } from "../types";
 type TCustomOptions = {
 	preventCopyAndPaste?: boolean | undefined;
 	preventDragAndDrop?: boolean | undefined;
+	addOn?: TIconAddOn | TLabelAddOn | undefined;
 };
 
 type TIconAddOn = {
@@ -23,7 +24,6 @@ type TLabelAddOn = {
 };
 
 export type TCustomOptionsText = TCustomOptions & {
-	addOn?: TIconAddOn | TLabelAddOn | undefined;
 	textTransform?: "uppercase" | undefined;
 };
 

--- a/src/components/fields/text-field/types.ts
+++ b/src/components/fields/text-field/types.ts
@@ -1,4 +1,6 @@
 import { FormInputProps } from "@lifesg/react-design-system/form/types";
+import { InputGroupAddonPosition } from "@lifesg/react-design-system/input-group";
+import * as Icons from "@lifesg/react-icons";
 import { TComponentOmitProps } from "../../frontend-engine";
 import { IBaseFieldSchema } from "../types";
 
@@ -7,7 +9,21 @@ type TCustomOptions = {
 	preventDragAndDrop?: boolean | undefined;
 };
 
+type TIconAddOn = {
+	type: "icon";
+	icon: keyof typeof Icons;
+	color?: string | undefined;
+	position?: InputGroupAddonPosition | undefined;
+};
+
+type TLabelAddOn = {
+	type: "label";
+	value: string;
+	position?: InputGroupAddonPosition | undefined;
+};
+
 export type TCustomOptionsText = TCustomOptions & {
+	addOn?: TIconAddOn | TLabelAddOn | undefined;
 	textTransform?: "uppercase" | undefined;
 };
 

--- a/src/stories/3-fields/email-field/email-field.stories.tsx
+++ b/src/stories/3-fields/email-field/email-field.stories.tsx
@@ -54,11 +54,14 @@ const meta: Meta = {
 			},
 		},
 		customOptions: {
-			description:
-				"<ul><li>`preventCopyAndPaste` prop accept `boolean` and also can be `undefined`. If value is true then it will prevent user from copy pasting.</li><li>`preventDragAndDrop` prop accept `boolean` and also can be `undefined`. If value is true then it will prevent user from drag and drop.</li></ul>",
+			description: `<ul>
+				<li>\`preventCopyAndPaste\` prop accept \`boolean\` and also can be \`undefined\`. If value is true then it will prevent user from copy pasting.</li><br>
+				<li>\`preventDragAndDrop\` prop accept \`boolean\` and also can be \`undefined\`. If value is true then it will prevent user from drag and drop.</li><br>
+				<li>\`addOn\` prop can be configured to display a label or icon at the start/end of the field. It is not included in the input</li><br>
+				</ul>`,
 			table: {
 				type: {
-					summary: `{preventCopyAndPaste?: boolean, preventCopyPaste?: boolean}`,
+					summary: `{preventCopyAndPaste?: boolean, preventCopyPaste?: boolean, addOn?: { type: "label", value: string, position?: "left" | "right" } | { type: "icon", value: string, position?: "left" | "right", color?: string }}`,
 				},
 			},
 			defaultValue: { PreventCopyAndPaste: false, PreventDragAndDrop: false },
@@ -153,10 +156,28 @@ PreventCopyAndPaste.args = {
 
 export const PreventDragAndDrop = DefaultStoryTemplate<IEmailFieldSchema>("prevent-drag-and-drop").bind({});
 PreventDragAndDrop.args = {
-	label: "Textfield",
+	label: "Email",
 	uiType: "email-field",
 	customOptions: {
 		preventDragAndDrop: true,
+	},
+};
+
+export const AddOnIcon = DefaultStoryTemplate<IEmailFieldSchema>("add-on-icon").bind({});
+AddOnIcon.args = {
+	label: "Email",
+	uiType: "email-field",
+	customOptions: {
+		addOn: { type: "icon", icon: "PlusIcon", color: "#686868" },
+	},
+};
+
+export const AddOnLabel = DefaultStoryTemplate<IEmailFieldSchema>("add-on-label").bind({});
+AddOnLabel.args = {
+	label: "Email",
+	uiType: "email-field",
+	customOptions: {
+		addOn: { type: "label", value: "#" },
 	},
 };
 

--- a/src/stories/3-fields/numeric-field/numeric-field.stories.tsx
+++ b/src/stories/3-fields/numeric-field/numeric-field.stories.tsx
@@ -54,11 +54,14 @@ const meta: Meta = {
 			},
 		},
 		customOptions: {
-			description:
-				"<ul><li>`preventCopyAndPaste` prop accept `boolean` and also can be `undefined`. If value is true then it will prevent user from copy pasting.</li><li>`preventDragAndDrop` prop accept `boolean` and also can be `undefined`. If value is true then it will prevent user from drag and drop.</li></ul>",
+			description: `<ul>
+				<li>\`preventCopyAndPaste\` prop accept \`boolean\` and also can be \`undefined\`. If value is true then it will prevent user from copy pasting.</li><br>
+				<li>\`preventDragAndDrop\` prop accept \`boolean\` and also can be \`undefined\`. If value is true then it will prevent user from drag and drop.</li><br>
+				<li>\`addOn\` prop can be configured to display a label or icon at the start/end of the field. It is not included in the input</li><br>
+				</ul>`,
 			table: {
 				type: {
-					summary: `{preventCopyAndPaste?: boolean, preventCopyPaste?: boolean}`,
+					summary: `{preventCopyAndPaste?: boolean, preventCopyPaste?: boolean, addOn?: { type: "label", value: string, position?: "left" | "right" } | { type: "icon", value: string, position?: "left" | "right", color?: string }}`,
 				},
 			},
 			defaultValue: { PreventCopyAndPaste: false, PreventDragAndDrop: false },
@@ -152,6 +155,25 @@ PreventDragAndDrop.args = {
 		preventDragAndDrop: true,
 	},
 };
+
+export const AddOnIcon = DefaultStoryTemplate<INumericFieldSchema>("add-on-icon").bind({});
+AddOnIcon.args = {
+	label: "Number",
+	uiType: "numeric-field",
+	customOptions: {
+		addOn: { type: "icon", icon: "StarFillIcon", color: "#686868", position: "right" },
+	},
+};
+
+export const AddOnLabel = DefaultStoryTemplate<INumericFieldSchema>("add-on-label").bind({});
+AddOnLabel.args = {
+	label: "Number",
+	uiType: "numeric-field",
+	customOptions: {
+		addOn: { type: "label", value: "kg", position: "right" },
+	},
+};
+
 export const Reset = ResetStoryTemplate<INumericFieldSchema>("numeric-reset").bind({});
 Reset.args = {
 	label: "Number",

--- a/src/stories/3-fields/text-field/text-field.stories.tsx
+++ b/src/stories/3-fields/text-field/text-field.stories.tsx
@@ -54,11 +54,15 @@ const meta: Meta = {
 			},
 		},
 		customOptions: {
-			description:
-				"<ul><li>`preventCopyAndPaste` prop accept `boolean` and also can be `undefined`. If value is true then it will prevent user from copy pasting.</li><li>`preventDragAndDrop` prop accept `boolean` and also can be `undefined`. If value is true then it will prevent user from drag and drop.</li><li>`textTransform` prop accept `uppercase` and also can be `undefined`. If value is set to `uppercase` then it will convert any user input to uppercase.<br>*Note: Unsetting `textTransform` at runtime does not revert existing input.</li></ul>",
+			description: `<ul>
+				<li>\`preventCopyAndPaste\` prop accept \`boolean\` and also can be \`undefined\`. If value is true then it will prevent user from copy pasting.</li><br>
+				<li>\`preventDragAndDrop\` prop accept \`boolean\` and also can be \`undefined\`. If value is true then it will prevent user from drag and drop.</li><br>
+				<li>\`textTransform\` prop accept \`uppercase\` and also can be \`undefined\`. If value is set to \`uppercase\` then it will convert any user input to uppercase.<br>*Note: Unsetting \`textTransform\` at runtime does not revert existing input.</li><br>
+				<li>\`addOn\` prop can be configured to display a label or icon at the start/end of the field. It is not included in the input</li><br>
+				</ul>`,
 			table: {
 				type: {
-					summary: `{preventCopyAndPaste?: boolean, preventCopyPaste?: boolean, textTransform?: "uppercase"}`,
+					summary: `{preventCopyAndPaste?: boolean, preventCopyPaste?: boolean, textTransform?: "uppercase", addOn?: { type: "label", value: string, position?: "left" | "right" } | { type: "icon", value: string, position?: "left" | "right", color?: string }}`,
 				},
 			},
 			defaultValue: { PreventCopyAndPaste: false, PreventDragAndDrop: false },
@@ -159,6 +163,24 @@ Uppercase.args = {
 	uiType: "text-field",
 	customOptions: {
 		textTransform: "uppercase",
+	},
+};
+
+export const AddOnIcon = DefaultStoryTemplate<ITextFieldSchema>("add-on-icon").bind({});
+AddOnIcon.args = {
+	label: "Textfield",
+	uiType: "text-field",
+	customOptions: {
+		addOn: { type: "icon", icon: "MagnifierIcon", color: "#686868" },
+	},
+};
+
+export const AddOnLabel = DefaultStoryTemplate<ITextFieldSchema>("add-on-label").bind({});
+AddOnLabel.args = {
+	label: "Textfield",
+	uiType: "text-field",
+	customOptions: {
+		addOn: { type: "label", value: "$" },
 	},
 };
 


### PR DESCRIPTION
**Changes**

Uses [DS InputGroup](https://designsystem.life.gov.sg/react/index.html?path=/docs/form-inputgroup--docs) to display add ons

-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Allow display of icon or label prefix/suffix in `text-field`