### PR TITLE
Support FEE schema in alert children

### DIFF
--- a/src/__tests__/components/elements/alert/alert.spec.tsx
+++ b/src/__tests__/components/elements/alert/alert.spec.tsx
@@ -62,4 +62,10 @@ describe(UI_TYPE, () => {
 		expect(screen.getByText("This is a sanitized string")).toBeInTheDocument();
 		expect(document.querySelector(".alert-element").innerHTML.includes("script")).toBe(false);
 	});
+
+	it("should be able to render FEE schema children", () => {
+		renderComponent({ children: { text: { uiType: "text-body", children: "This is a schema" } } });
+
+		expect(screen.getByText("This is a schema")).toBeInTheDocument();
+	});
 });

--- a/src/components/elements/alert/alert.tsx
+++ b/src/components/elements/alert/alert.tsx
@@ -1,7 +1,10 @@
 import { Alert as DSAlert } from "@lifesg/react-design-system/alert";
+import React from "react";
 import { TestHelper } from "../../../utils";
+import { TFrontendEngineFieldSchema } from "../../frontend-engine";
 import { Sanitize } from "../../shared";
 import { IGenericElementProps } from "../types";
+import { Wrapper } from "../wrapper";
 import { IAlertSchema } from "./types";
 
 export const Alert = (props: IGenericElementProps<IAlertSchema>) => {
@@ -16,9 +19,27 @@ export const Alert = (props: IGenericElementProps<IAlertSchema>) => {
 	// =============================================================================
 	// RENDER FUNCTIONS
 	// =============================================================================
+	const renderContent = () => {
+		if (typeof children === "string") {
+			return <Sanitize id={id}>{children}</Sanitize>;
+		}
+
+		if (
+			React.isValidElement(children) ||
+			Array.isArray(children) ||
+			typeof children === "number" ||
+			typeof children === "boolean" ||
+			typeof children == undefined
+		) {
+			return children as React.ReactNode;
+		}
+
+		return <Wrapper>{children as Record<string, TFrontendEngineFieldSchema>}</Wrapper>;
+	};
+
 	return (
 		<DSAlert id={id} data-testid={TestHelper.generateId(id, "alert")} {...otherSchema}>
-			<Sanitize id={id}>{children}</Sanitize>
+			{renderContent()}
 		</DSAlert>
 	);
 };

--- a/src/components/elements/alert/types.ts
+++ b/src/components/elements/alert/types.ts
@@ -1,8 +1,10 @@
 import { AlertProps, AlertType } from "@lifesg/react-design-system";
-import { TComponentOmitProps } from "../../frontend-engine";
+import { TComponentOmitProps, TFrontendEngineFieldSchema } from "../../frontend-engine";
 import { IBaseElementSchema } from "../types";
 
-export interface IAlertSchema extends IBaseElementSchema<"alert">, TComponentOmitProps<AlertProps> {
+export interface IAlertSchema<V = undefined, C = undefined>
+	extends IBaseElementSchema<"alert">,
+		TComponentOmitProps<AlertProps> {
 	type: AlertType;
-	children: React.ReactNode;
+	children: React.ReactNode | Record<string, TFrontendEngineFieldSchema<V, C>>;
 }

--- a/src/components/elements/alert/types.ts
+++ b/src/components/elements/alert/types.ts
@@ -1,10 +1,10 @@
 import { AlertProps, AlertType } from "@lifesg/react-design-system";
-import { TComponentOmitProps, TFrontendEngineFieldSchema } from "../../frontend-engine";
-import { IBaseElementSchema } from "../types";
+import { TComponentOmitProps } from "../../frontend-engine";
+import { IBaseElementSchema, TElementSchema } from "../types";
 
 export interface IAlertSchema<V = undefined, C = undefined>
 	extends IBaseElementSchema<"alert">,
 		TComponentOmitProps<AlertProps> {
 	type: AlertType;
-	children: React.ReactNode | Record<string, TFrontendEngineFieldSchema<V, C>>;
+	children: React.ReactNode | Record<string, TElementSchema<V, C>>; // use element schema instead
 }

--- a/src/components/elements/alert/types.ts
+++ b/src/components/elements/alert/types.ts
@@ -1,10 +1,15 @@
 import { AlertProps, AlertType } from "@lifesg/react-design-system";
 import { TComponentOmitProps } from "../../frontend-engine";
-import { IBaseElementSchema, TElementSchema } from "../types";
+import type { IDividerSchema } from "../divider";
+import type { IOrderedListSchema, IUnorderedListSchema } from "../list";
+import type { ITextSchema } from "../text";
+import { IBaseElementSchema } from "../types";
 
 export interface IAlertSchema<V = undefined, C = undefined>
 	extends IBaseElementSchema<"alert">,
 		TComponentOmitProps<AlertProps> {
 	type: AlertType;
-	children: React.ReactNode | Record<string, TElementSchema<V, C>>; // use element schema instead
+	children:
+		| React.ReactNode
+		| Record<string, IDividerSchema | IOrderedListSchema<V, C> | ITextSchema | IUnorderedListSchema<V, C>>;
 }

--- a/src/stories/4-elements/alert/alert.stories.tsx
+++ b/src/stories/4-elements/alert/alert.stories.tsx
@@ -142,6 +142,38 @@ ReactNodeChildren.args = {
 	),
 };
 
+export const SchemaChildren = Template("alert-schema-children").bind({});
+SchemaChildren.args = {
+	uiType: "alert",
+	type: "success",
+	children: {
+		description: {
+			uiType: "text-body",
+			children: "The following fruits are provided:",
+		},
+		list: {
+			uiType: "unordered-list",
+			children: [
+				{
+					listItem1: {
+						uiType: "list-item",
+						children: "Apple",
+					},
+					listItem2: {
+						uiType: "list-item",
+						children: "Banana",
+					},
+					listItem3: {
+						uiType: "list-item",
+						children: "Cherry",
+						showIf: [{ inStock: [{ equals: true }] }],
+					},
+				},
+			],
+		},
+	},
+};
+
 export const HTMLString = Template("alert-html-string").bind({});
 HTMLString.args = {
 	uiType: "alert",


### PR DESCRIPTION
**Changes**

Add additional children type, used in JSON-only configs to have more control over the alert display

-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Support schema as children in `alert` element