### PR TITLE
Fix textarea error and max length counter not being on the same line

### DIFF
--- a/src/components/fields/textarea/textarea.styles.tsx
+++ b/src/components/fields/textarea/textarea.styles.tsx
@@ -1,8 +1,7 @@
-import { Textarea } from "@lifesg/react-design-system/input-textarea";
+import { Form } from "@lifesg/react-design-system/form";
 import styled, { css } from "styled-components";
 
 interface ITextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
-	maxLength?: number | undefined;
 	resizable?: boolean | undefined;
 }
 
@@ -21,7 +20,7 @@ export const ChipContainer = styled.div<{ $chipPosition?: "top" | "bottom" | und
 	gap: 0.5rem;
 `;
 
-export const StyledTextarea = styled(Textarea)<ITextareaProps>`
+export const StyledTextarea = styled(Form.Textarea)<ITextareaProps>`
 	width: auto;
 
 	${(props) =>

--- a/src/components/fields/textarea/textarea.tsx
+++ b/src/components/fields/textarea/textarea.tsx
@@ -97,23 +97,9 @@ export const Textarea = (props: IGenericFieldProps<ITextareaSchema>) => {
 		);
 	};
 
-	const renderLabel = () => {
-		const baseId = `${id}-base`;
-		if (typeof formattedLabel === "string") {
-			return <Form.Label htmlFor={baseId}>{formattedLabel}</Form.Label>;
-		} else {
-			return (
-				<Form.Label {...formattedLabel} htmlFor={baseId}>
-					{formattedLabel?.children}
-				</Form.Label>
-			);
-		}
-	};
-
 	return (
 		<>
-			<Form.CustomField id={id}>
-				{renderLabel()}
+			<Form.CustomField id={id} label={formattedLabel}>
 				<Wrapper chipPosition={chipPosition}>
 					{renderChips()}
 					<StyledTextarea

--- a/src/components/fields/textarea/textarea.tsx
+++ b/src/components/fields/textarea/textarea.tsx
@@ -37,6 +37,7 @@ export const Textarea = (props: IGenericFieldProps<ITextareaSchema>) => {
 		// ensure default value is passed to react-hook-form on mount
 		// this is used in conjunction with chips + textarea field
 		setValue(id, value);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	useEffect(() => {
@@ -96,15 +97,29 @@ export const Textarea = (props: IGenericFieldProps<ITextareaSchema>) => {
 		);
 	};
 
+	const renderLabel = () => {
+		const baseId = `${id}-base`;
+		if (typeof formattedLabel === "string") {
+			return <Form.Label htmlFor={baseId}>{formattedLabel}</Form.Label>;
+		} else {
+			return (
+				<Form.Label {...formattedLabel} htmlFor={baseId}>
+					{formattedLabel?.children}
+				</Form.Label>
+			);
+		}
+	};
+
 	return (
 		<>
-			<Form.CustomField label={formattedLabel} id={id} errorMessage={error?.message}>
+			<Form.CustomField id={id}>
+				{renderLabel()}
 				<Wrapper chipPosition={chipPosition}>
 					{renderChips()}
 					<StyledTextarea
 						{...otherSchema}
 						{...otherProps}
-						id={id + "-base"}
+						id={id}
 						data-testid={TestHelper.generateId(id, "textarea")}
 						className={className}
 						name={name}
@@ -113,7 +128,7 @@ export const Textarea = (props: IGenericFieldProps<ITextareaSchema>) => {
 						resizable={resizable}
 						onChange={handleChange}
 						value={stateValue}
-						error={!!error?.message}
+						errorMessage={error?.message}
 					/>
 				</Wrapper>
 			</Form.CustomField>


### PR DESCRIPTION
**Changes**
The error message and counter texts are not aligned. This PR changes `Textarea` to use `Form.Textarea` instead of the standalone component (form version has this fixed)
![image](https://github.com/user-attachments/assets/5af25559-6282-40cd-bb4b-a14e3ea8e296)

-   [delete] branch

**Changelog entry**
- Fixed textarea error message and max length counter not being on the same line