### PR TITLE
Support schema label in checkbox and radio

### DIFF
--- a/src/__tests__/components/elements/wrapper/wrapper.spec.tsx
+++ b/src/__tests__/components/elements/wrapper/wrapper.spec.tsx
@@ -30,7 +30,7 @@ const renderComponent = (
 				children: {
 					[PARENT_ID]: {
 						uiType: wrapperType,
-						children,
+						children: children as any,
 					},
 					...getSubmitButtonProps(),
 				},

--- a/src/__tests__/components/fields/checkbox-group/checkbox-group.spec.tsx
+++ b/src/__tests__/components/fields/checkbox-group/checkbox-group.spec.tsx
@@ -203,6 +203,14 @@ describe(UI_TYPE, () => {
 		expect(document.querySelector(".checkbox-field").innerHTML.includes("script")).toBe(false);
 	});
 
+	it("should be able to render FEE schema in option label", () => {
+		renderComponent({
+			options: [{ label: { text: { uiType: "span", children: "Schema Label" } }, value: "Schema Label" }],
+		});
+
+		expect(screen.getByText("Schema Label")).toBeInTheDocument();
+	});
+
 	it.each`
 		displaySize  | expected
 		${"small"}   | ${"1.5rem"}

--- a/src/__tests__/components/fields/checkbox-group/checkbox-toggle-group.spec.tsx
+++ b/src/__tests__/components/fields/checkbox-group/checkbox-toggle-group.spec.tsx
@@ -181,6 +181,35 @@ describe("checkbox toggle group", () => {
 		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
 	});
 
+	it("should be able to render HTML string in option label", () => {
+		renderComponent({
+			options: [{ label: "<strong>HTML Label</strong>", value: "HTML Label" }],
+		});
+
+		expect(screen.getByText("HTML Label")).toBeInTheDocument();
+		expect(screen.getByText("HTML Label").nodeName).toBe("STRONG");
+	});
+
+	it("should be able to sanitise HTML string in option label", () => {
+		renderComponent({
+			className: "checkbox-field",
+			options: [
+				{ label: "This is a sanitized string<script>console.log('hello world')</script>", value: "HTML Label" },
+			],
+		});
+
+		expect(screen.getByText("This is a sanitized string")).toBeInTheDocument();
+		expect(document.querySelector(".checkbox-field").innerHTML.includes("script")).toBe(false);
+	});
+
+	it("should be able to render FEE schema in option label", () => {
+		renderComponent({
+			options: [{ label: { text: { uiType: "span", children: "Schema Label" } }, value: "Schema Label" }],
+		});
+
+		expect(screen.getByText("Schema Label")).toBeInTheDocument();
+	});
+
 	describe("update options through schema", () => {
 		it.each`
 			scenario                                                                             | selected      | expectedValueBeforeUpdate | expectedValueAfterUpdate

--- a/src/__tests__/components/fields/radio-button/radio-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-button.spec.tsx
@@ -163,6 +163,14 @@ describe(UI_TYPE, () => {
 		expect(document.querySelector(".radio-field").innerHTML.includes("script")).toBe(false);
 	});
 
+	it("should be able to render FEE schema in option label", () => {
+		renderComponent({
+			options: [{ label: { text: { uiType: "span", children: "Schema Label" } }, value: "Schema Label" }],
+		});
+
+		expect(screen.getByText("Schema Label")).toBeInTheDocument();
+	});
+
 	describe("update options through schema", () => {
 		it.each`
 			scenario                                                                 | selected | expectedValueBeforeUpdate | expectedValueAfterUpdate

--- a/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
@@ -150,6 +150,35 @@ describe("radio toggle button", () => {
 		expect(getRadioButtonB()).toBeDisabled();
 	});
 
+	it("should be able to render HTML string in option label", () => {
+		renderComponent({
+			options: [{ label: "<strong>HTML Label</strong>", value: "HTML Label" }],
+		});
+
+		expect(screen.getByText("HTML Label")).toBeInTheDocument();
+		expect(screen.getByText("HTML Label").nodeName).toBe("STRONG");
+	});
+
+	it("should be able to sanitise HTML string in option label", () => {
+		renderComponent({
+			className: "radio-field",
+			options: [
+				{ label: "This is a sanitized string<script>console.log('hello world')</script>", value: "HTML Label" },
+			],
+		});
+
+		expect(screen.getByText("This is a sanitized string")).toBeInTheDocument();
+		expect(document.querySelector(".radio-field").innerHTML.includes("script")).toBe(false);
+	});
+
+	it("should be able to render FEE schema in option label", () => {
+		renderComponent({
+			options: [{ label: { text: { uiType: "span", children: "Schema Label" } }, value: "Schema Label" }],
+		});
+
+		expect(screen.getByText("Schema Label")).toBeInTheDocument();
+	});
+
 	describe("update options through schema", () => {
 		it.each`
 			scenario                                                                 | selected | expectedValueBeforeUpdate | expectedValueAfterUpdate

--- a/src/components/custom/review/types.ts
+++ b/src/components/custom/review/types.ts
@@ -2,9 +2,10 @@ import { BoxContainerProps } from "@lifesg/react-design-system/box-container";
 import { UneditableSectionItemProps } from "@lifesg/react-design-system/uneditable-section/types";
 import { TFieldEventListener } from "../../../utils";
 import type { TBlockElementSchema, TInlineElementSchema } from "../../elements";
+import type { TWrapperSchema } from "../../elements/wrapper";
 import type { ICustomElementJsonSchema } from "../types";
 
-type TReviewSectionChildren = TBlockElementSchema | TInlineElementSchema;
+type TReviewSectionChildren = TBlockElementSchema | TInlineElementSchema | TWrapperSchema;
 export type TReviewSchema = IReviewSchemaAccordion | IReviewSchemaBox;
 
 /** @deprecated use TReviewSchema */

--- a/src/components/custom/review/types.ts
+++ b/src/components/custom/review/types.ts
@@ -2,10 +2,10 @@ import { BoxContainerProps } from "@lifesg/react-design-system/box-container";
 import { UneditableSectionItemProps } from "@lifesg/react-design-system/uneditable-section/types";
 import { TFieldEventListener } from "../../../utils";
 import type { IAlertSchema, ITextSchema } from "../../elements";
-import type { IWrapperSchema } from "../../elements/wrapper";
+import type { TWrapperSchema } from "../../elements/wrapper";
 import type { ICustomElementJsonSchema } from "../types";
 
-type TReviewSectionChildren = IAlertSchema | ITextSchema | IWrapperSchema;
+type TReviewSectionChildren = IAlertSchema | ITextSchema | TWrapperSchema;
 export type TReviewSchema = IReviewSchemaAccordion | IReviewSchemaBox;
 
 /** @deprecated use TReviewSchema */

--- a/src/components/custom/review/types.ts
+++ b/src/components/custom/review/types.ts
@@ -1,11 +1,10 @@
 import { BoxContainerProps } from "@lifesg/react-design-system/box-container";
 import { UneditableSectionItemProps } from "@lifesg/react-design-system/uneditable-section/types";
 import { TFieldEventListener } from "../../../utils";
-import type { IAlertSchema, ITextSchema } from "../../elements";
-import type { TWrapperSchema } from "../../elements/wrapper";
+import type { TBlockElementSchema, TInlineElementSchema } from "../../elements";
 import type { ICustomElementJsonSchema } from "../types";
 
-type TReviewSectionChildren = IAlertSchema | ITextSchema | TWrapperSchema;
+type TReviewSectionChildren = TBlockElementSchema | TInlineElementSchema;
 export type TReviewSchema = IReviewSchemaAccordion | IReviewSchemaBox;
 
 /** @deprecated use TReviewSchema */

--- a/src/components/elements/accordion/types.ts
+++ b/src/components/elements/accordion/types.ts
@@ -2,7 +2,7 @@ import { BoxContainerDisplayState, BoxContainerSubComponentTestIds } from "@life
 import { TFieldEventListener } from "../../../utils";
 import { TComponentOmitProps, TFrontendEngineFieldSchema } from "../../frontend-engine";
 import { IBaseElementSchema } from "../types";
-import { IWrapperSchema } from "../wrapper";
+import { TWrapperSchema } from "../wrapper";
 
 export interface IButtonAccordion {
 	label: string | undefined;
@@ -10,7 +10,7 @@ export interface IButtonAccordion {
 
 export interface IAccordionSchema<V = undefined, C = undefined>
 	extends IBaseElementSchema<"accordion">,
-		TComponentOmitProps<IWrapperSchema> {
+		TComponentOmitProps<TWrapperSchema> {
 	uiType: "accordion";
 	button?: boolean | IButtonAccordion | undefined;
 	children: Record<string, TFrontendEngineFieldSchema<V, C>>;

--- a/src/components/elements/alert/types.ts
+++ b/src/components/elements/alert/types.ts
@@ -1,15 +1,10 @@
 import { AlertProps, AlertType } from "@lifesg/react-design-system";
 import { TComponentOmitProps } from "../../frontend-engine";
-import type { IDividerSchema } from "../divider";
-import type { IOrderedListSchema, IUnorderedListSchema } from "../list";
-import type { ITextSchema } from "../text";
-import { IBaseElementSchema } from "../types";
+import { IBaseElementSchema, TBlockElementSchema, TInlineElementSchema } from "../types";
 
 export interface IAlertSchema<V = undefined, C = undefined>
 	extends IBaseElementSchema<"alert">,
 		TComponentOmitProps<AlertProps> {
 	type: AlertType;
-	children:
-		| React.ReactNode
-		| Record<string, IDividerSchema | IOrderedListSchema<V, C> | ITextSchema | IUnorderedListSchema<V, C>>;
+	children: React.ReactNode | Record<string, TBlockElementSchema<V, C> | TInlineElementSchema>;
 }

--- a/src/components/elements/alert/types.ts
+++ b/src/components/elements/alert/types.ts
@@ -2,9 +2,11 @@ import { AlertProps, AlertType } from "@lifesg/react-design-system";
 import { TComponentOmitProps } from "../../frontend-engine";
 import { IBaseElementSchema, TBlockElementSchema, TInlineElementSchema } from "../types";
 
+type TAlertChildren<V, C> = Exclude<TBlockElementSchema<V, C>, IAlertSchema> | TInlineElementSchema;
+
 export interface IAlertSchema<V = undefined, C = undefined>
 	extends IBaseElementSchema<"alert">,
 		TComponentOmitProps<AlertProps> {
 	type: AlertType;
-	children: React.ReactNode | Record<string, TBlockElementSchema<V, C> | TInlineElementSchema>;
+	children: React.ReactNode | Record<string, TAlertChildren<V, C>>;
 }

--- a/src/components/elements/list/types.ts
+++ b/src/components/elements/list/types.ts
@@ -1,7 +1,7 @@
 import { OrderedListProps, UnorderedListProps } from "@lifesg/react-design-system/text-list";
 import { TComponentOmitProps, TFrontendEngineFieldSchema } from "../../frontend-engine";
 import { IBaseElementSchema } from "../types";
-import { IWrapperSchema } from "../wrapper";
+import { TWrapperSchema } from "../wrapper";
 
 export interface IUnorderedListSchema<V = undefined, C = undefined>
 	extends IBaseElementSchema<"unordered-list">,
@@ -17,6 +17,6 @@ export interface IOrderedListSchema<V = undefined, C = undefined>
 
 export interface IListItemSchema<V = undefined, C = undefined>
 	extends IBaseElementSchema<"list-item">,
-		TComponentOmitProps<IWrapperSchema> {
+		TComponentOmitProps<TWrapperSchema> {
 	children: string | Record<string, TFrontendEngineFieldSchema<V, C>>;
 }

--- a/src/components/elements/section/types.ts
+++ b/src/components/elements/section/types.ts
@@ -1,10 +1,10 @@
 import { TComponentOmitProps, TFrontendEngineFieldSchema } from "../../frontend-engine";
 import { IBaseElementSchema } from "../types";
-import { IWrapperSchema } from "../wrapper";
+import { TWrapperSchema } from "../wrapper";
 
 export interface ISectionSchema<V = undefined, C = undefined>
 	extends IBaseElementSchema<"section">,
-		TComponentOmitProps<IWrapperSchema> {
+		TComponentOmitProps<TWrapperSchema> {
 	children: Record<string, TFrontendEngineFieldSchema<V, C>>;
 	layoutType?: "default" | "grid" | "contain" | undefined;
 }

--- a/src/components/elements/tab/types.ts
+++ b/src/components/elements/tab/types.ts
@@ -1,17 +1,17 @@
 import { TComponentOmitProps, TFrontendEngineFieldSchema } from "../../frontend-engine";
 import { IBaseElementSchema } from "../types";
-import { IWrapperSchema } from "../wrapper";
+import { TWrapperSchema } from "../wrapper";
 
 export interface ITabSchema<V = undefined, C = undefined>
 	extends IBaseElementSchema<"tab">,
-		TComponentOmitProps<IWrapperSchema> {
+		TComponentOmitProps<TWrapperSchema> {
 	children: Record<string, ITabItemSchema<V, C>>;
 	currentActiveTabId?: string | undefined;
 }
 
 export interface ITabItemSchema<V = undefined, C = undefined>
 	extends IBaseElementSchema<"tab-item">,
-		TComponentOmitProps<IWrapperSchema> {
+		TComponentOmitProps<TWrapperSchema> {
 	children: Record<string, TFrontendEngineFieldSchema<V, C>>;
 	title: string;
 }

--- a/src/components/elements/text/types.ts
+++ b/src/components/elements/text/types.ts
@@ -1,7 +1,6 @@
 import { TextProps } from "@lifesg/react-design-system/text";
 import { TComponentOmitProps } from "../../frontend-engine";
-import { IPopoverSchema } from "../popover/types";
-import { IBaseElementSchema } from "../types";
+import { IBaseElementSchema, TInlineElementSchema } from "../types";
 
 export type TTextType =
 	| "text-d1"
@@ -18,5 +17,5 @@ export type TTextType =
 	| "text-xsmall";
 
 export interface ITextSchema extends IBaseElementSchema<TTextType>, TComponentOmitProps<TextProps, "children"> {
-	children: string | string[] | Record<string, ITextSchema | IPopoverSchema>;
+	children: string | string[] | Record<string, ITextSchema | TInlineElementSchema>;
 }

--- a/src/components/elements/types.ts
+++ b/src/components/elements/types.ts
@@ -8,7 +8,7 @@ import { IOrderedListSchema, IUnorderedListSchema } from "./list";
 import { IPopoverSchema } from "./popover";
 import { ITabItemSchema, ITabSchema } from "./tab";
 import type { ITextSchema } from "./text";
-import type { IWrapperSchema } from "./wrapper";
+import type { IInlineWrapperSchema, TWrapperSchema } from "./wrapper";
 
 /**
  * element types
@@ -55,17 +55,28 @@ export enum EElementType {
  * union type to represent all element schemas
  */
 export type TElementSchema<V = undefined, C = undefined> =
+	| TContainerElementSchema<V, C>
+	| TBlockElementSchema<V, C>
+	| TInlineElementSchema;
+
+/** represent element schemas that render content containers */
+export type TContainerElementSchema<V = undefined, C = undefined> =
 	| IAccordionSchema<V, C>
+	| ITabItemSchema<V, C>
+	| ITabSchema<V, C>;
+
+/** represent element schemas that render block-level ui elements */
+export type TBlockElementSchema<V = undefined, C = undefined> =
 	| IAlertSchema
 	| IDividerSchema
 	| IGridSchema<V, C>
 	| IOrderedListSchema<V, C>
-	| IPopoverSchema
-	| ITabItemSchema<V, C>
-	| ITabSchema<V, C>
 	| ITextSchema
 	| IUnorderedListSchema<V, C>
-	| IWrapperSchema<V, C>;
+	| TWrapperSchema<V, C>;
+
+/** represent element schemas that render inline ui elements */
+export type TInlineElementSchema<V = undefined, C = undefined> = IInlineWrapperSchema<V, C> | IPopoverSchema;
 
 /**
  * intersection type to represent all field events

--- a/src/components/elements/types.ts
+++ b/src/components/elements/types.ts
@@ -57,11 +57,13 @@ export enum EElementType {
 export type TElementSchema<V = undefined, C = undefined> =
 	| TContainerElementSchema<V, C>
 	| TBlockElementSchema<V, C>
-	| TInlineElementSchema;
+	| TInlineElementSchema
+	| TWrapperSchema<V, C>;
 
 /** represent element schemas that render content containers */
 export type TContainerElementSchema<V = undefined, C = undefined> =
 	| IAccordionSchema<V, C>
+	| IGridSchema<V, C>
 	| ITabItemSchema<V, C>
 	| ITabSchema<V, C>;
 
@@ -69,11 +71,9 @@ export type TContainerElementSchema<V = undefined, C = undefined> =
 export type TBlockElementSchema<V = undefined, C = undefined> =
 	| IAlertSchema
 	| IDividerSchema
-	| IGridSchema<V, C>
 	| IOrderedListSchema<V, C>
 	| ITextSchema
-	| IUnorderedListSchema<V, C>
-	| TWrapperSchema<V, C>;
+	| IUnorderedListSchema<V, C>;
 
 /** represent element schemas that render inline ui elements */
 export type TInlineElementSchema<V = undefined, C = undefined> = IInlineWrapperSchema<V, C> | IPopoverSchema;

--- a/src/components/elements/wrapper/types.ts
+++ b/src/components/elements/wrapper/types.ts
@@ -3,14 +3,31 @@ import { IFilterCheckboxSchema } from "../../custom/filter/filter-checkbox/types
 import { IFilterItemSchema } from "../../custom/filter/filter-item/types";
 import { IColumns, TComponentOmitProps, TFrontendEngineFieldSchema } from "../../frontend-engine";
 import { IListItemSchema } from "../list";
+import { TInlineElementSchema } from "../types";
 
-export type TWrapperType = "div" | "span" | "header" | "footer" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p";
+export type TWrapperType = TBlockWrapperType | TInlineWrapperType;
+export type TBlockWrapperType = "div" | "header" | "footer" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p";
+export type TInlineWrapperType = "span";
 
-export interface IWrapperSchema<V = undefined, C = undefined>
+export type TWrapperSchema<V = undefined, C = undefined> = IBlockWrapperSchema<V, C> | IInlineWrapperSchema;
+
+/** @deprecated use `TWrapperSchema` */
+export type IWrapperSchema<V = undefined, C = undefined> = IBlockWrapperSchema<V, C> | IInlineWrapperSchema;
+
+export interface IBlockWrapperSchema<V = undefined, C = undefined>
 	extends TComponentOmitProps<React.HTMLAttributes<HTMLElement>, "children"> {
-	uiType: TWrapperType;
+	uiType: TBlockWrapperType;
 	showIf?: TRenderRules[] | undefined;
 	children: Record<string, TFrontendEngineFieldSchema<V, C>> | string;
+	/** set responsive columns */
+	columns?: IColumns | undefined;
+}
+
+export interface IInlineWrapperSchema<V = undefined, C = undefined>
+	extends TComponentOmitProps<React.HTMLAttributes<HTMLElement>, "children"> {
+	uiType: TInlineWrapperType;
+	showIf?: TRenderRules[] | undefined;
+	children: Record<string, TInlineElementSchema<V, C>> | string;
 	/** set responsive columns */
 	columns?: IColumns | undefined;
 }

--- a/src/components/elements/wrapper/types.ts
+++ b/src/components/elements/wrapper/types.ts
@@ -34,7 +34,7 @@ export interface IInlineWrapperSchema<V = undefined, C = undefined>
 
 export interface IWrapperProps {
 	id?: string | undefined;
-	schema?: IWrapperSchema | undefined;
+	schema?: TWrapperSchema | undefined;
 	/** only used internally by FrontendEngine */
 	children?:
 		| Record<string, TFrontendEngineFieldSchema>

--- a/src/components/fields/checkbox-group/checkbox-group.tsx
+++ b/src/components/fields/checkbox-group/checkbox-group.tsx
@@ -10,7 +10,7 @@ import { useValidationConfig } from "../../../utils/hooks";
 import { Wrapper } from "../../elements/wrapper";
 import { ERROR_MESSAGES, Sanitize, Warning } from "../../shared";
 import { CheckboxContainer, Label, StyledCheckbox, StyledToggle, ToggleWrapper } from "./checkbox-group.styles";
-import { IToggleOption, TCheckboxGroupSchema } from "./types";
+import { ICheckboxGroupOption, IToggleOption, TCheckboxGroupSchema } from "./types";
 
 export const CheckboxGroup = (props: IGenericFieldProps<TCheckboxGroupSchema>) => {
 	// =============================================================================
@@ -96,6 +96,13 @@ export const CheckboxGroup = (props: IGenericFieldProps<TCheckboxGroupSchema>) =
 	// =============================================================================
 	// RENDER FUNCTIONS
 	// =============================================================================
+	const renderLabel = (label: ICheckboxGroupOption["label"]) => {
+		if (typeof label === "string") {
+			return <Sanitize inline>{label}</Sanitize>;
+		}
+		return <Wrapper>{label}</Wrapper>;
+	};
+
 	const renderCheckboxes = () => {
 		return (
 			options.length > 0 &&
@@ -119,7 +126,7 @@ export const CheckboxGroup = (props: IGenericFieldProps<TCheckboxGroupSchema>) =
 							onChange={() => handleChange(option.value)}
 						/>
 						<Label as="label" htmlFor={checkboxId} disabled={disabled ?? option.disabled}>
-							<Sanitize inline>{option.label}</Sanitize>
+							{renderLabel(option.label)}
 						</Label>
 					</CheckboxContainer>
 				);
@@ -161,7 +168,7 @@ export const CheckboxGroup = (props: IGenericFieldProps<TCheckboxGroupSchema>) =
 										: null
 								}
 							>
-								{option.label}
+								{renderLabel(option.label)}
 							</StyledToggle>
 						);
 					})}

--- a/src/components/fields/checkbox-group/types.ts
+++ b/src/components/fields/checkbox-group/types.ts
@@ -1,14 +1,16 @@
 import { CheckboxProps } from "@lifesg/react-design-system/checkbox";
+import type { IPopoverSchema, ITextSchema } from "../../elements";
+import type { IInlineWrapperSchema } from "../../elements/wrapper";
 import { TComponentOmitProps, TFrontendEngineFieldSchema } from "../../frontend-engine";
 import { IBaseFieldSchema } from "../types";
 
-export interface IOption {
-	label: string;
+export interface ICheckboxGroupOption {
+	label: string | Record<string, ITextSchema | IPopoverSchema | IInlineWrapperSchema>;
 	value: string;
 	disabled?: boolean | undefined;
 }
 
-export interface IToggleOption<V = undefined, C = undefined> extends IOption {
+export interface IToggleOption<V = undefined, C = undefined> extends ICheckboxGroupOption {
 	none?: boolean | undefined;
 	children?: Record<string, TFrontendEngineFieldSchema<V, C>> | undefined;
 }
@@ -18,7 +20,7 @@ export type TCheckboxToggleLayoutType = "horizontal" | "vertical";
 interface ICheckboxGroupDefaultSchema<V = undefined>
 	extends IBaseFieldSchema<"checkbox", V>,
 		TComponentOmitProps<CheckboxProps> {
-	options: IOption[];
+	options: ICheckboxGroupOption[];
 	customOptions?: { styleType: "default" } | undefined;
 }
 

--- a/src/components/fields/error-field/types.ts
+++ b/src/components/fields/error-field/types.ts
@@ -1,5 +1,5 @@
 import type { IAlertSchema, IOrderedListSchema, ITextSchema, IUnorderedListSchema } from "../../elements";
-import type { IWrapperSchema } from "../../elements/wrapper";
+import type { TWrapperSchema } from "../../elements/wrapper";
 import { IBaseFieldSchema } from "../types";
 
 export interface IErrorFieldValidationRule {
@@ -8,7 +8,7 @@ export interface IErrorFieldValidationRule {
 	errorMessage?: string | undefined;
 }
 
-type TErrorFieldChildren = IAlertSchema | ITextSchema | IWrapperSchema | IOrderedListSchema | IUnorderedListSchema;
+type TErrorFieldChildren = IAlertSchema | ITextSchema | TWrapperSchema | IOrderedListSchema | IUnorderedListSchema;
 
 export interface IErrorFieldSchema
 	extends Pick<IBaseFieldSchema<"error-field", undefined, IErrorFieldValidationRule>, "showIf" | "uiType"> {

--- a/src/components/fields/error-field/types.ts
+++ b/src/components/fields/error-field/types.ts
@@ -1,5 +1,4 @@
-import type { IAlertSchema, IOrderedListSchema, ITextSchema, IUnorderedListSchema } from "../../elements";
-import type { TWrapperSchema } from "../../elements/wrapper";
+import type { TBlockElementSchema } from "../../elements";
 import { IBaseFieldSchema } from "../types";
 
 export interface IErrorFieldValidationRule {
@@ -8,10 +7,8 @@ export interface IErrorFieldValidationRule {
 	errorMessage?: string | undefined;
 }
 
-type TErrorFieldChildren = IAlertSchema | ITextSchema | TWrapperSchema | IOrderedListSchema | IUnorderedListSchema;
-
 export interface IErrorFieldSchema
 	extends Pick<IBaseFieldSchema<"error-field", undefined, IErrorFieldValidationRule>, "showIf" | "uiType"> {
 	validation?: [IErrorFieldValidationRule] | undefined;
-	children?: Record<string, TErrorFieldChildren> | undefined;
+	children?: Record<string, TBlockElementSchema> | undefined;
 }

--- a/src/components/fields/error-field/types.ts
+++ b/src/components/fields/error-field/types.ts
@@ -1,4 +1,4 @@
-import type { TBlockElementSchema } from "../../elements";
+import type { TBlockElementSchema, TInlineElementSchema } from "../../elements";
 import { IBaseFieldSchema } from "../types";
 
 export interface IErrorFieldValidationRule {
@@ -10,5 +10,5 @@ export interface IErrorFieldValidationRule {
 export interface IErrorFieldSchema
 	extends Pick<IBaseFieldSchema<"error-field", undefined, IErrorFieldValidationRule>, "showIf" | "uiType"> {
 	validation?: [IErrorFieldValidationRule] | undefined;
-	children?: Record<string, TBlockElementSchema> | undefined;
+	children?: Record<string, TBlockElementSchema | TInlineElementSchema> | undefined;
 }

--- a/src/components/fields/radio-button/radio-button.tsx
+++ b/src/components/fields/radio-button/radio-button.tsx
@@ -17,7 +17,7 @@ import {
 	StyledRadioButton,
 	StyledToggle,
 } from "./radio-button.styles";
-import { TRadioButtonGroupSchema } from "./types";
+import { IRadioButtonOption, TRadioButtonGroupSchema } from "./types";
 
 export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSchema>) => {
 	// =============================================================================
@@ -77,6 +77,13 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 	// =============================================================================
 	// RENDER FUNCTIONS
 	// =============================================================================
+	const renderLabel = (label: IRadioButtonOption["label"]) => {
+		if (typeof label === "string") {
+			return <Sanitize inline>{label}</Sanitize>;
+		}
+		return <Wrapper>{label}</Wrapper>;
+	};
+
 	const renderRadioButtons = () => {
 		return (
 			options.length > 0 &&
@@ -97,7 +104,7 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 							onChange={() => handleChangeOrClick(option.value)}
 						/>
 						<Label as="label" htmlFor={radioButtonId} disabled={disabled ?? option.disabled}>
-							<Sanitize inline>{option.label}</Sanitize>
+							{renderLabel(option.label)}
 						</Label>
 					</RadioContainer>
 				);
@@ -140,7 +147,7 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 										: null
 								}
 							>
-								{option.label}
+								{renderLabel(option.label)}
 							</StyledToggle>
 						);
 					})}

--- a/src/components/fields/radio-button/types.ts
+++ b/src/components/fields/radio-button/types.ts
@@ -1,18 +1,20 @@
 import { RadioButtonProps } from "@lifesg/react-design-system/radio-button";
+import type { IPopoverSchema, ITextSchema } from "../../elements";
+import type { IInlineWrapperSchema } from "../../elements/wrapper";
 import { TComponentOmitProps, TFrontendEngineFieldSchema } from "../../frontend-engine";
 import { IBaseFieldSchema } from "../types";
 
-interface IOption {
-	label: string;
+export interface IRadioButtonOption {
+	label: string | Record<string, ITextSchema | IPopoverSchema | IInlineWrapperSchema>;
 	value: string;
 	disabled?: boolean | undefined;
 }
 
-interface IToggleOption<V = undefined, C = undefined> extends IOption {
+interface IToggleOption<V = undefined, C = undefined> extends IRadioButtonOption {
 	children?: Record<string, TFrontendEngineFieldSchema<V, C>> | undefined;
 }
 
-interface IImageButtonOption extends IOption {
+interface IImageButtonOption extends IRadioButtonOption {
 	imgSrc?: string | undefined;
 }
 
@@ -21,7 +23,7 @@ export type TRadioToggleLayoutType = "horizontal" | "vertical";
 interface IRadioButtonDefaultSchema<V = undefined>
 	extends IBaseFieldSchema<"radio", V>,
 		TComponentOmitProps<RadioButtonProps> {
-	options: IOption[];
+	options: IRadioButtonOption[];
 	customOptions?:
 		| {
 				styleType: "default";

--- a/src/stories/3-fields/checkbox-group/checkbox-group.stories.tsx
+++ b/src/stories/3-fields/checkbox-group/checkbox-group.stories.tsx
@@ -146,6 +146,17 @@ FormattedOptions.args = {
 		{ label: "Fruits <a href='#'>Apple with a link</a>", value: "Apple" },
 		{ label: "<strong>Bolded Berry</strong>", value: "Berry" },
 		{ label: "<em>Italicised Cherry</em>", value: "Cherry" },
+		{
+			label: {
+				description: { uiType: "span", children: "Durian with tooltip " },
+				tooltip: {
+					uiType: "popover",
+					icon: "QuestionmarkCircleFillIcon",
+					hint: { content: "A pungent fruit" },
+				},
+			},
+			value: "Durian",
+		},
 	],
 };
 

--- a/src/stories/3-fields/checkbox-group/checkbox-toggle-group.stories.tsx
+++ b/src/stories/3-fields/checkbox-group/checkbox-toggle-group.stories.tsx
@@ -271,6 +271,30 @@ NestedFields.args = {
 	],
 };
 
+export const FormattedOptions = DefaultStoryTemplate<TCheckboxGroupSchema>("checkbox-formatted-options").bind({});
+FormattedOptions.args = {
+	uiType: "checkbox",
+	label: "Fruits",
+	customOptions: {
+		styleType: "toggle",
+	},
+	options: [
+		{
+			label: {
+				description: { uiType: "span", children: "Apple with tooltip " },
+				tooltip: {
+					uiType: "popover",
+					icon: "QuestionmarkCircleFillIcon",
+					hint: { content: "Keeps the doctor away" },
+				},
+			},
+			value: "Apple",
+		},
+		{ label: "<strong>Bolded Berry</strong>", value: "Berry" },
+		{ label: "<em>Italicised Cherry</em>", value: "Cherry" },
+	],
+};
+
 export const Reset = ResetStoryTemplate<TCheckboxGroupSchema>("checkbox-reset").bind({});
 Reset.args = {
 	uiType: "checkbox",

--- a/src/stories/3-fields/radio-button/radio-button.stories.tsx
+++ b/src/stories/3-fields/radio-button/radio-button.stories.tsx
@@ -132,6 +132,17 @@ FormattedOptions.args = {
 		{ label: "<a href='#'>Apple with a link</a>", value: "Apple" },
 		{ label: "<strong>Bolded Berry</strong>", value: "Berry" },
 		{ label: "<em>Italicised Cherry</em>", value: "Cherry" },
+		{
+			label: {
+				description: { uiType: "span", children: "Durian with tooltip " },
+				tooltip: {
+					uiType: "popover",
+					icon: "QuestionmarkCircleFillIcon",
+					hint: { content: "A pungent fruit" },
+				},
+			},
+			value: "Durian",
+		},
 	],
 };
 

--- a/src/stories/3-fields/radio-button/radio-toggle-button.stories.tsx
+++ b/src/stories/3-fields/radio-button/radio-toggle-button.stories.tsx
@@ -150,6 +150,30 @@ Disabled.args = {
 	disabled: true,
 };
 
+export const FormattedOptions = DefaultStoryTemplate<TRadioButtonGroupSchema>("radio-formatted-options").bind({});
+FormattedOptions.args = {
+	uiType: "radio",
+	label: "Radio Button",
+	customOptions: {
+		styleType: "toggle",
+	},
+	options: [
+		{
+			label: {
+				description: { uiType: "span", children: "Apple with tooltip " },
+				tooltip: {
+					uiType: "popover",
+					icon: "QuestionmarkCircleFillIcon",
+					hint: { content: "Keeps the doctor away" },
+				},
+			},
+			value: "Apple",
+		},
+		{ label: "<strong>Bolded Berry</strong>", value: "Berry" },
+		{ label: "<em>Italicised Cherry</em>", value: "Cherry" },
+	],
+};
+
 export const WithValidation = DefaultStoryTemplate<TRadioButtonGroupSchema>("radio-with-validation").bind({});
 WithValidation.args = {
 	uiType: "radio",

--- a/src/stories/4-elements/wrapper/wrapper.stories.tsx
+++ b/src/stories/4-elements/wrapper/wrapper.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgTypes, Stories, Title } from "@storybook/addon-docs";
 import { Meta, StoryFn } from "@storybook/react";
-import { IWrapperSchema } from "../../../components/elements/wrapper";
+import { TWrapperSchema } from "../../../components/elements/wrapper";
 import {
 	CommonFieldStoryProps,
 	FrontendEngine,
@@ -69,9 +69,9 @@ const Template = (id: string) =>
 				},
 			}}
 		/>
-	)) as StoryFn<IWrapperSchema>;
+	)) as StoryFn<TWrapperSchema>;
 
-const SectionTemplate: StoryFn<Record<string, IWrapperSchema>> = (args) => (
+const SectionTemplate: StoryFn<Record<string, TWrapperSchema>> = (args) => (
 	<FrontendEngine
 		data={{
 			sections: {
@@ -216,7 +216,7 @@ Layout.args = {
 };
 Layout.parameters = VariousElements.parameters;
 
-export const Overrides = OverrideStoryTemplate<IWrapperSchema>("wrapper-overrides", false).bind({});
+export const Overrides = OverrideStoryTemplate<TWrapperSchema>("wrapper-overrides", false).bind({});
 Overrides.args = {
 	uiType: "div",
 	children: {


### PR DESCRIPTION
**Changes**

- 38d9b1451bd132552dd3e8cd9ca868532250683e
  - enhanced checkbox/radio option label to support schema. the use case is to support popover at any position 
  - the children are restricted to [phrasing content](https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#phrasing_content) which we can usually think of as "inline" elements (in terms of presentation). currently the inline elements in FEE are `popover` and `span`
  - to restrict the typing of children, split up `IWrapperSchema` and `TElementSchema` to be more discrete
- 6028ab9ba9629b4577d150ef51c17428819dfecf
  - `IWrapperSchema` renamed to `TWrapperSchema` as it's now a type, not an interface
- f666c0eb92a5dfaab92b53aeb2089680edfcaf56
  - updating existing components that also restrict typing of children, to reuse the new discrete schemas
-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Support schema label in checkbox and radio
- Deprecate `IWrapperSchema` and replace with `TWrapperSchema`