### PR TITLE
[MOL-17213][WH] Fix image became pixelated after user drew on it issue

### DIFF
--- a/src/components/fields/image-upload/image-review/image-editor/image-editor.tsx
+++ b/src/components/fields/image-upload/image-review/image-editor/image-editor.tsx
@@ -58,11 +58,14 @@ export const ImageEditor = forwardRef((props: IImageEditorProps, ref: ForwardedR
 					height: fabricBackground.current.getScaledHeight(),
 					width: fabricBackground.current.getScaledWidth(),
 				}) || "";
-			const filesize = FileHelper.getFilesizeFromBase64(dataURL);
 
 			const reducedQuality = quality - 0.05;
 			if (reducedQuality < 0) return dataURL;
-			if (limit && filesize > limit) return toDataURLWithLimit(limit, reducedQuality);
+
+			const filesizeInB = FileHelper.getFilesizeFromBase64(dataURL);
+			const maxSizeInB = limit * 1024;
+			if (maxSizeInB && filesizeInB > maxSizeInB) return toDataURLWithLimit(limit, reducedQuality);
+
 			return dataURL;
 		}
 		return "";

--- a/src/utils/file-helper.ts
+++ b/src/utils/file-helper.ts
@@ -85,7 +85,7 @@ export namespace FileHelper {
 	};
 
 	/**
-	 * estimate filesize from base64 string
+	 * estimate filesize (in terms of bytes) from base64 string
 	 * https://stackoverflow.com/questions/53228948/how-to-get-image-file-size-from-base-64-string-in-javascript#answer-53229045
 	 */
 	export const getFilesizeFromBase64 = (base64: string): number => {


### PR DESCRIPTION
**Changes**
Make sure it's checking the max file size in correct unit

-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   To check for max file size correctly when compressing image after user draw on the image uploaded

**Additional information**

-   You may refer to this [ticket](https://sgtechstack.atlassian.net/browse/MOL-17213)
