### PR TITLE
[MOL-15397][NL] Fix location modal being empty on first load

### DIFF
--- a/src/components/fields/location-field/location-modal/location-modal.tsx
+++ b/src/components/fields/location-field/location-modal/location-modal.tsx
@@ -338,6 +338,10 @@ const LocationModal = ({
 		}
 	}, [selectedAddressInfo, gettingCurrentLocation, setSinglePanelMode]);
 
+	useEffect(() => {
+		setSelectedAddressInfo(formValues || {});
+	}, [formValues]);
+
 	// =============================================================================
 	// RENDER FUNCTIONS
 	// =============================================================================

--- a/src/components/fields/location-field/location-modal/location-search/location-search.tsx
+++ b/src/components/fields/location-field/location-modal/location-search/location-search.tsx
@@ -328,6 +328,12 @@ export const LocationSearch = ({
 		}
 	}, [selectablePins]);
 
+	useEffect(() => {
+		if (selectedAddressInfo.address) {
+			setQueryString(selectedAddressInfo.address);
+		}
+	}, [selectedAddressInfo.address]);
+
 	// =============================================================================
 	// EVENT HANDLERS
 	// =============================================================================


### PR DESCRIPTION
**Changes**

When populating the location from image metadata, clicking the location modal to open the map modal shows the location field as empty the first time but works correctly on subsequent attempts.

-   [ delete ] branch

**Additional information**

-   You may refer to this [ticket](https://sgtechstack.atlassian.net/browse/MOL-15397)
