### PR TITLE
Fix outdated values when validating array-field

### DIFF
--- a/src/components/custom/array-field/array-field.tsx
+++ b/src/components/custom/array-field/array-field.tsx
@@ -44,7 +44,7 @@ export const ArrayField = (props: IGenericCustomFieldProps<IArrayFieldSchema>) =
 		value,
 		warning,
 	} = props;
-	const [stateValue, setStateValue] = useState<TFrontendEngineValues[]>([{}]);
+	const [stateValue, _setStateValue] = useState<TFrontendEngineValues[]>([{}]);
 	const [stateKeys, setStateKeys] = useState<string[]>(() => [generateRandomId()]);
 	const [showRemovePrompt, setShowRemovePrompt] = useState<boolean>(false);
 	const [indexToRemove, setIndexToRemove] = useState<number>(-1);
@@ -60,10 +60,6 @@ export const ArrayField = (props: IGenericCustomFieldProps<IArrayFieldSchema>) =
 	// =============================================================================
 	// EFFECTS
 	// =============================================================================
-	useEffect(() => {
-		stateValueRef.current = stateValue;
-	}, [stateValue]);
-
 	useEffect(() => {
 		const isRequiredRule = validation?.find((rule) => "required" in rule);
 		const validRule = validation?.find((rule) => "valid" in rule);
@@ -174,6 +170,11 @@ export const ArrayField = (props: IGenericCustomFieldProps<IArrayFieldSchema>) =
 			newArr.push(generator());
 		}
 		return newArr;
+	};
+
+	const setStateValue = (nextValue: TFrontendEngineValues[]) => {
+		_setStateValue(nextValue);
+		stateValueRef.current = nextValue;
 	};
 
 	// =============================================================================


### PR DESCRIPTION
**Changes**

- `array-field` was still returning wrong validity in `onValueChange` after a section is added/removed as `stateValue` hasn't been updated by `useEffect`
- as a workaround, update `stateValue` ref immediately whenever state is set
-   [delete] branch