### PR TITLE
Fix prefilled option not populated for select field with overrides

### DIFF
--- a/src/__tests__/components/custom/filter/filter-checkbox.spec.tsx
+++ b/src/__tests__/components/custom/filter/filter-checkbox.spec.tsx
@@ -114,6 +114,21 @@ describe(REFERENCE_KEY, () => {
 		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
 	});
 
+	it("should support default values matching initial overrides", async () => {
+		const value = "Overridden";
+		renderComponent(
+			{ options: [] },
+			{
+				defaultValues: { [COMPONENT_ID]: [value] },
+				overrides: { [COMPONENT_ID]: { options: [{ label: value, value: value }] } },
+			}
+		);
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: [value] }));
+	});
+
 	describe("update options schema", () => {
 		const CustomComponent = () => {
 			const [options, setOptions] = useState([

--- a/src/__tests__/components/fields/checkbox-group/checkbox-group.spec.tsx
+++ b/src/__tests__/components/fields/checkbox-group/checkbox-group.spec.tsx
@@ -218,6 +218,21 @@ describe(UI_TYPE, () => {
 		);
 	});
 
+	it("should support default values matching initial overrides", async () => {
+		const value = "Overridden";
+		renderComponent(
+			{ options: [] },
+			{
+				defaultValues: { [COMPONENT_ID]: [value] },
+				overrides: { [COMPONENT_ID]: { options: [{ label: value, value: value }] } },
+			}
+		);
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: [value] }));
+	});
+
 	describe("update options through schema", () => {
 		it.each`
 			scenario                                                                             | selected      | expectedValueBeforeUpdate | expectedValueAfterUpdate

--- a/src/__tests__/components/fields/chips/chips.spec.tsx
+++ b/src/__tests__/components/fields/chips/chips.spec.tsx
@@ -251,6 +251,21 @@ describe(UI_TYPE, () => {
 		});
 	});
 
+	it("should support default values matching initial overrides", async () => {
+		const value = "Overridden";
+		renderComponent(
+			{ options: [] },
+			{
+				defaultValues: { [COMPONENT_ID]: [value] },
+				overrides: { [COMPONENT_ID]: { options: [{ label: value, value: value }] } },
+			}
+		);
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: [value] }));
+	});
+
 	describe("update options through schema", () => {
 		it.each`
 			scenario                                                                             | selected      | expectedValueBeforeUpdate | expectedValueAfterUpdate

--- a/src/__tests__/components/fields/multi-select/multi-select.spec.tsx
+++ b/src/__tests__/components/fields/multi-select/multi-select.spec.tsx
@@ -173,6 +173,21 @@ describe(UI_TYPE, () => {
 		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
 	});
 
+	it("should support default values matching initial overrides", async () => {
+		const value = "Overridden";
+		renderComponent(
+			{ options: [] },
+			{
+				defaultValues: { [COMPONENT_ID]: [value] },
+				overrides: { [COMPONENT_ID]: { options: [{ label: value, value: value }] } },
+			}
+		);
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: [value] }));
+	});
+
 	describe("update options through schema", () => {
 		it.each`
 			scenario                                                                             | selected      | expectedValueBeforeUpdate | expectedValueAfterUpdate

--- a/src/__tests__/components/fields/nested-multi-select/nested-multi-select.spec.tsx
+++ b/src/__tests__/components/fields/nested-multi-select/nested-multi-select.spec.tsx
@@ -420,6 +420,32 @@ describe(UI_TYPE, () => {
 		});
 	});
 
+	it("should support default values matching initial overrides", async () => {
+		renderComponent(
+			{ options: [] },
+			{
+				defaultValues: { [COMPONENT_ID]: { parentKey: { childKey: "Overridden" } } },
+				overrides: {
+					[COMPONENT_ID]: {
+						options: [
+							{
+								label: "parent",
+								key: "parentKey",
+								subItems: [{ label: "child", value: "Overridden", key: "childKey" }],
+							},
+						],
+					},
+				},
+			}
+		);
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+
+		expect(SUBMIT_FN).toHaveBeenCalledWith(
+			expect.objectContaining({ [COMPONENT_ID]: { parentKey: { childKey: "Overridden" } } })
+		);
+	});
+
 	describe("update options through overrides", () => {
 		it.each`
 			scenario                                                                          | selected      | expectedValueBeforeUpdate                       | expectedValueAfterUpdate

--- a/src/__tests__/components/fields/radio-button/radio-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-button.spec.tsx
@@ -205,6 +205,21 @@ describe(UI_TYPE, () => {
 		);
 	});
 
+	it("should support default values matching initial overrides", async () => {
+		const value = "Overridden";
+		renderComponent(
+			{ options: [] },
+			{
+				defaultValues: { [COMPONENT_ID]: value },
+				overrides: { [COMPONENT_ID]: { options: [{ label: value, value: value }] } },
+			}
+		);
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: value }));
+	});
+
 	describe("update options through overrides", () => {
 		it.each`
 			scenario                                                              | selected | expectedValueBeforeUpdate | expectedValueAfterUpdate

--- a/src/__tests__/components/fields/range-select/range-select.spec.tsx
+++ b/src/__tests__/components/fields/range-select/range-select.spec.tsx
@@ -227,6 +227,29 @@ describe(UI_TYPE, () => {
 		);
 	});
 
+	it("should support default values matching initial overrides", async () => {
+		renderComponent(
+			{ options: {} },
+			{
+				defaultValues: { [COMPONENT_ID]: { from: "Apple", to: "Cherry" } },
+				overrides: {
+					[COMPONENT_ID]: {
+						options: {
+							from: [{ label: "A", value: "Apple" }],
+							to: [{ label: "C", value: "Cherry" }],
+						},
+					},
+				},
+			}
+		);
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+
+		expect(SUBMIT_FN).toHaveBeenCalledWith(
+			expect.objectContaining({ [COMPONENT_ID]: { from: "Apple", to: "Cherry" } })
+		);
+	});
+
 	describe("update options through overrides", () => {
 		it.each`
 			scenario                                                                        | selected      | expectedValueBeforeUpdate          | expectedValueAfterUpdate

--- a/src/__tests__/components/fields/select/select.spec.tsx
+++ b/src/__tests__/components/fields/select/select.spec.tsx
@@ -124,6 +124,20 @@ describe(UI_TYPE, () => {
 		expect(screen.getByText(placeholder)).toBeInTheDocument();
 	});
 
+	it("should support default values matching initial overrides", async () => {
+		const value = "Overridden";
+		renderComponent(
+			{ options: [] },
+			{
+				defaultValues: { [COMPONENT_ID]: value },
+				overrides: { [COMPONENT_ID]: { options: [{ label: value, value: value }] } },
+			}
+		);
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: value }));
+	});
+
 	describe("update options through schema", () => {
 		it.each`
 			scenario                                                                 | selected | expectedValueBeforeUpdate | expectedValueAfterUpdate

--- a/src/components/elements/sections/index.ts
+++ b/src/components/elements/sections/index.ts
@@ -1,2 +1,1 @@
 export * from "./sections";
-export * from "./types";

--- a/src/components/elements/sections/sections.tsx
+++ b/src/components/elements/sections/sections.tsx
@@ -1,6 +1,5 @@
 import { useFormSchema } from "../../../utils/hooks";
 import { Section } from "../section";
-import { ISectionsProps } from "./types";
 
 /**
  * this component is meant to render "pages" which consists of individual Section component
@@ -14,13 +13,12 @@ import { ISectionsProps } from "./types";
  * - render pages properly
  * - handle validation and errors in each section before navigating away
  */
-export const Sections = (props: ISectionsProps) => {
+export const Sections = () => {
 	// =============================================================================
 	// CONST, STATE, REF
 	// =============================================================================
-	const { schema } = props;
 	const {
-		formSchema: { overrides },
+		formSchema: { sections, overrides },
 		overrideSchema,
 	} = useFormSchema();
 
@@ -28,7 +26,7 @@ export const Sections = (props: ISectionsProps) => {
 	// RENDER FUNCTIONS
 	// =============================================================================
 	const renderSections = () => {
-		const overriddenSchema = overrideSchema(schema, overrides);
+		const overriddenSchema = overrideSchema(sections, overrides);
 		if (overriddenSchema) {
 			return Object.entries(overriddenSchema).map(([id, section], i) => (
 				<Section key={`section-${i}`} id={id} sectionSchema={section} />

--- a/src/components/elements/sections/types.ts
+++ b/src/components/elements/sections/types.ts
@@ -1,5 +1,0 @@
-import { ISectionSchema } from "../section";
-
-export interface ISectionsProps {
-	schema?: Record<string, ISectionSchema> | undefined;
-}

--- a/src/components/frontend-engine/frontend-engine.tsx
+++ b/src/components/frontend-engine/frontend-engine.tsx
@@ -47,7 +47,6 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 	const {
 		className: dataClassName = null,
 		defaultValues,
-		sections,
 		id,
 		stripUnknown,
 		revalidationMode = "onChange",
@@ -315,7 +314,7 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 				onSubmit={reactFormHookSubmit(handleSubmit, handleSubmitError)}
 				ref={ref}
 			>
-				<Sections schema={sections} />
+				<Sections />
 			</InnerElement>
 		</FormProvider>
 	);


### PR DESCRIPTION
**Changes**

- caused by field mounting before the overrides are loaded
- this is because `Sections` gets its schema from props and overrides from the context. the context is delayed by 1 render since it depends on `useEffect` to populate
- update `Sections` to get schema from form context, this ensures it renders the current schema in sync with its children
-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Fix prefill not working for `select` and `multi-select` when using overridden options