### PR TITLE
Update design system

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The intention of frontend engine is to take out the heavy lifting of form develo
 
 Developers are expected to have the following packages installed:
 
--   @lifesg/react-design-system 2.7.0-canary.2
+-   @lifesg/react-design-system 2.7.0-canary.3
 -   @lifesg/react-icons 1.2.0
 -   react 17.0.2 or 18
 -   react-dom 17.0.2 or 18

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 				"@babel/preset-env": "^7.19.3",
 				"@babel/preset-react": "^7.18.6",
 				"@babel/preset-typescript": "^7.18.6",
-				"@lifesg/react-design-system": "^2.7.0-canary.2",
+				"@lifesg/react-design-system": "^2.7.0-canary.3",
 				"@lifesg/react-icons": "^1.6.0",
 				"@rollup/plugin-commonjs": "^22.0.2",
 				"@rollup/plugin-image": "^2.1.1",
@@ -3646,9 +3646,9 @@
 			"dev": true
 		},
 		"node_modules/@lifesg/react-design-system": {
-			"version": "2.7.0-canary.2",
-			"resolved": "https://registry.npmjs.org/@lifesg/react-design-system/-/react-design-system-2.7.0-canary.2.tgz",
-			"integrity": "sha512-1dth3dDVz/fp6PrTFTeRVy4GnURL+DJY4TogvaLltH0Sw+URICmmbs01f9QBmo4PNUWnm3U3JgYYFIPwur9Ypg==",
+			"version": "2.7.0-canary.3",
+			"resolved": "https://registry.npmjs.org/@lifesg/react-design-system/-/react-design-system-2.7.0-canary.3.tgz",
+			"integrity": "sha512-phKxNVyuB14Zb13JpNAJ0WR8CuyRrkmoB0zEde9E2dhzgTT1SIBpJcMIpGkz0/L9jqaX9pRnZ9v5bFBFW0PLKw==",
 			"dev": true,
 			"dependencies": {
 				"@floating-ui/dom": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"yup": "^0.32.11"
 	},
 	"peerDependencies": {
-		"@lifesg/react-design-system": "^2.7.0-canary.2",
+		"@lifesg/react-design-system": "^2.7.0-canary.3",
 		"@lifesg/react-icons": "^1.6.0",
 		"react": "^17.0.2 || ^18.0.0",
 		"react-dom": "^17.0.2 || ^18.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"@babel/preset-env": "^7.19.3",
 		"@babel/preset-react": "^7.18.6",
 		"@babel/preset-typescript": "^7.18.6",
-		"@lifesg/react-design-system": "^2.7.0-canary.2",
+		"@lifesg/react-design-system": "^2.7.0-canary.3",
 		"@lifesg/react-icons": "^1.6.0",
 		"@rollup/plugin-commonjs": "^22.0.2",
 		"@rollup/plugin-image": "^2.1.1",

--- a/src/__tests__/common/helper.tsx
+++ b/src/__tests__/common/helper.tsx
@@ -10,7 +10,7 @@ import {
 import { ERROR_MESSAGE, RESET_BUTTON_ID, RESET_BUTTON_LABEL, SUBMIT_BUTTON_ID, SUBMIT_BUTTON_LABEL } from "./data";
 import { useRef } from "react";
 
-type TAriaRoles = "textbox" | "generic" | "button" | "spinbutton" | "radio" | "list" | "slider";
+type TAriaRoles = "textbox" | "generic" | "button" | "spinbutton" | "radio" | "list" | "slider" | "option";
 
 export const getSubmitButton = (): HTMLElement => {
 	return screen.getByRole("button", { name: SUBMIT_BUTTON_LABEL });

--- a/src/__tests__/components/elements/wrapper/conditional-renderer.spec.tsx
+++ b/src/__tests__/components/elements/wrapper/conditional-renderer.spec.tsx
@@ -161,19 +161,19 @@ describe("conditional-renderer", () => {
 		};
 		renderComponent(fields);
 
-		await waitFor(() => fireEvent.click(getField("button", FIELD_ONE_LABEL)));
+		await waitFor(() => fireEvent.click(getField("button", "Select")));
 
 		invalid?.forEach((value: string) => {
-			fireEvent.click(screen.getByText(value).closest("button"));
+			fireEvent.click(screen.getByRole("option", { name: value }));
 		});
 		expect(getFieldTwo(true)).not.toBeInTheDocument();
 
 		// fire invalid again to deselect values
 		invalid?.forEach((value: string) => {
-			fireEvent.click(screen.getByText(value).closest("button"));
+			fireEvent.click(screen.getByRole("option", { name: value }));
 		});
 		valid?.forEach((value: string) => {
-			fireEvent.click(screen.getByText(value).closest("button"));
+			fireEvent.click(screen.getByRole("option", { name: value }));
 		});
 		expect(getFieldTwo()).toBeInTheDocument();
 	});

--- a/src/__tests__/components/fields/multi-select/multi-select.spec.tsx
+++ b/src/__tests__/components/fields/multi-select/multi-select.spec.tsx
@@ -77,15 +77,15 @@ const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineDa
 };
 
 const getComponent = (): HTMLElement => {
-	return getField("button", FIELD_LABEL);
+	return screen.getByTestId("selector");
 };
 
 const getCheckboxA = (): HTMLElement => {
-	return getField("button", "A");
+	return getField("option", "A");
 };
 
 const getCheckboxB = (): HTMLElement => {
-	return getField("button", "B");
+	return getField("option", "B");
 };
 
 describe(UI_TYPE, () => {
@@ -108,7 +108,7 @@ describe(UI_TYPE, () => {
 		renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: defaultValues } });
 
 		await waitFor(() => fireEvent.click(getComponent()));
-		expect(getCheckboxA().querySelector("div[aria-checked=true]")).toBeInTheDocument();
+		expect(getCheckboxA()).toHaveAttribute("aria-selected", "true");
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
 		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
@@ -125,14 +125,7 @@ describe(UI_TYPE, () => {
 	it("should be disabled if configured", async () => {
 		renderComponent({ disabled: true });
 
-		expect(getComponent().parentElement).toHaveAttribute("disabled");
-	});
-
-	it("should be able to support custom list style width", async () => {
-		const width = "24rem";
-		renderComponent({ listStyleWidth: width });
-		await waitFor(() => fireEvent.click(getComponent()));
-		expect(getField("list")).toHaveStyle({ width });
+		expect(getComponent()).toBeDisabled();
 	});
 
 	it("should be able to support custom placeholder", () => {
@@ -214,7 +207,7 @@ describe(UI_TYPE, () => {
 
 				await waitFor(() => fireEvent.click(getComponent()));
 
-				selected.forEach((name) => fireEvent.click(screen.getByRole("button", { name })));
+				selected.forEach((name) => fireEvent.click(screen.getByRole("option", { name })));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
 				expect(SUBMIT_FN).toBeCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
@@ -256,7 +249,7 @@ describe(UI_TYPE, () => {
 
 				await waitFor(() => fireEvent.click(getComponent()));
 
-				selected.forEach((name) => fireEvent.click(screen.getByRole("button", { name })));
+				selected.forEach((name) => fireEvent.click(screen.getByRole("option", { name })));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
 				expect(SUBMIT_FN).toBeCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
@@ -283,8 +276,8 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			expect(screen.getByText("Select")).toBeInTheDocument();
-			expect(apple.querySelector("div[aria-checked=false]")).toBeInTheDocument();
-			expect(berry.querySelector("div[aria-checked=false]")).toBeInTheDocument();
+			expect(apple).toHaveAttribute("aria-selected", "false");
+			expect(berry).toHaveAttribute("aria-selected", "false");
 			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
@@ -301,8 +294,8 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			expect(screen.getByText("1 selected")).toBeInTheDocument();
-			expect(apple.querySelector("div[aria-checked=true]")).toBeInTheDocument();
-			expect(berry.querySelector("div[aria-checked=false]")).toBeInTheDocument();
+			expect(apple).toHaveAttribute("aria-selected", "true");
+			expect(berry).toHaveAttribute("aria-selected", "false");
 			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
 		});
 	});

--- a/src/__tests__/components/fields/select/select.spec.tsx
+++ b/src/__tests__/components/fields/select/select.spec.tsx
@@ -99,7 +99,7 @@ describe(UI_TYPE, () => {
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
 
-		expect(screen.getByTestId(`${COMPONENT_ID}-base`)).toHaveTextContent(defaultLabel);
+		expect(screen.getByTestId("selector")).toHaveTextContent(defaultLabel);
 		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 	});
 
@@ -114,7 +114,7 @@ describe(UI_TYPE, () => {
 	it("should be disabled if configured", async () => {
 		renderComponent({ disabled: true });
 
-		expect(getSelectToggle().parentElement).toHaveAttribute("disabled");
+		expect(getSelectToggle()).toHaveAttribute("disabled");
 	});
 
 	it("should be able to support custom placeholder", () => {
@@ -155,7 +155,7 @@ describe(UI_TYPE, () => {
 				);
 
 				await waitFor(() => fireEvent.click(getSelectToggle()));
-				fireEvent.click(screen.getByRole("button", { name: selected }));
+				fireEvent.click(screen.getByRole("option", { name: selected }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
 				expect(SUBMIT_FN).toBeCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
@@ -194,7 +194,7 @@ describe(UI_TYPE, () => {
 				);
 
 				await waitFor(() => fireEvent.click(getSelectToggle()));
-				fireEvent.click(screen.getByRole("button", { name: selected }));
+				fireEvent.click(screen.getByRole("option", { name: selected }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
 				expect(SUBMIT_FN).toBeCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
@@ -212,11 +212,11 @@ describe(UI_TYPE, () => {
 			renderComponent();
 
 			fireEvent.click(getSelectToggle());
-			fireEvent.click(screen.getByRole("button", { name: "A" }));
+			fireEvent.click(screen.getByRole("option", { name: "A" }));
 			fireEvent.click(getResetButton());
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
-			expect(screen.getByTestId(`${COMPONENT_ID}-base`)).toHaveTextContent("Select");
+			expect(screen.getByTestId("selector")).toHaveTextContent("Select");
 			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
@@ -225,11 +225,11 @@ describe(UI_TYPE, () => {
 			renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: defaultValue } });
 
 			fireEvent.click(getField("button", "A"));
-			fireEvent.click(screen.getByRole("button", { name: "B" }));
+			fireEvent.click(screen.getByRole("option", { name: "B" }));
 			fireEvent.click(getResetButton());
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
-			expect(screen.getByTestId(`${COMPONENT_ID}-base`)).toHaveTextContent("A");
+			expect(screen.getByTestId("selector")).toHaveTextContent("A");
 			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 		});
 	});
@@ -254,7 +254,7 @@ describe(UI_TYPE, () => {
 		it("should set form state as dirty if user modifies the field", async () => {
 			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
 			fireEvent.click(getSelectToggle());
-			fireEvent.click(screen.getByRole("button", { name: "A" }));
+			fireEvent.click(screen.getByRole("option", { name: "A" }));
 			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
 
 			expect(formIsDirty).toBe(true);
@@ -275,7 +275,7 @@ describe(UI_TYPE, () => {
 		it("should reset and revert form dirty state to false", async () => {
 			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
 			fireEvent.click(getSelectToggle());
-			fireEvent.click(screen.getByRole("button", { name: "A" }));
+			fireEvent.click(screen.getByRole("option", { name: "A" }));
 			fireEvent.click(getResetButton());
 			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
 
@@ -290,7 +290,7 @@ describe(UI_TYPE, () => {
 				/>
 			);
 			fireEvent.click(getSelectToggle());
-			fireEvent.click(screen.getByRole("button", { name: "A" }));
+			fireEvent.click(screen.getByRole("option", { name: "A" }));
 			fireEvent.click(getResetButton());
 			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
 

--- a/src/stories/3-fields/multi-select/multi-select.stories.tsx
+++ b/src/stories/3-fields/multi-select/multi-select.stories.tsx
@@ -59,14 +59,6 @@ const meta: Meta = {
 				},
 			},
 		},
-		listStyleWidth: {
-			description: "Style option: The width of the options. You can specify e.g. 100% or 12rem",
-			table: {
-				type: {
-					summary: "string",
-				},
-			},
-		},
 	},
 };
 export default meta;
@@ -142,18 +134,6 @@ Searchable.args = {
 		{ label: "Cherry", value: "cherry" },
 	],
 	enableSearch: true,
-};
-
-export const CustomWidth = DefaultStoryTemplate<IMultiSelectSchema>("multi-select-custom-width").bind({});
-CustomWidth.args = {
-	uiType: "multi-select",
-	label: "Fruits",
-	options: [
-		{ value: "Apple", label: "Apple" },
-		{ value: "Berry", label: "Berry" },
-		{ value: "Cherry", label: "Cherry" },
-	],
-	listStyleWidth: "12rem",
 };
 
 export const Placeholder = DefaultStoryTemplate<IMultiSelectSchema>("multi-select-placeholder").bind({});

--- a/src/stories/3-fields/select/select.stories.tsx
+++ b/src/stories/3-fields/select/select.stories.tsx
@@ -57,14 +57,6 @@ const meta: Meta = {
 				},
 			},
 		},
-		listStyleWidth: {
-			description: "Style option: The width of the options. You can specify e.g. 100% or 12rem",
-			table: {
-				type: {
-					summary: "string",
-				},
-			},
-		},
 	},
 };
 export default meta;
@@ -139,18 +131,6 @@ Searchable.args = {
 		{ label: "Cherry", value: "cherry" },
 	],
 	enableSearch: true,
-};
-
-export const CustomWidth = DefaultStoryTemplate<ISelectSchema>("select-custom-width").bind({});
-CustomWidth.args = {
-	uiType: "select",
-	label: "Fruits",
-	options: [
-		{ label: "Apple", value: "apple" },
-		{ label: "Berry", value: "berry" },
-		{ label: "Cherry", value: "cherry" },
-	],
-	listStyleWidth: "12rem",
 };
 
 export const Placeholder = DefaultStoryTemplate<ISelectSchema>("select-placeholder").bind({});


### PR DESCRIPTION
**Changes**

Bump DS peer dependency

Notable changes in `v2.7.0-canary.3`:
- select and multi-select have a new dropdown menu
- the `listStyleWidth` prop is deprecated - have removed the stories
- list items now have aria role `option` instead of being buttons - update selectors in unit tests
---
-   [delete] branch