### PR TITLE
Object custom validation

### DIFF
--- a/src/context-providers/yup/helper.ts
+++ b/src/context-providers/yup/helper.ts
@@ -238,15 +238,20 @@ export namespace YupHelper {
 				customYupConditions.includes(k as TYupCondition)
 			)?.[0] as TYupCondition;
 			if (customRuleKey) {
-				yupSchema = (yupSchema as unknown)[customRuleKey](rule[customRuleKey], rule.errorMessage);
+				yupSchema = (yupSchema as unknown)[customRuleKey]?.(rule[customRuleKey], rule.errorMessage);
 			}
-
 			// prevent applying non-required validation for empty fields
-			yupSchema = yupSchema.transform((value) => {
-				if (value === null || value === "" || (typeof value === "object" && Object.keys(value).length === 0))
-					return undefined;
-				return value;
-			});
+			if (yupSchema) {
+				yupSchema = yupSchema.transform((value) => {
+					if (
+						value === null ||
+						value === "" ||
+						(typeof value === "object" && Object.keys(value).length === 0)
+					)
+						return undefined;
+					return value;
+				});
+			}
 		});
 
 		return yupSchema;

--- a/src/context-providers/yup/helper.ts
+++ b/src/context-providers/yup/helper.ts
@@ -293,7 +293,8 @@ export namespace YupHelper {
 
 					// from typing is only added in v1.0.0-beta.7 (https://github.com/jquense/yup/issues/1631)
 					// TODO: switch from dynamic reference once yup is updated
-					const metaYupId = testContext.options["from"][0].schema.describe().meta.yupId;
+					const fromLength = testContext.options["from"].length;
+					const metaYupId = testContext.options["from"][fromLength - 1].schema.describe().meta.yupId;
 					return customValidationMapping[metaYupId]?.[name]?.(value, arg, testContext);
 				},
 			});


### PR DESCRIPTION
**Changes**
- updated Yup custom validation to look for `yupId` in the correct place
- added test cases for applying custom validations for various data types

**Additional information**
- error is reported when adding custom validation for `date-range-field`
- issue is with the checking of `yupId` in `const metaYupId = testContext.options["from"][0].schema.describe().meta.yupId;`
- it appears that when using `Yup.object()`, an extra entry is added to the from array, the last entry is the topmost layer where `yupId` is stored

