### PR TITLE
Create popover element

### DIFF
--- a/src/__tests__/components/elements/popover/popover.spec.tsx
+++ b/src/__tests__/components/elements/popover/popover.spec.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { IPopoverSchema } from "../../../../components/elements";
+import { FrontendEngine, IFrontendEngineData } from "../../../../components/frontend-engine";
+import { TestHelper } from "../../../../utils";
+import { FRONTEND_ENGINE_ID, TOverrideField, TOverrideSchema } from "../../../common";
+
+const SUBMIT_FN = jest.fn();
+const COMPONENT_ID = "field";
+const UI_TYPE = "popover";
+const COMPONENT_TEST_ID = TestHelper.generateId(COMPONENT_ID, "popover");
+
+const renderComponent = (overrideField?: TOverrideField<IPopoverSchema>, overrideSchema?: TOverrideSchema) => {
+	const json: IFrontendEngineData = {
+		id: FRONTEND_ENGINE_ID,
+		sections: {
+			section: {
+				uiType: "section",
+				children: {
+					[COMPONENT_ID]: {
+						uiType: UI_TYPE,
+						children: "Text",
+						hint: { content: "Hint" },
+						...overrideField,
+					},
+				},
+			},
+		},
+		...overrideSchema,
+	};
+	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
+};
+
+describe(UI_TYPE, () => {
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it("should be able to render the text and hint", () => {
+		renderComponent();
+
+		expect(screen.getByText("Text")).toBeInTheDocument();
+		expect(screen.queryByText("Hint")).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByTestId("field__popover"));
+
+		expect(screen.getByText("Hint")).toBeVisible();
+	});
+
+	it("should be able to render a HTML string", () => {
+		renderComponent({ children: "<div>HTML text</div>", hint: { content: "<div>HTML hint</div>" } });
+
+		fireEvent.click(screen.getByTestId("field__popover"));
+
+		expect(screen.getByText("HTML text")).toBeInTheDocument();
+		expect(screen.getByText("HTML hint")).toBeInTheDocument();
+	});
+
+	it("should be able to sanitize HTML string", () => {
+		renderComponent({
+			children: "<div>HTML text<script>console.log('hello world')</script></div>",
+			hint: { content: "<div>HTML hint<script>console.log('hello world')</script></div>" },
+		});
+
+		fireEvent.click(screen.getByTestId("field__popover"));
+
+		expect(screen.getByText("HTML text")).toBeInTheDocument();
+		expect(screen.getByText("HTML hint")).toBeInTheDocument();
+		expect(screen.queryByTestId(COMPONENT_TEST_ID).innerHTML.includes("script")).toBe(false);
+		expect(screen.queryByTestId("popover").innerHTML.includes("script")).toBe(false);
+	});
+});

--- a/src/__tests__/components/elements/popover/popover.spec.tsx
+++ b/src/__tests__/components/elements/popover/popover.spec.tsx
@@ -68,4 +68,13 @@ describe(UI_TYPE, () => {
 		expect(screen.queryByTestId(COMPONENT_TEST_ID).innerHTML.includes("script")).toBe(false);
 		expect(screen.queryByTestId("popover").innerHTML.includes("script")).toBe(false);
 	});
+
+	it("should render icon after text if specified", async () => {
+		renderComponent({ icon: "AlbumFillIcon" });
+
+		const label = screen.getByText("Text");
+		const icon = document.querySelector("svg");
+
+		expect(label.compareDocumentPosition(icon)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+	});
 });

--- a/src/components/elements/index.ts
+++ b/src/components/elements/index.ts
@@ -3,6 +3,7 @@ export * from "./alert";
 export * from "./divider";
 export * from "./grid";
 export * from "./list";
+export * from "./popover";
 export * from "./tab";
 export * from "./text";
 export * from "./types";

--- a/src/components/elements/popover/index.ts
+++ b/src/components/elements/popover/index.ts
@@ -1,0 +1,2 @@
+export * from "./popover";
+export * from "./types";

--- a/src/components/elements/popover/popover.styles.ts
+++ b/src/components/elements/popover/popover.styles.ts
@@ -1,0 +1,27 @@
+import { Color } from "@lifesg/react-design-system/color";
+import styled from "styled-components";
+
+// =============================================================================
+// STYLE INTERFACE
+// =============================================================================
+
+interface StyledIconProps {
+	$standalone: boolean;
+}
+
+// =============================================================================
+// STYLING
+// =============================================================================
+
+export const StyledText = styled.span`
+	color: ${Color.Primary};
+	font-weight: 600;
+`;
+
+export const StyledIcon = styled.span<StyledIconProps>`
+	height: 1lh; // align vertically
+	width: 1em; // scale icon with font size
+	vertical-align: top;
+
+	${(props) => !props.$standalone && "margin-left: 0.25rem;"}
+`;

--- a/src/components/elements/popover/popover.tsx
+++ b/src/components/elements/popover/popover.tsx
@@ -1,10 +1,9 @@
-import { Color } from "@lifesg/react-design-system/color";
 import { PopoverTrigger } from "@lifesg/react-design-system/popover-v2";
 import * as Icons from "@lifesg/react-icons";
-import styled from "styled-components";
 import { TestHelper } from "../../../utils";
 import { Sanitize } from "../../shared";
 import { IGenericElementProps } from "../types";
+import { StyledIcon, StyledText } from "./popover.styles";
 import { IPopoverSchema } from "./types";
 
 export const Popover = (props: IGenericElementProps<IPopoverSchema>) => {
@@ -23,7 +22,7 @@ export const Popover = (props: IGenericElementProps<IPopoverSchema>) => {
 		if (!icon) return null;
 
 		const Element = Icons[icon];
-		return <StyledIcon as={Element} />;
+		return <StyledIcon as={Element} $standalone={!children} />;
 	};
 
 	return (
@@ -42,15 +41,3 @@ export const Popover = (props: IGenericElementProps<IPopoverSchema>) => {
 		</PopoverTrigger>
 	);
 };
-
-const StyledText = styled.span`
-	color: ${Color.Primary};
-	font-weight: 600;
-`;
-
-const StyledIcon = styled.span`
-	height: 1lh; // align vertically
-	width: 1em; // scale icon with font size
-	margin-left: 0.25rem;
-	vertical-align: top;
-`;

--- a/src/components/elements/popover/popover.tsx
+++ b/src/components/elements/popover/popover.tsx
@@ -1,0 +1,56 @@
+import { Color } from "@lifesg/react-design-system/color";
+import { PopoverTrigger } from "@lifesg/react-design-system/popover-v2";
+import * as Icons from "@lifesg/react-icons";
+import styled from "styled-components";
+import { TestHelper } from "../../../utils";
+import { Sanitize } from "../../shared";
+import { IGenericElementProps } from "../types";
+import { IPopoverSchema } from "./types";
+
+export const Popover = (props: IGenericElementProps<IPopoverSchema>) => {
+	// =============================================================================
+	// CONST, STATE, REF
+	// =============================================================================
+	const {
+		id,
+		schema: { children, className, icon, hint, trigger },
+	} = props;
+
+	// =============================================================================
+	// RENDER FUNCTIONS
+	// =============================================================================
+	const renderIcon = () => {
+		if (!icon) return null;
+
+		const Element = Icons[icon];
+		return <StyledIcon as={Element} />;
+	};
+
+	return (
+		<PopoverTrigger
+			id={id}
+			data-testid={TestHelper.generateId(id, "popover")}
+			className={className}
+			popoverContent={<Sanitize inline>{hint.content}</Sanitize>}
+			trigger={trigger}
+			zIndex={hint.zIndex}
+		>
+			<StyledText>
+				<Sanitize inline>{children}</Sanitize>
+				{renderIcon()}
+			</StyledText>
+		</PopoverTrigger>
+	);
+};
+
+const StyledText = styled.span`
+	color: ${Color.Primary};
+	font-weight: 600;
+`;
+
+const StyledIcon = styled.span`
+	height: 1lh; // align vertically
+	width: 1em; // scale icon with font size
+	margin-left: 0.25rem;
+	vertical-align: top;
+`;

--- a/src/components/elements/popover/types.ts
+++ b/src/components/elements/popover/types.ts
@@ -8,7 +8,7 @@ interface IPopoverHint {
 }
 
 export interface IPopoverSchema extends IBaseElementSchema<"popover"> {
-	children: string;
+	children?: string | undefined;
 	className?: string | undefined;
 	hint: IPopoverHint;
 	icon?: keyof typeof Icons | undefined;

--- a/src/components/elements/popover/types.ts
+++ b/src/components/elements/popover/types.ts
@@ -1,0 +1,16 @@
+import { PopoverV2TriggerType } from "@lifesg/react-design-system/popover-v2";
+import * as Icons from "@lifesg/react-icons";
+import { IBaseElementSchema } from "../types";
+
+interface IPopoverHint {
+	content: string;
+	zIndex?: number | undefined;
+}
+
+export interface IPopoverSchema extends IBaseElementSchema<"popover"> {
+	children: string;
+	className?: string | undefined;
+	hint: IPopoverHint;
+	icon?: keyof typeof Icons | undefined;
+	trigger?: PopoverV2TriggerType | undefined;
+}

--- a/src/components/elements/text/text.tsx
+++ b/src/components/elements/text/text.tsx
@@ -2,13 +2,14 @@ import { Button } from "@lifesg/react-design-system/button";
 import isArray from "lodash/isArray";
 import isObject from "lodash/isObject";
 import { useEffect, useRef, useState } from "react";
+import sanitizeHtml, { IOptions } from "sanitize-html";
+import styled from "styled-components";
 import { TestHelper } from "../../../utils";
 import { Sanitize } from "../../shared";
 import { IGenericElementProps } from "../types";
 import { TEXT_MAPPING } from "./data";
 import { ITextSchema } from "./types";
-import styled from "styled-components";
-import sanitizeHtml from "sanitize-html";
+import { Wrapper } from "../wrapper";
 
 export const Text = (props: IGenericElementProps<ITextSchema>) => {
 	// =============================================================================
@@ -58,6 +59,11 @@ export const Text = (props: IGenericElementProps<ITextSchema>) => {
 	// =============================================================================
 	// RENDER FUNCTIONS
 	// =============================================================================
+	const sanitizeOptions: IOptions = {
+		allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img"]),
+		allowedAttributes: false,
+	};
+
 	const renderText = (): JSX.Element[] | JSX.Element | string[] | string => {
 		if (isArray(children)) {
 			return children.map((text, index) => {
@@ -65,18 +71,20 @@ export const Text = (props: IGenericElementProps<ITextSchema>) => {
 
 				return (
 					<Element key={index} id={childrenId} data-testid={getTestId(childrenId)}>
-						<Sanitize id={childrenId} inline>
+						<Sanitize id={childrenId} inline sanitizeOptions={sanitizeOptions}>
 							{text}
 						</Sanitize>
 					</Element>
 				);
 			});
 		} else if (typeof children === "object") {
-			return Object.entries(children).map(([id, childSchema], index) => (
-				<Text key={index} id={id} schema={childSchema} />
-			));
+			return <Wrapper>{children}</Wrapper>;
 		}
-		return children;
+		return (
+			<Sanitize inline sanitizeOptions={sanitizeOptions}>
+				{children}
+			</Sanitize>
+		);
 	};
 
 	return (
@@ -90,15 +98,7 @@ export const Text = (props: IGenericElementProps<ITextSchema>) => {
 				// NOTE: Parent text body should be transformed into <div> to prevent validateDOMNesting error
 				{...(hasNestedFields() && { as: "div" })}
 			>
-				<Sanitize
-					inline
-					sanitizeOptions={{
-						allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img"]),
-						allowedAttributes: false,
-					}}
-				>
-					{renderText()}
-				</Sanitize>
+				{renderText()}
 			</Element>
 
 			{showExpandButton && (

--- a/src/components/elements/text/types.ts
+++ b/src/components/elements/text/types.ts
@@ -1,5 +1,6 @@
 import { TextProps } from "@lifesg/react-design-system/text";
 import { TComponentOmitProps } from "../../frontend-engine";
+import { IPopoverSchema } from "../popover/types";
 import { IBaseElementSchema } from "../types";
 
 export type TTextType =
@@ -17,5 +18,5 @@ export type TTextType =
 	| "text-xsmall";
 
 export interface ITextSchema extends IBaseElementSchema<TTextType>, TComponentOmitProps<TextProps, "children"> {
-	children: string | string[] | Record<string, ITextSchema>;
+	children: string | string[] | Record<string, ITextSchema | IPopoverSchema>;
 }

--- a/src/components/elements/types.ts
+++ b/src/components/elements/types.ts
@@ -5,6 +5,7 @@ import type { IAlertSchema } from "./alert";
 import { IDividerSchema } from "./divider";
 import { IGridSchema } from "./grid";
 import { IOrderedListSchema, IUnorderedListSchema } from "./list";
+import { IPopoverSchema } from "./popover";
 import { ITabItemSchema, ITabSchema } from "./tab";
 import type { ITextSchema } from "./text";
 import type { IWrapperSchema } from "./wrapper";
@@ -47,6 +48,7 @@ export enum EElementType {
 	"ORDERED-LIST" = "List",
 	"UNORDERED-LIST" = "List",
 	ACCORDION = "Accordion",
+	POPOVER = "Popover",
 }
 
 /**
@@ -58,6 +60,7 @@ export type TElementSchema<V = undefined, C = undefined> =
 	| IDividerSchema
 	| IGridSchema<V, C>
 	| IOrderedListSchema<V, C>
+	| IPopoverSchema
 	| ITabItemSchema<V, C>
 	| ITabSchema<V, C>
 	| ITextSchema

--- a/src/stories/4-elements/popover/popover.stories.tsx
+++ b/src/stories/4-elements/popover/popover.stories.tsx
@@ -99,10 +99,17 @@ Default.args = {
 	hint: { content: "Hint" },
 };
 
-export const Icon = Template("popover-icon").bind({});
-Icon.args = {
+export const WithIcon = Template("popover-with-icon").bind({});
+WithIcon.args = {
 	uiType: "popover",
 	children: "More info",
+	icon: "ICircleFillIcon",
+	hint: { content: "Hint" },
+};
+
+export const IconOnly = Template("popover-icon-only").bind({});
+IconOnly.args = {
+	uiType: "popover",
 	icon: "ICircleFillIcon",
 	hint: { content: "Hint" },
 };

--- a/src/stories/4-elements/popover/popover.stories.tsx
+++ b/src/stories/4-elements/popover/popover.stories.tsx
@@ -1,0 +1,171 @@
+import * as Icons from "@lifesg/react-icons";
+import { ArgTypes, Stories, Title } from "@storybook/addon-docs";
+import { Meta, StoryFn } from "@storybook/react";
+import { IPopoverSchema } from "../../../components/elements";
+import { CommonFieldStoryProps, FrontendEngine, OVERRIDES_ARG_TYPE, OverrideStoryTemplate } from "../../common";
+
+const meta: Meta = {
+	title: "Element/Popover",
+	parameters: {
+		docs: {
+			page: () => (
+				<>
+					<Title>Popover</Title>
+					<p>
+						This component renders text with an optional icon that triggers a <code>Popover</code> within a
+						Frontend Engine generated form.
+					</p>
+					<ArgTypes of={Default} />
+					<Stories includePrimary={true} title="Example" />
+				</>
+			),
+		},
+	},
+	argTypes: {
+		...CommonFieldStoryProps("popover", true),
+		children: {
+			type: {
+				name: "string",
+				required: true,
+			},
+			description: "The content of the popover trigger",
+			table: {
+				type: {
+					summary: "string",
+				},
+			},
+		},
+		icon: {
+			description:
+				"Add an icon based on <a href='https://designsystem.life.gov.sg/reacticons/index.html?path=/docs/collection--docs' target='_blank' rel='noopener noreferrer'>React Icons</a>",
+			table: {
+				type: {
+					summary: "Refer to React Icons",
+				},
+			},
+			control: {
+				type: "select",
+			},
+			options: Object.keys(Icons),
+		},
+		hint: {
+			description: `The popover configuration
+				<ul>
+					<li>content: Content to display in the popover.</li>
+					<li>zIndex: Customises the popover z-index.</li>
+				</ul>
+			`,
+			table: {
+				type: {
+					summary: "{ content: string; zIndex?: number }",
+				},
+			},
+		},
+		trigger: {
+			description: "Activate the popover via click or hover",
+			table: {
+				type: {
+					summary: "click | hover",
+				},
+				defaultValue: {
+					summary: "click",
+				},
+			},
+		},
+	},
+};
+export default meta;
+
+const Template = (id: string) =>
+	((args) => (
+		<FrontendEngine
+			data={{
+				sections: {
+					section: {
+						uiType: "section",
+						children: {
+							[id]: args,
+						},
+					},
+				},
+			}}
+		/>
+	)) as StoryFn<IPopoverSchema>;
+
+export const Default = Template("popover-default").bind({});
+Default.args = {
+	uiType: "popover",
+	children: "More info",
+	hint: { content: "Hint" },
+};
+
+export const Icon = Template("popover-icon").bind({});
+Icon.args = {
+	uiType: "popover",
+	children: "More info",
+	icon: "ICircleFillIcon",
+	hint: { content: "Hint" },
+};
+
+export const HTMLString = Template("popover-html-string").bind({});
+HTMLString.args = {
+	uiType: "popover",
+	children: "More <em>important</em> info",
+	hint: { content: "Hint" },
+};
+
+export const TooltipCustomisation = Template("popover-tooltip-customisation").bind({});
+TooltipCustomisation.args = {
+	uiType: "popover",
+	children: "More info",
+	hint: { content: "A helpful tip<br>Another helpful tip on next line" },
+};
+
+export const Hover = Template("popover-hover").bind({});
+Hover.args = {
+	uiType: "popover",
+	children: "More info",
+	trigger: "hover",
+	hint: { content: "Hint" },
+};
+
+export const InlineUsage: StoryFn = () => {
+	return (
+		<FrontendEngine
+			data={{
+				sections: {
+					section: {
+						uiType: "section",
+						children: {
+							text: {
+								uiType: "text-body",
+								children: {
+									1: { uiType: "text-body", children: "Click ", inline: true },
+									2: {
+										uiType: "popover",
+										children: "here",
+										hint: { content: "Hint" },
+										icon: "QuestionmarkCircleFillIcon",
+									},
+									3: { uiType: "text-body", children: " to find out more", inline: true },
+								},
+							},
+						},
+					},
+				},
+			}}
+		/>
+	);
+};
+
+export const Overrides = OverrideStoryTemplate<IPopoverSchema>("popover-overrides", false).bind({});
+Overrides.args = {
+	uiType: "popover",
+	children: "Popover",
+	hint: { content: "Hint" },
+	overrides: {
+		children: "Overridden",
+		hint: { content: "Overridden" },
+	},
+};
+Overrides.argTypes = OVERRIDES_ARG_TYPE;


### PR DESCRIPTION
**Changes**
Add popover element that renders an interactive text string and supports an optional icon based on the DS collection

It can be used standalone (with a parent container) or inline with text elements (see `Inline Usage` story)

The sanitisation behaviour in the text component was tweaked to prevent stripping of the inline svg icon. As a side effect, it seems to restore the paragraph styling

![Screenshot 2024-09-05 at 11 08 19 AM](https://github.com/user-attachments/assets/ad7387f0-bf19-404b-9994-cc4b7f902c93)

-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Add popover element

**Additional information**

-   You may refer to this [ticket](https://jira.ship.gov.sg/browse/MOL-16147)

