### PR TITLE
Add error-field to force invalid form

### DIFF
--- a/src/__tests__/components/fields/error-field/error-field.spec.tsx
+++ b/src/__tests__/components/fields/error-field/error-field.spec.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import cloneDeep from "lodash/cloneDeep";
+import merge from "lodash/merge";
+import { FrontendEngine } from "../../../../components";
+import { IErrorFieldSchema } from "../../../../components/fields";
+import { IFrontendEngineData } from "../../../../components/types";
+import {
+	FRONTEND_ENGINE_ID,
+	TOverrideSchema,
+	getField,
+	getResetButtonProps,
+	getSubmitButton,
+	getSubmitButtonProps,
+} from "../../../common";
+
+const SUBMIT_FN = jest.fn();
+const COMPONENT_ID = "field";
+const PARENT_ID = "input";
+const UI_TYPE = "error-field";
+const JSON_SCHEMA: IFrontendEngineData = {
+	id: FRONTEND_ENGINE_ID,
+	sections: {
+		section: {
+			uiType: "section",
+			children: {
+				[PARENT_ID]: {
+					uiType: "text-field",
+					label: "Text",
+				},
+				[COMPONENT_ID]: {
+					uiType: UI_TYPE,
+				},
+				...getSubmitButtonProps(),
+				...getResetButtonProps(),
+			},
+		},
+	},
+};
+
+const renderComponent = (overrideField?: Partial<IErrorFieldSchema>, overrideSchema?: TOverrideSchema) => {
+	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
+	merge(json, {
+		sections: {
+			section: {
+				children: {
+					[COMPONENT_ID]: overrideField,
+				},
+			},
+		},
+	});
+	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
+};
+
+describe(UI_TYPE, () => {
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it("should cause form to be invalid if shown", async () => {
+		renderComponent();
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+
+		expect(SUBMIT_FN).not.toHaveBeenCalled();
+	});
+
+	it("should not affect form validity if not shown", async () => {
+		renderComponent(
+			{ showIf: [{ [PARENT_ID]: [{ equals: "error" }] }] },
+			{ defaultValues: { [PARENT_ID]: "not-error" } }
+		);
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+
+		expect(SUBMIT_FN).toHaveBeenCalled();
+	});
+
+	it("should update form validity when conditionally rendered", async () => {
+		renderComponent({ showIf: [{ [PARENT_ID]: [{ equals: "error" }] }] });
+
+		fireEvent.change(getField("textbox", "Text"), { target: { value: "not-error" } });
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+
+		expect(SUBMIT_FN).toHaveBeenCalledTimes(1);
+
+		fireEvent.change(getField("textbox", "Text"), { target: { value: "error" } });
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+
+		expect(SUBMIT_FN).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/components/fields/error-field/error-field.tsx
+++ b/src/components/fields/error-field/error-field.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import * as Yup from "yup";
+import { useValidationConfig } from "../../../utils/hooks";
+import { IGenericFieldProps } from "../types";
+import { IErrorFieldSchema } from "./types";
+
+export const ErrorField = (props: IGenericFieldProps<IErrorFieldSchema>) => {
+	// =============================================================================
+	// CONST, STATE, REFS
+	// =============================================================================
+	const { id } = props;
+	const { setFieldValidationConfig } = useValidationConfig();
+
+	// =============================================================================
+	// EFFECTS
+	// =============================================================================
+	useEffect(() => {
+		setFieldValidationConfig(
+			id,
+			Yup.mixed().test(() => false),
+			[]
+		);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	// =============================================================================
+	// RENDER FUNCTIONS
+	// =============================================================================
+	return null;
+};

--- a/src/components/fields/error-field/index.ts
+++ b/src/components/fields/error-field/index.ts
@@ -1,0 +1,2 @@
+export * from "./error-field";
+export * from "./types";

--- a/src/components/fields/error-field/types.ts
+++ b/src/components/fields/error-field/types.ts
@@ -1,0 +1,13 @@
+import { IYupValidationRule } from "../../frontend-engine/types";
+import { IBaseFieldSchema } from "../types";
+
+export interface IErrorFieldValidationRule extends IYupValidationRule {
+	/** for customising error message when field is present, not visible to user */
+	error?: boolean | undefined;
+}
+
+export interface IErrorFieldSchema
+	extends Pick<
+		IBaseFieldSchema<"error-field", undefined, IErrorFieldValidationRule>,
+		"showIf" | "uiType" | "validation"
+	> {}

--- a/src/components/fields/index.ts
+++ b/src/components/fields/index.ts
@@ -5,6 +5,7 @@ export * from "./contact-field";
 export * from "./date-field";
 export * from "./date-range-field";
 export * from "./e-signature-field";
+export * from "./error-field";
 export * from "./file-upload";
 export * from "./hidden-field";
 export * from "./histogram-slider";

--- a/src/components/fields/types.ts
+++ b/src/components/fields/types.ts
@@ -9,6 +9,7 @@ import { IContactFieldSchema } from "./contact-field";
 import { IDateFieldSchema } from "./date-field";
 import { TDateRangeFieldSchema } from "./date-range-field";
 import { IESignatureFieldSchema } from "./e-signature-field/types";
+import { IErrorFieldSchema } from "./error-field";
 import { IFileUploadSchema, TFileUploadEvents } from "./file-upload";
 import { IHiddenFieldSchema } from "./hidden-field/types";
 import { IHistogramSliderSchema } from "./histogram-slider";
@@ -44,6 +45,7 @@ export enum EFieldType {
 	"DATE-RANGE-FIELD" = "DateRangeField",
 	"EMAIL-FIELD" = "TextField",
 	"E-SIGNATURE-FIELD" = "ESignatureField",
+	"ERROR-FIELD" = "ErrorField",
 	"FILE-UPLOAD" = "FileUpload",
 	"HIDDEN-FIELD" = "HiddenField",
 	"HISTOGRAM-SLIDER" = "HistogramSlider",
@@ -77,6 +79,7 @@ export type TFieldSchema<V = undefined, C = undefined> =
 	| IDateFieldSchema<V>
 	| IEmailFieldSchema<V>
 	| IESignatureFieldSchema<V>
+	| IErrorFieldSchema
 	| IFileUploadSchema<V>
 	| IHiddenFieldSchema<V>
 	| IHistogramSliderSchema<V>

--- a/src/stories/3-fields/error-field/error-field.stories.tsx
+++ b/src/stories/3-fields/error-field/error-field.stories.tsx
@@ -1,0 +1,80 @@
+import { ArgTypes, Stories, Title } from "@storybook/addon-docs";
+import { Meta } from "@storybook/react";
+import { CommonFieldStoryProps, FrontendEngine, SUBMIT_BUTTON_SCHEMA } from "../../common";
+
+const meta: Meta = {
+	title: "Field/ErrorField",
+	parameters: {
+		docs: {
+			page: () => (
+				<>
+					<Title>ErrorField</Title>
+					<p>
+						A hidden form element that forces the form to be invalid when present. Useful for validating
+						known combinations of input.
+					</p>
+					<ArgTypes of={Default} />
+					<Stories includePrimary={true} title="Examples" />
+				</>
+			),
+		},
+	},
+	argTypes: {
+		...CommonFieldStoryProps("error-field"),
+		columns: { table: { disable: true } },
+		label: { table: { disable: true } },
+		validation: { table: { disable: true } },
+	},
+};
+export default meta;
+
+export const Default = () => (
+	<FrontendEngine
+		data={{
+			sections: {
+				section: {
+					uiType: "section",
+					children: {
+						fruit: {
+							uiType: "radio",
+							label: "Fruit",
+							options: [
+								{ label: "Apple", value: "Apple" },
+								{ label: "Bell Pepper", value: "Bell Pepper" },
+							],
+						},
+						color: {
+							uiType: "radio",
+							label: "Color",
+							options: [
+								{ label: "Red", value: "Red" },
+								{ label: "Green", value: "Green" },
+								{ label: "Purple", value: "Purple" },
+							],
+						},
+						error: {
+							uiType: "error-field",
+							showIf: [
+								{
+									fruit: [{ equals: "Apple" }],
+									color: [{ equals: "Purple" }],
+								},
+							],
+						},
+						errorAlert: {
+							uiType: "alert",
+							type: "error",
+							children: "Apples cannot be purple",
+							showIf: [
+								{
+									error: [{ shown: true }],
+								},
+							],
+						},
+						...SUBMIT_BUTTON_SCHEMA,
+					},
+				},
+			},
+		}}
+	/>
+);


### PR DESCRIPTION
**Changes**

- An invisible field that when present, forces the form to be invalid
- Useful for validating a finite set of input combinations on the frontend without having to create a custom rule
- Can be used together with `shown` rule to display an actual error message to the user. The default story has an example usage
- Exposes an `error` rule to customise the message, but this is used by `validation-schema-generator` only
-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Add `error-field` to force invalid form when shown