### PR TITLE
[MOL-16619][WH] to not setSelectionRange when input is not currently …

### DIFF
--- a/src/components/fields/text-field/text-field.tsx
+++ b/src/components/fields/text-field/text-field.tsx
@@ -92,7 +92,11 @@ export const TextField = (props: IGenericFieldProps<ITextFieldSchema | IEmailFie
 	}, [value]);
 
 	useEffect(() => {
-		if (uiType === "text-field" && ref.current.selectionEnd !== caret.current) {
+		if (
+			uiType === "text-field" &&
+			document?.activeElement === ref.current &&
+			ref.current.selectionEnd !== caret.current
+		) {
 			// keep caret in place after uppercase, not available for 'email' & 'number' HTML input types
 			ref.current.setSelectionRange(caret.current, caret.current);
 		}


### PR DESCRIPTION
**Changes**
To not call the `setSelectionRange` if the input is not in focus

-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   [WARNING] To not call the `setSelectionRange` if the input is not in focus

**Additional information**

- there is a bug/feature in Safari (which is being used by iOS webview) that it will auto focus on the input if we set selection range for it, then mobile Safari will autoscroll to the focused input
- chain of reactions: FEE set default values -> `stateValue` changed -> useEffect triggered -> setSelectionRange -> autofocus -> autoscroll

