### PR TITLE
[FILE_UPLOAD][WL] fix jpg validation in file-upload

### DIFF
--- a/src/utils/file-helper.ts
+++ b/src/utils/file-helper.ts
@@ -138,7 +138,7 @@ export namespace FileHelper {
 		const [fileInfo] = getFileInfo(bytes);
 		return {
 			mime: fileInfo?.mime,
-			ext: fileInfo?.extension,
+			ext: fileInfo?.extension === "jpeg" ? "jpg" : fileInfo?.extension,
 		};
 	};
 


### PR DESCRIPTION
**Changes**
- Fix jpg validation with file-upload

**Additional information**

- Validation is failing because the derived ext is `jpeg` but our rule accepts `jpg` only
- Solution is to convert the derived ext to `jpg`
