### PR TITLE
Add new optional DS props for Filter & FilterCheckbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The intention of frontend engine is to take out the heavy lifting of form develo
 
 Developers are expected to have the following packages installed:
 
--   @lifesg/react-design-system 2.7.0-canary.3
+-   @lifesg/react-design-system 2.7.0-canary.6
 -   @lifesg/react-icons 1.2.0
 -   react 17.0.2 or 18
 -   react-dom 17.0.2 or 18

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 				"@babel/preset-env": "^7.19.3",
 				"@babel/preset-react": "^7.18.6",
 				"@babel/preset-typescript": "^7.18.6",
-				"@lifesg/react-design-system": "^2.7.0-canary.5",
+				"@lifesg/react-design-system": "^2.7.0-canary.6",
 				"@lifesg/react-icons": "^1.6.0",
 				"@mihkeleidast/storybook-addon-source": "^1.0.1",
 				"@rollup/plugin-commonjs": "^22.0.2",
@@ -95,7 +95,7 @@
 				"typescript": "^4.8.4"
 			},
 			"peerDependencies": {
-				"@lifesg/react-design-system": "^2.7.0-canary.5",
+				"@lifesg/react-design-system": "^2.7.0-canary.6",
 				"@lifesg/react-icons": "^1.6.0",
 				"react": "^17.0.2 || ^18.0.0",
 				"react-dom": "^17.0.2 || ^18.0.0",
@@ -3445,9 +3445,9 @@
 			}
 		},
 		"node_modules/@lifesg/react-design-system": {
-			"version": "2.7.0-canary.5",
-			"resolved": "https://registry.npmjs.org/@lifesg/react-design-system/-/react-design-system-2.7.0-canary.5.tgz",
-			"integrity": "sha512-pvpMI6Ts+qvui12ls1qDDS4rYRERFbFHKUxITsMkMmUkaYna7Od8zcUYqe3INHgyQ3M82I9I8NPvBQ+A1yyO6A==",
+			"version": "2.7.0-canary.6",
+			"resolved": "https://registry.npmjs.org/@lifesg/react-design-system/-/react-design-system-2.7.0-canary.6.tgz",
+			"integrity": "sha512-IL74s/AgWzYiaOAins7AvScKibzDornCx2/4rygT2V9pEYWoqTUb4KbUP7K1Dk8HHesXpWnJZ+d4FXkyu4LUaA==",
 			"dev": true,
 			"dependencies": {
 				"@floating-ui/dom": "^1.5.4",
@@ -16147,6 +16147,7 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
 			"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"yup": "^0.32.11"
 	},
 	"peerDependencies": {
-		"@lifesg/react-design-system": "^2.7.0-canary.5",
+		"@lifesg/react-design-system": "^2.7.0-canary.6",
 		"@lifesg/react-icons": "^1.6.0",
 		"react": "^17.0.2 || ^18.0.0",
 		"react-dom": "^17.0.2 || ^18.0.0",
@@ -66,7 +66,7 @@
 		"@babel/preset-env": "^7.19.3",
 		"@babel/preset-react": "^7.18.6",
 		"@babel/preset-typescript": "^7.18.6",
-		"@lifesg/react-design-system": "^2.7.0-canary.5",
+		"@lifesg/react-design-system": "^2.7.0-canary.6",
 		"@lifesg/react-icons": "^1.6.0",
 		"@mihkeleidast/storybook-addon-source": "^1.0.1",
 		"@rollup/plugin-commonjs": "^22.0.2",

--- a/src/components/custom/filter/filter-checkbox/types.ts
+++ b/src/components/custom/filter/filter-checkbox/types.ts
@@ -11,6 +11,7 @@ export interface IFilterCheckboxSchema<V = undefined>
 	showMobileDivider?: boolean | undefined;
 	clearBehavior?: TClearBehavior | undefined;
 	expanded?: boolean | undefined;
+	useToggleContentWidth?: boolean | undefined;
 }
 
 export interface IOption {

--- a/src/components/custom/filter/filter/filter.tsx
+++ b/src/components/custom/filter/filter/filter.tsx
@@ -19,7 +19,7 @@ export const Filter = (props: IGenericCustomElementProps<IFilterSchema>) => {
 
 	const {
 		id,
-		schema: { children, label, toggleFilterButtonLabel, clearButtonDisabled },
+		schema: { children, label, toggleFilterButtonLabel, toggleFilterButtonStyle, clearButtonDisabled },
 	} = props;
 
 	// =============================================================================
@@ -79,6 +79,7 @@ export const Filter = (props: IGenericCustomElementProps<IFilterSchema>) => {
 		<FilterComponent
 			data-testid={TestHelper.generateId(id, "filter")}
 			toggleFilterButtonLabel={toggleFilterButtonLabel}
+			toggleFilterButtonStyle={toggleFilterButtonStyle}
 			headerTitle={label}
 			clearButtonDisabled={clearButtonDisabled}
 			onClear={clearData}

--- a/src/components/custom/filter/filter/types.ts
+++ b/src/components/custom/filter/filter/types.ts
@@ -1,3 +1,4 @@
+import { ButtonStyleType } from "@lifesg/react-design-system";
 import { ICustomElementJsonSchema } from "../../types";
 import { IFilterCheckboxSchema } from "../filter-checkbox/types";
 import { IFilterItemSchema } from "../filter-item/types";
@@ -5,6 +6,7 @@ import { IFilterItemSchema } from "../filter-item/types";
 export interface IFilterSchema<V = undefined, C = undefined> extends ICustomElementJsonSchema<"filter"> {
 	label?: string | undefined;
 	toggleFilterButtonLabel?: string | undefined;
+	toggleFilterButtonStyle?: ButtonStyleType | undefined;
 	children: Record<string, IFilterItemSchema<V, C> | IFilterCheckboxSchema>;
 	clearButtonDisabled?: boolean | undefined;
 }

--- a/src/components/custom/filter/filter/types.ts
+++ b/src/components/custom/filter/filter/types.ts
@@ -1,4 +1,4 @@
-import { ButtonStyleType } from "@lifesg/react-design-system";
+import { ButtonStyleType } from "@lifesg/react-design-system/button";
 import { ICustomElementJsonSchema } from "../../types";
 import { IFilterCheckboxSchema } from "../filter-checkbox/types";
 import { IFilterItemSchema } from "../filter-item/types";

--- a/src/stories/5-custom/filter/filter-checkbox-item.stories.tsx
+++ b/src/stories/5-custom/filter/filter-checkbox-item.stories.tsx
@@ -97,6 +97,14 @@ const meta: Meta = {
 			},
 			defaultValue: false,
 		},
+		useToggleContentWidth: {
+			description: "Changes the minimum width of the checkbox toggle to fit its content (on mobile)",
+			table: {
+				type: {
+					summary: "boolean",
+				},
+			},
+		},
 	},
 };
 export default meta;
@@ -296,3 +304,14 @@ Overrides.args = {
 	},
 };
 Overrides.argTypes = OVERRIDES_ARG_TYPE;
+
+export const MobileContentWidth = Template("filter-checkbox-mobile-content-width").bind({});
+MobileContentWidth.args = {
+	label: "Filter checkbox",
+	referenceKey: "filter-checkbox",
+	options: [
+		{ label: "Red", value: "red" },
+		{ label: "Blue", value: "blue" },
+	],
+	useToggleContentWidth: true,
+};

--- a/src/stories/5-custom/filter/filter.stories.tsx
+++ b/src/stories/5-custom/filter/filter.stories.tsx
@@ -33,6 +33,15 @@ const meta: Meta = {
 			description: "Filter button label used in mobile view.",
 			defaultValue: "Filters Mobile",
 		},
+		toggleFilterButtonStyle: {
+			description: "Filter button style type used in mobile view.",
+			table: {
+				type: {
+					summary: "default | secondary | light | link",
+				},
+				defaultValue: { summary: "light" },
+			},
+		},
 		clearButtonDisabled: {
 			description: "Toggle to disable the clear filters button",
 			control: {
@@ -147,3 +156,24 @@ Overrides.args = {
 	},
 };
 Overrides.argTypes = OVERRIDES_ARG_TYPE;
+
+export const MobileButtonStyle = Template("wrapper-default").bind({});
+MobileButtonStyle.args = {
+	referenceKey: "filter",
+	label: "Filters Desktop",
+	toggleFilterButtonLabel: "Filters Mobile",
+	toggleFilterButtonStyle: "secondary",
+	children: {
+		filterItem1: {
+			label: "Search",
+			referenceKey: "filter-item",
+			children: {
+				name: {
+					label: "",
+					uiType: "text-field",
+					placeholder: "Enter keyword",
+				},
+			},
+		},
+	},
+};

--- a/src/stories/5-custom/timeline/timeline.stories.tsx
+++ b/src/stories/5-custom/timeline/timeline.stories.tsx
@@ -1,4 +1,4 @@
-import { ArgsTable, Description, Heading, PRIMARY_STORY, Stories, Title } from "@storybook/addon-docs";
+import { ArgTypes, Heading, Stories, Title } from "@storybook/addon-docs";
 import { Meta } from "@storybook/react";
 import { ITimelineSchema } from "../../../components/custom/timeline";
 import { CommonCustomStoryProps, DefaultStoryTemplate } from "../../common";
@@ -10,9 +10,8 @@ const meta: Meta = {
 			page: () => (
 				<>
 					<Title>Timeline</Title>
-					<Description>Represents the steps of a process in a chronological order.</Description>
-					<Heading>Props</Heading>
-					<ArgsTable story={PRIMARY_STORY} />
+					<p>Represents the steps of a process in a chronological order.</p>
+					<ArgTypes of={Default} />
 					<Stories includePrimary={true} title="Example" />
 				</>
 			),


### PR DESCRIPTION
**Changes**
- Bump DS version
- Fix deprecated storybook components for `Timeline`
- Add `toggleFilterButtonStyle` and `useToggleContentWidth` props for `Filter` & `FilterCheckbox` respectively (same props added in DS)

-   [delete] branch

**Changelog entry**
- Add optional `toggleFilterButtonStyle` prop for `Filter` component
- Add optional `useContentWidth` prop for `FilterCheckbox` component

**Additional information**

-   You may refer to these [BOOKINGSG-6062](https://jira.ship.gov.sg/browse/BOOKINGSG-6062), [BOOKINGSG-5999](https://jira.ship.gov.sg/browse/BOOKINGSG-5999)