### PR TITLE
[MOL-16871][CWH] Add wrapper and apply word break only to filename

### DIFF
--- a/src/components/fields/image-upload/image-input/file-item/file-item.styles.ts
+++ b/src/components/fields/image-upload/image-input/file-item/file-item.styles.ts
@@ -67,6 +67,9 @@ export const Thumbnail = styled.div<{ src: string }>`
 
 export const TextBody = styled(Text.Body)`
 	flex: 1;
+`;
+
+export const FileNameWrapper = styled.div`
 	word-break: break-all;
 `;
 

--- a/src/components/fields/image-upload/image-input/file-item/file-item.tsx
+++ b/src/components/fields/image-upload/image-input/file-item/file-item.tsx
@@ -13,6 +13,7 @@ import {
 	DesktopTextBodyDetail,
 	ErrorCustomMutedThumbnailContainer,
 	ErrorText,
+	FileNameWrapper,
 	MobileTextBodyDetail,
 	ProgressBar,
 	TextBody,
@@ -168,9 +169,8 @@ export const FileItem = ({ id = "file-item", index, fileItem, maxSizeInKb, accep
 						as="div"
 						id={TestHelper.generateId(`${id}-${index + 1}`, "file-image")}
 						data-testid={TestHelper.generateId(`${id}-${index + 1}`, "file-image")}
-						ref={fileNameWrapperRef}
 					>
-						{transformedFileName}
+						<FileNameWrapper ref={fileNameWrapperRef}>{transformedFileName}</FileNameWrapper>
 						<DesktopTextBodyDetail>{renderError()}</DesktopTextBodyDetail>
 						<MobileTextBodyDetail>{fileSize}</MobileTextBodyDetail>
 					</TextBody>
@@ -179,7 +179,6 @@ export const FileItem = ({ id = "file-item", index, fileItem, maxSizeInKb, accep
 					as="div"
 					id={TestHelper.generateId(`${id}-${index + 1}`, "file-error")}
 					data-testid={TestHelper.generateId(`${id}-${index + 1}`, "file-error")}
-					ref={fileNameWrapperRef}
 				>
 					<MobileTextBodyDetail>{renderError()}</MobileTextBodyDetail>
 				</TextBody>
@@ -197,9 +196,8 @@ export const FileItem = ({ id = "file-item", index, fileItem, maxSizeInKb, accep
 					as="div"
 					id={TestHelper.generateId(`${id}-${index + 1}`, "file-image")}
 					data-testid={TestHelper.generateId(`${id}-${index + 1}`, "file-image")}
-					ref={fileNameWrapperRef}
 				>
-					{transformedFileName}
+					<FileNameWrapper ref={fileNameWrapperRef}>{transformedFileName}</FileNameWrapper>
 					{renderError()}
 					<MobileTextBodyDetail>{fileSize}</MobileTextBodyDetail>
 				</TextBody>


### PR DESCRIPTION
**Changes**
- fix error message issue due to word-break: all, add in word break wrapper to filename
- remove fileNameWrapperRef from error message
- delete branch

**Additional information**

-   You may refer to this [MOL-16871](https://jira.ship.gov.sg/browse/MOL-16871)