### PR TITLE
[MOL-16463][XZY] Fix invalid jpg MIME type for image-upload

### DIFF
--- a/src/components/fields/image-upload/image-input/drag-upload/drag-upload.tsx
+++ b/src/components/fields/image-upload/image-input/drag-upload/drag-upload.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, forwardRef, useImperativeHandle, useRef } from "react";
 import { useDropzone } from "react-dropzone";
-import { TestHelper } from "../../../../../utils";
+import { FileHelper, TestHelper } from "../../../../../utils";
 import { HiddenInput, HintContainer, HintText, Wrapper } from "./drag-upload.styles";
 import { IDragUploadProps, IDragUploadRef } from "./types";
 
@@ -55,7 +55,7 @@ export const DragUpload = forwardRef<IDragUploadRef, IDragUploadProps>((props, r
 				/* accept needs to be full MIME types (e.g., image/jpeg).
 				Otherwise, the camera on some Android devices will not open when the capture attribute is set.
 				See more here: https://stackoverflow.com/questions/77876374 */
-				accept={accept?.map((type) => `image/${type}`).join(",")}
+				accept={accept?.map((type) => FileHelper.fileExtensionToMimeType(type)).join(",")}
 				onChange={handleInputChange}
 				onClick={(event) => {
 					(event.target as HTMLInputElement).value = "";


### PR DESCRIPTION
**Changes**
This PR fixes an issue in the `image-upload` component where certain Android devices were unable to display all images in the gallery for uploading.

Before this fix, `image-upload` component was using "image/jpg". This fix calls the MIME type conversion util. The behaviour on iOS and Web remain unchanged.

- [delete] branch


**Changelog entry**
- Updated the MIME type for JPEG images from "image/jpg" to "image/jpeg" in the `image-upload` component to resolve gallery image display issues on Android by calling the helper function.

**Additional information**

-   You may refer to this [MOL-16463](https://jira.ship.gov.sg/browse/MOL-16463)

**Screenshots**
Before fix:
<img width="270" alt="image" src="https://github.com/user-attachments/assets/e0fe945b-9b8e-4a5c-a73a-315cbbd731a5">
After fix:
<img width="262" alt="image" src="https://github.com/user-attachments/assets/95a83004-5949-4dc6-9ea9-0cd590f2bd35">
<img width="208" alt="image" src="https://github.com/user-attachments/assets/8e641625-299b-4421-8cb5-8c36d6e29429">
<img width="410" alt="image" src="https://github.com/user-attachments/assets/2f9e78bd-6cfc-4714-857a-1a3b84948a22">
