### PR TITLE
Enhance review and accordion displays

### DIFF
--- a/src/components/custom/review/types.ts
+++ b/src/components/custom/review/types.ts
@@ -55,6 +55,7 @@ interface IReviewBaseSchema {
 export interface IReviewSchemaBox extends IReviewBaseSchema, ICustomElementJsonSchema<"review"> {
 	variant?: "box" | undefined;
 	description?: string | undefined;
+	background?: boolean | undefined;
 }
 
 // =========================================================================

--- a/src/components/elements/accordion/accordion.tsx
+++ b/src/components/elements/accordion/accordion.tsx
@@ -15,7 +15,7 @@ export const Accordion = (props: IGenericElementProps<IAccordionSchema>) => {
 	// CONST, STATE, REF
 	// =============================================================================
 	const { schema, id } = props;
-	const { children, button, title, ...otherSchema } = schema;
+	const { children, button, title, disableContentInset, ...otherSchema } = schema;
 
 	const { dispatchFieldEvent } = useFieldEvent();
 
@@ -36,11 +36,15 @@ export const Accordion = (props: IGenericElementProps<IAccordionSchema>) => {
 				) : undefined
 			}
 		>
-			<Layout.Content>
-				<Container>
-					<Wrapper id={id}>{children}</Wrapper>
-				</Container>
-			</Layout.Content>
+			{disableContentInset ? (
+				<Wrapper id={id}>{children}</Wrapper>
+			) : (
+				<Layout.Content>
+					<Container>
+						<Wrapper id={id}>{children}</Wrapper>
+					</Container>
+				</Layout.Content>
+			)}
 		</BoxContainer>
 	);
 };

--- a/src/components/elements/accordion/types.ts
+++ b/src/components/elements/accordion/types.ts
@@ -21,6 +21,7 @@ export interface IAccordionSchema<V = undefined, C = undefined>
 	expanded?: boolean | undefined;
 	displayState?: BoxContainerDisplayState | undefined;
 	title: string;
+	disableContentInset?: boolean | undefined;
 }
 
 // =============================================================================

--- a/src/stories/4-elements/accordion/accordion.stories.tsx
+++ b/src/stories/4-elements/accordion/accordion.stories.tsx
@@ -86,6 +86,17 @@ const meta: Meta = {
 				type: "select",
 			},
 		},
+		disableContentInset: {
+			description: "Specifies if there is spacing between content and the edges of the accordion box",
+			table: {
+				type: {
+					summary: "boolean",
+				},
+			},
+			control: {
+				type: "boolean",
+			},
+		},
 	},
 };
 export default meta;
@@ -242,4 +253,28 @@ DisplayState.args = {
 	displayState: "warning",
 	collapsible: false,
 	title: "Title",
+};
+
+export const DisableContentInset = DefaultStoryTemplate<IAccordionSchema>("accordion-content-inset").bind({});
+DisableContentInset.args = {
+	uiType: "accordion",
+	children: {
+		text1: {
+			uiType: "text-body",
+			children: "Section one",
+			style: { margin: "1rem 2rem" },
+		},
+		divider: {
+			uiType: "divider",
+		},
+		text2: {
+			uiType: "text-body",
+			children: "Section two",
+			style: { margin: "1rem 2rem" },
+		},
+	},
+	button: false,
+	collapsible: false,
+	title: "Title",
+	disableContentInset: true,
 };

--- a/src/stories/5-custom/review/review-box.stories.tsx
+++ b/src/stories/5-custom/review/review-box.stories.tsx
@@ -78,6 +78,20 @@ const meta: Meta = {
 				},
 			},
 		},
+		background: {
+			description: "Specifies if a background should be rendered",
+			table: {
+				type: {
+					summary: "boolean",
+				},
+				defaultValue: {
+					summary: "true",
+				},
+			},
+			control: {
+				type: "boolean",
+			},
+		},
 	},
 };
 export default meta;
@@ -204,4 +218,13 @@ Masking.args = {
 			},
 		},
 	],
+};
+
+export const NoBackground = DefaultStoryTemplate<TReviewSchema>("review-no-background").bind({});
+NoBackground.args = {
+	referenceKey: "review",
+	label: "Your personal information",
+	description: "Retrieved on 27 Jun 2023",
+	items: SAMPLE_ITEMS,
+	background: false,
 };


### PR DESCRIPTION
**Changes**

- Expose background prop in `review` box variant to support composition in other layouts
- Allow default content padding in `accordion` to be toggled, useful for layouts that need full-width content like dividers
-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Add `background` option for `review` box variant
- Support disabling of default content padding in `accordion`