### PR TITLE
[BOOKINGSG-6223][GC] add sublabel option for Toggle radio button option

### DIFF
--- a/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
@@ -179,6 +179,18 @@ describe("radio toggle button", () => {
 		expect(screen.getByText("Schema Label")).toBeInTheDocument();
 	});
 
+	it("should be able to render option subLabel", () => {
+		renderComponent({
+			options: [
+				{ label: "A", value: "Apple", subLabel: "Keeps the doctor away" },
+				{ label: "B", value: "Berry", subLabel: "Berry nutritious, good for you" },
+			],
+		});
+
+		expect(screen.getByText("Keeps the doctor away")).toBeInTheDocument();
+		expect(screen.getByText("Berry nutritious, good for you")).toBeInTheDocument();
+	});
+
 	describe("update options through schema", () => {
 		it.each`
 			scenario                                                                 | selected | expectedValueBeforeUpdate | expectedValueAfterUpdate

--- a/src/components/fields/radio-button/radio-button.tsx
+++ b/src/components/fields/radio-button/radio-button.tsx
@@ -146,6 +146,7 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 										  }
 										: null
 								}
+								subLabel={!!option.subLabel && renderLabel(option.subLabel)}
 							>
 								{renderLabel(option.label)}
 							</StyledToggle>

--- a/src/components/fields/radio-button/types.ts
+++ b/src/components/fields/radio-button/types.ts
@@ -12,6 +12,7 @@ export interface IRadioButtonOption {
 
 interface IToggleOption<V = undefined, C = undefined> extends IRadioButtonOption {
 	children?: Record<string, TFrontendEngineFieldSchema<V, C>> | undefined;
+	subLabel?: string | undefined;
 }
 
 interface IImageButtonOption extends IRadioButtonOption {

--- a/src/stories/3-fields/radio-button/radio-toggle-button.stories.tsx
+++ b/src/stories/3-fields/radio-button/radio-toggle-button.stories.tsx
@@ -128,7 +128,6 @@ OptionsWithSubLabel.args = {
 	uiType: "radio",
 	label: {
 		mainLabel: "Fruits",
-		subLabel: "Some helpful <strong>instructions</strong>",
 	},
 	customOptions: {
 		styleType: "toggle",

--- a/src/stories/3-fields/radio-button/radio-toggle-button.stories.tsx
+++ b/src/stories/3-fields/radio-button/radio-toggle-button.stories.tsx
@@ -55,7 +55,7 @@ const meta: Meta = {
 			table: {
 				type: {
 					summary:
-						"{ label: string, value: string, disabled?: boolean; children?: Record<string, TFrontendEngineFieldSchema> }[]",
+						"{label: string, value: string, disabled?: boolean; children?: Record<string, TFrontendEngineFieldSchema> }[]; subLabel?: string}",
 				},
 			},
 			type: { name: "object", value: {} },
@@ -118,6 +118,25 @@ LabelCustomisation.args = {
 		{ value: "Apple", label: "Apple" },
 		{ value: "Berry", label: "Berry" },
 		{ value: "Cherry", label: "Cherry" },
+	],
+};
+
+export const OptionsWithSubLabel = DefaultStoryTemplate<TRadioButtonGroupSchema>("radio-options-with-sub-label").bind(
+	{}
+);
+OptionsWithSubLabel.args = {
+	uiType: "radio",
+	label: {
+		mainLabel: "Fruits",
+		subLabel: "Some helpful <strong>instructions</strong>",
+	},
+	customOptions: {
+		styleType: "toggle",
+	},
+	options: [
+		{ value: "Apple", label: "Apple", subLabel: "Keeps the <strong>doctor</strong> away" },
+		{ value: "Berry", label: "Berry", subLabel: "<i>Berry</i> nutritious, good for you" },
+		{ value: "Cherry", label: "Cherry", subLabel: "Pick<br>The cherry on top" },
 	],
 };
 


### PR DESCRIPTION
**Changes**
Add `subLabel` prop for toggle radio button options

-   [delete] branch

**Changelog entry**

-   [WARNING] Radio buttons, with styleType set as `toggle`, can now accept an optional field called `subLabel`, which renders an additional block of text (i.e. `subLabel`) below the `label`.

**Additional information**

-   This enhancement activates the following [DS component feature](https://designsystem.life.gov.sg/react/index.html?path=/docs/data-input-toggle-with-sub-label--docs).
- This FEE feature will be used in [this BSG-Appts2.0 ticket](https://jira.ship.gov.sg/browse/BOOKINGSG-6223).
![image](https://github.com/user-attachments/assets/732053a3-2d0c-4a54-99c7-101dee7beac4)

