### PR TITLE
Mol 15191

### DIFF
--- a/src/components/fields/image-upload/image-review/image-thumbnails/image-thumbnails.tsx
+++ b/src/components/fields/image-upload/image-review/image-thumbnails/image-thumbnails.tsx
@@ -1,7 +1,6 @@
 import { ChangeEvent, useRef } from "react";
 import { TestHelper } from "../../../../../utils";
-import { TFileCapture } from "../../types";
-import { EImageStatus, IImage, ISharedImageProps } from "../../types";
+import { EImageStatus, IImage, ISharedImageProps, TFileCapture } from "../../types";
 import {
 	AddImageButton,
 	BorderOverlay,
@@ -117,6 +116,7 @@ export const ImageThumbnails = (props: IProps) => {
 					accept={accepts.map((fileType) => `.${fileType}`).join(", ")}
 					onChange={handleInputChange}
 					multiple={multiple}
+					value="" // controlling the value to allow for the same file to be uploaded (by triggering on change)
 				/>
 				<AddImageButton
 					type="button"

--- a/src/components/shared/prompt/prompt.styles.ts
+++ b/src/components/shared/prompt/prompt.styles.ts
@@ -55,7 +55,7 @@ export const LabelContainer = styled.div<SizeProps>`
 	display: flex;
 	flex-direction: column;
 	text-align: center;
-	padding: 1.5rem;
+	padding: 4rem 1.5rem 1.5rem;
 
 	${MediaQuery.MinWidth.mobileL} {
 		padding: ${(props) => (props.size === "large" ? "4rem 4rem 0rem 4rem" : "1rem 1.5rem 0")};
@@ -67,5 +67,5 @@ export const Description = styled(Text.H4)`
 `;
 
 export const Title = styled(Text.H4)<SizeProps>`
-	margin-top: ${(props) => (props.size === "large" ? "0rem" : "2rem")};
+	margin-top: 0rem;
 `;


### PR DESCRIPTION
**Changes**
- fix styling of image prompts (for both sizes large and normal)
<img width="598" alt="Screenshot 2024-08-22 at 3 59 22 PM" src="https://github.com/user-attachments/assets/c7d9773d-40f3-461f-9858-769224c304dc">
<img width="541" alt="Screenshot 2024-08-23 at 6 25 40 PM" src="https://github.com/user-attachments/assets/74b62108-e935-4ed3-a23a-4c8f2180fac7">
<img width="595" alt="Screenshot 2024-08-23 at 6 25 51 PM" src="https://github.com/user-attachments/assets/d81c165b-9e05-4bd7-a70d-a2d9f3d5b218">
<img width="558" alt="Screenshot 2024-08-22 at 3 57 53 PM" src="https://github.com/user-attachments/assets/d0ff202b-9ce6-414d-b813-b6f6490b5ab9">

- control image input value to allow for uploading of the same file

-   [delete] branch

**Changelog entry**

-   fix image prompts padding
-   fix bug where user cannot upload the same image twice in a row 
