### PR TITLE
[MOL-17410][GW] Update accordion element to allow for custom titles

### DIFF
--- a/src/__tests__/components/elements/accordion/accordion.spec.tsx
+++ b/src/__tests__/components/elements/accordion/accordion.spec.tsx
@@ -97,9 +97,48 @@ describe(UI_TYPE, () => {
 		expect(screen.getByText(CUSTOM_LABEL)).toBeInTheDocument();
 	});
 
-	it("should render the title correctly", () => {
+	it("should render the title string correctly", () => {
 		renderComponent({});
-		expect(screen.getByText(ACCORDION_TITLE)).toBeInTheDocument();
+		const element = screen.getByText(ACCORDION_TITLE);
+		expect(element).toBeInTheDocument();
+		expect(element.tagName).toBe("H3");
+	});
+
+	it("should render the title schema correctly", () => {
+		const SPAN_TITLE = "span title";
+		renderComponent(
+			{},
+			{
+				title: {
+					text: {
+						uiType: "text-h4",
+						children: ACCORDION_TITLE,
+					},
+					span: {
+						uiType: "span",
+						children: SPAN_TITLE,
+					},
+					popover: {
+						hint: {
+							content: "this is a custom title",
+						},
+						icon: "ICircleFillIcon",
+						uiType: "popover",
+					},
+				},
+			}
+		);
+		const element = screen.getByText(ACCORDION_TITLE);
+		expect(element).toBeInTheDocument();
+		expect(element.tagName).toBe("SPAN");
+		expect(element.parentElement.tagName).toBe("H4");
+
+		const spanElement = screen.getByText(SPAN_TITLE);
+		expect(spanElement).toBeInTheDocument();
+		expect(spanElement.tagName).toBe("SPAN");
+		expect(spanElement.parentElement.tagName).toBe("H3");
+
+		expect(screen.queryByTestId("popover__popover")).toBeInTheDocument();
 	});
 
 	it("should render the default button if button is true", () => {

--- a/src/components/elements/accordion/accordion.tsx
+++ b/src/components/elements/accordion/accordion.tsx
@@ -22,7 +22,7 @@ export const Accordion = (props: IGenericElementProps<IAccordionSchema>) => {
 	return (
 		<BoxContainer
 			id={id}
-			title={title}
+			title={typeof title === "string" ? title : <Wrapper>{title}</Wrapper>}
 			{...otherSchema}
 			callToActionComponent={
 				button ? (

--- a/src/components/elements/accordion/types.ts
+++ b/src/components/elements/accordion/types.ts
@@ -1,8 +1,10 @@
 import { BoxContainerDisplayState, BoxContainerSubComponentTestIds } from "@lifesg/react-design-system/box-container";
 import { TFieldEventListener } from "../../../utils";
 import { TComponentOmitProps, TFrontendEngineFieldSchema } from "../../frontend-engine";
+import { IPopoverSchema } from "../popover/types";
+import { ITextSchema } from "../text/types";
 import { IBaseElementSchema } from "../types";
-import { TWrapperSchema } from "../wrapper";
+import { IInlineWrapperSchema, TWrapperSchema } from "../wrapper";
 
 export interface IButtonAccordion {
 	label: string | undefined;
@@ -10,7 +12,7 @@ export interface IButtonAccordion {
 
 export interface IAccordionSchema<V = undefined, C = undefined>
 	extends IBaseElementSchema<"accordion">,
-		TComponentOmitProps<TWrapperSchema> {
+		TComponentOmitProps<TWrapperSchema, "title"> {
 	uiType: "accordion";
 	button?: boolean | IButtonAccordion | undefined;
 	children: Record<string, TFrontendEngineFieldSchema<V, C>>;
@@ -20,7 +22,7 @@ export interface IAccordionSchema<V = undefined, C = undefined>
 	collapsible?: boolean | undefined;
 	expanded?: boolean | undefined;
 	displayState?: BoxContainerDisplayState | undefined;
-	title: string;
+	title: string | Record<string, ITextSchema | IPopoverSchema | IInlineWrapperSchema<V, C>>;
 	disableContentInset?: boolean | undefined;
 }
 

--- a/src/stories/4-elements/accordion/accordion.stories.tsx
+++ b/src/stories/4-elements/accordion/accordion.stories.tsx
@@ -67,10 +67,11 @@ const meta: Meta = {
 			},
 		},
 		title: {
-			description: "A name of the purpose of the element",
+			description:
+				"A name of the purpose of the element. Also accepts <code>Text</code>, <code>Popover</code> or <code>span</code> schemas",
 			table: {
 				type: {
-					summary: "string",
+					summary: "string | ITextSchema | IPopoverSchema | IInlineWrapperSchema",
 				},
 			},
 		},
@@ -152,6 +153,44 @@ Default.args = {
 	collapsible: true,
 	expanded: true,
 	title: "Title",
+};
+
+export const CustomTitle = DefaultStoryTemplate<IAccordionSchema>("accordion-default").bind({});
+CustomTitle.args = {
+	uiType: "accordion",
+	children: {
+		text: {
+			uiType: "text-field",
+			label: "Text",
+			validation: [{ required: true }],
+		},
+		text2: {
+			uiType: "text-field",
+			label: "Text 2",
+			validation: [{ required: true }],
+		},
+	},
+	button: false,
+	collapsible: true,
+	expanded: true,
+	title: {
+		text: {
+			uiType: "text-h4",
+			weight: "semibold",
+			children: "Custom&nbsp;",
+		},
+		span: {
+			uiType: "span",
+			children: "title",
+		},
+		popover: {
+			hint: {
+				content: "this is a custom title",
+			},
+			icon: "ICircleFillIcon",
+			uiType: "popover",
+		},
+	},
 };
 
 export const Collapsible = DefaultStoryTemplate<IAccordionSchema>("accordion-collapsible").bind({});


### PR DESCRIPTION
**Changes**
Currently, the accordion's title is fixed and not customisable. The new design calls for the title to be in "semibold" and a H4 element instead.

-   delete branch


**Changelog entry**

-   Update accordion element to allow for custom titles

**Additional information**

-   You may refer to this [MOL-17410](https://sgtechstack.atlassian.net/browse/MOL-17410)

