### PR TITLE
Call onValueChange with latest validity when schema changes

### DIFF
--- a/src/components/frontend-engine/use-form-change.ts
+++ b/src/components/frontend-engine/use-form-change.ts
@@ -2,6 +2,7 @@ import isEmpty from "lodash/isEmpty";
 import isEqual from "lodash/isEqual";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { UseFormReturn } from "react-hook-form";
+import { TFormYupConfig } from "../../context-providers";
 import { useFormValues, usePrevious, useValidationConfig, useValidationSchema } from "../../utils/hooks";
 import { IFrontendEngineProps, TFrontendEngineValues } from "./types";
 
@@ -98,12 +99,15 @@ export const useFormChange = (props: IFrontendEngineProps, formMethods: UseFormR
 
 	useEffect(() => {
 		// when config changes due to overrides or conditional rendering, mark validity for re-evaluation
-		if (
-			previousFormValidationConfig &&
-			// TODO: compare validation rules directly
-			JSON.stringify(previousFormValidationConfig) !== JSON.stringify(formValidationConfig)
-		) {
-			setHasSchemaChange(true);
+		if (previousFormValidationConfig) {
+			const mapValidationRules = (config: TFormYupConfig) => {
+				return Object.entries(config).map(([fieldId, { validationRules }]) => [fieldId, validationRules]);
+			};
+			const previousValidationRules = mapValidationRules(previousFormValidationConfig);
+			const validationRules = mapValidationRules(formValidationConfig);
+			if (!isEqual(previousValidationRules, validationRules)) {
+				setHasSchemaChange(true);
+			}
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [formValidationConfig]);

--- a/src/components/frontend-engine/use-form-change.ts
+++ b/src/components/frontend-engine/use-form-change.ts
@@ -1,0 +1,150 @@
+import isEmpty from "lodash/isEmpty";
+import isEqual from "lodash/isEqual";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { UseFormReturn } from "react-hook-form";
+import { useFormValues, usePrevious, useValidationConfig, useValidationSchema } from "../../utils/hooks";
+import { IFrontendEngineProps, TFrontendEngineValues } from "./types";
+
+/**
+ * Handles change in form values and validity. Updates consumer change handlers and error state.
+ *
+ * @param props
+ * @param formMethods
+ * @returns `checkIsFormValid`: helper to check current form validity
+ */
+export const useFormChange = (props: IFrontendEngineProps, formMethods: UseFormReturn) => {
+	// =============================================================================
+	// CONST, STATE, REFS
+	// =============================================================================
+	const { data, onChange, onValueChange } = props;
+	const { stripUnknown } = data || {};
+	const { hardValidationSchema } = useValidationSchema();
+	const { formValidationConfig } = useValidationConfig();
+	const { watch, getValues, formState, clearErrors } = formMethods;
+	const { setFields, setField, getFormValues } = useFormValues(formMethods);
+	const [oldFormValues, setOldFormValues] = useState<TFrontendEngineValues>({});
+	const [hasSchemaChange, setHasSchemaChange] = useState(false);
+	const previousFormValidationConfig = usePrevious(formValidationConfig);
+	const previousHardValidationSchema = usePrevious(hardValidationSchema);
+	const previousFormValues = useRef(undefined);
+	const previousFormValidity = useRef(undefined);
+
+	// =============================================================================
+	// HELPER FUNCTIONS
+	// =============================================================================
+	const checkIsFormValid = useCallback(() => {
+		try {
+			hardValidationSchema.validateSync(getValues());
+			return true;
+		} catch (error) {
+			return false;
+		}
+	}, [getValues, hardValidationSchema]);
+
+	const handleValueChange = useRef(() => {
+		// noop
+	});
+	handleValueChange.current = () => {
+		const formValues = getFormValues(undefined, stripUnknown);
+		const formValidity = checkIsFormValid();
+		// attach / fire onValueChange event only when formValidationConfig has values
+		// otherwise isValid will be returned incorrectly as true
+		if (onValueChange && Object.keys(formValidationConfig || {}).length) {
+			// memoise to prevent unnecessary calls
+			if (previousFormValidity.current !== formValidity || !isEqual(previousFormValues.current, formValues)) {
+				onValueChange(formValues, formValidity);
+			}
+		}
+		previousFormValues.current = formValues;
+		previousFormValidity.current = formValidity;
+	};
+
+	// =============================================================================
+	// EFFECTS
+	// =============================================================================
+	useEffect(() => {
+		const subscription = watch((value, { name }) => {
+			if (name) {
+				setField(name, value[name]);
+			} else {
+				setFields(value);
+			}
+		});
+		return () => subscription.unsubscribe();
+	}, []);
+
+	useEffect(() => {
+		// attach / fire onChange event only when formValidationConfig has values
+		// otherwise isValid will be returned incorrectly as true
+		if (onChange && Object.keys(formValidationConfig || {}).length) {
+			const subscription = watch(() => {
+				onChange(getFormValues(undefined, stripUnknown), checkIsFormValid());
+			});
+			onChange(getFormValues(undefined, stripUnknown), checkIsFormValid());
+
+			return () => subscription.unsubscribe();
+		}
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [checkIsFormValid, onChange, watch, formValidationConfig]);
+
+	useEffect(() => {
+		const subscription = watch(() => {
+			handleValueChange.current();
+		});
+
+		return () => subscription.unsubscribe();
+	}, [watch]);
+
+	useEffect(() => {
+		// when config changes due to overrides or conditional rendering, mark validity for re-evaluation
+		if (
+			previousFormValidationConfig &&
+			// TODO: compare validation rules directly
+			JSON.stringify(previousFormValidationConfig) !== JSON.stringify(formValidationConfig)
+		) {
+			setHasSchemaChange(true);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [formValidationConfig]);
+
+	useEffect(() => {
+		// re-evaluate form validity when schema changes
+		if (hasSchemaChange && previousHardValidationSchema !== hardValidationSchema) {
+			handleValueChange.current();
+			setHasSchemaChange(false);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [hasSchemaChange, hardValidationSchema]);
+
+	useEffect(() => {
+		const errors = formState.errors;
+
+		if (errors && !isEmpty(errors)) {
+			const subscription = watch((value) => {
+				const apiErrors = Object.fromEntries(
+					Object.entries(formState.errors).filter(([_, value]) => value.type === "api")
+				);
+				const hasApiErrors = apiErrors && !isEmpty(apiErrors);
+
+				if (hasApiErrors) {
+					Object.keys(apiErrors).forEach((key) => {
+						const oldValue = oldFormValues[key];
+						const updatedValue = value[key];
+
+						if (oldValue !== updatedValue) {
+							clearErrors(key);
+						}
+					});
+				}
+
+				setOldFormValues(value);
+			});
+
+			return () => subscription.unsubscribe();
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [formState, watch]);
+
+	return { checkIsFormValid };
+};

--- a/src/context-providers/yup/helper.ts
+++ b/src/context-providers/yup/helper.ts
@@ -55,7 +55,7 @@ export namespace YupHelper {
 
 		const parsedFieldConfigs = { ...fieldConfigs };
 		Object.entries(parsedFieldConfigs).forEach(([id, { validationRules }]) => {
-			const [parsedFieldConfig, fieldWhenPairIds] = addSchemaToWhenRules(id, fieldConfigs, validationRules);
+			const [parsedFieldConfig, fieldWhenPairIds] = addSchemaToWhenRules(id, parsedFieldConfigs, validationRules);
 			whenPairIds.push(...fieldWhenPairIds);
 			parsedFieldConfigs[id].validationRules = parsedFieldConfig;
 		});
@@ -80,7 +80,10 @@ export namespace YupHelper {
 		fieldValidationConfig
 			?.filter((fieldValidationConfig) => "when" in fieldValidationConfig)
 			.forEach((fieldValidationConfig) => {
-				const parsedConfig = { ...fieldValidationConfig };
+				const parsedConfig = {
+					...fieldValidationConfig,
+					when: fieldValidationConfig.when ? { ...fieldValidationConfig.when } : undefined,
+				};
 				Object.keys(parsedConfig.when).forEach((whenFieldId) => {
 					// when
 					whenPairIds.push([id, whenFieldId]);


### PR DESCRIPTION
**Changes**

`onValueChange` is not triggered when schema changes e.g. due to conditional rendering. This can cause the validity status to be stale. Detect when the form validation changes and trigger this callback accordingly

-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   [WARNING] Trigger onValueChange when schema changes