### PR TITLE
clear boolean values if restoreMode=none

### DIFF
--- a/src/components/elements/wrapper/field-wrapper.tsx
+++ b/src/components/elements/wrapper/field-wrapper.tsx
@@ -2,6 +2,7 @@ import { Color } from "@lifesg/react-design-system/color";
 import { FormLabelProps } from "@lifesg/react-design-system/form/types";
 import { TextStyleHelper } from "@lifesg/react-design-system/text";
 import isArray from "lodash/isArray";
+import isBoolean from "lodash/isBoolean";
 import isNumber from "lodash/isNumber";
 import isString from "lodash/isString";
 import { useEffect, useRef } from "react";
@@ -60,8 +61,10 @@ export const FieldWrapper = ({ Field, id, schema, warning }: IProps) => {
 					const value = getField(id);
 					if (isArray(value)) {
 						setField(id, []);
-					} else if (isString(value) || isNumber(value)) {
+					} else if (isString(value)) {
 						setField(id, "");
+					} else if (isNumber(value) || isBoolean(value)) {
+						setField(id, undefined);
 					}
 					break;
 				}


### PR DESCRIPTION
**Changes**
- when `restoreMode=none`, allow boolean values to be cleared as well
- delete branch

**Note**
the clearing behaviour is still rather awkward and need further enhancements 
- setting `undefined` is the only way to clear numeric / boolean fields but it cannot be done in `reset` button because RHF dont accept `undefined` for reset. we need further enhancements to make all fields support `null` value and align the reset value
- we cant handle clearing of objects yet because every object is expecting a different shape, individual fields need to be enhanced to work with the clearing / reset