### PR TITLE
Set `hidden-field` value from schema

### DIFF
--- a/src/__tests__/components/fields/hidden-field/hidden-field.spec.tsx
+++ b/src/__tests__/components/fields/hidden-field/hidden-field.spec.tsx
@@ -122,6 +122,15 @@ describe(UI_TYPE, () => {
 		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: false }));
 	});
 
+	it("should set value to null if valueType=null", async () => {
+		const defaultValue = true;
+		renderComponent({ valueType: "null" }, { defaultValues: { [COMPONENT_ID]: defaultValue } });
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: null }));
+	});
+
 	it("should not let setValue override the schema value", async () => {
 		const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), {
 			sections: {
@@ -216,6 +225,15 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: "hello" }));
+		});
+
+		it("should revert to null if valueType=null on reset", async () => {
+			renderComponent({ valueType: "null" }, { defaultValues: { [COMPONENT_ID]: "bye" } });
+
+			fireEvent.click(getResetButton());
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: null }));
 		});
 	});
 });

--- a/src/__tests__/components/fields/hidden-field/hidden-field.spec.tsx
+++ b/src/__tests__/components/fields/hidden-field/hidden-field.spec.tsx
@@ -105,6 +105,23 @@ describe(UI_TYPE, () => {
 		expect(SUBMIT_FN).not.toHaveBeenCalled();
 	});
 
+	it("should support setting of value from the schema", async () => {
+		renderComponent({ valueType: "number", value: 0 });
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: 0 }));
+	});
+
+	it("should not let default value override the schema value", async () => {
+		const defaultValue = true;
+		renderComponent({ valueType: "boolean", value: false }, { defaultValues: { [COMPONENT_ID]: defaultValue } });
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: false }));
+	});
+
 	describe("dirty state", () => {
 		let formIsDirty: boolean;
 		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
@@ -143,6 +160,22 @@ describe(UI_TYPE, () => {
 			);
 			fireEvent.change(getHiddenField(), { target: { value: "world" } });
 			fireEvent.click(getResetButton());
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(false);
+		});
+
+		it("should mount with schema value without setting field state as dirty", () => {
+			const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), {
+				sections: {
+					section: {
+						children: {
+							[COMPONENT_ID]: { valueType: "string", value: "hello" },
+						},
+					},
+				},
+			});
+			render(<FrontendEngineWithCustomButton data={json} onClick={handleClick} />);
 			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
 
 			expect(formIsDirty).toBe(false);

--- a/src/components/fields/hidden-field/hidden-field.tsx
+++ b/src/components/fields/hidden-field/hidden-field.tsx
@@ -1,10 +1,12 @@
+import isNil from "lodash/isNil";
 import { useEffect } from "react";
+import { useFormContext } from "react-hook-form";
 import * as Yup from "yup";
 import { IGenericFieldProps } from "..";
 import { useValidationConfig } from "../../../utils/hooks";
-import { IHiddenFieldSchema } from "./types";
+import { THiddenFieldSchema } from "./types";
 
-export const HiddenField = (props: IGenericFieldProps<IHiddenFieldSchema>) => {
+export const HiddenField = (props: IGenericFieldProps<THiddenFieldSchema>) => {
 	// =============================================================================
 	// CONST, STATE, REFS
 	// =============================================================================
@@ -13,10 +15,11 @@ export const HiddenField = (props: IGenericFieldProps<IHiddenFieldSchema>) => {
 		name,
 		onBlur,
 		onChange,
-		schema: { showIf: _showIf, uiType: _uiType, validation, valueType, ...otherSchema },
+		schema: { showIf: _showIf, uiType: _uiType, validation, valueType, value: schemaValue, ...otherSchema },
 		value,
 	} = props;
 	const { setFieldValidationConfig } = useValidationConfig();
+	const { setValue } = useFormContext();
 
 	// =============================================================================
 	// EFFECTS
@@ -38,6 +41,12 @@ export const HiddenField = (props: IGenericFieldProps<IHiddenFieldSchema>) => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [validation, valueType]);
 
+	useEffect(() => {
+		if (!isNil(schemaValue) && value !== schemaValue) {
+			setValue(id, schemaValue);
+		}
+	}, [setValue, id, schemaValue, value]);
+
 	// =============================================================================
 	// RENDER FUNCTIONS
 	// =============================================================================
@@ -50,7 +59,7 @@ export const HiddenField = (props: IGenericFieldProps<IHiddenFieldSchema>) => {
 			id={id}
 			data-testid={id}
 			name={name}
-			value={value}
+			value={schemaValue ?? value}
 		/>
 	);
 };

--- a/src/components/fields/hidden-field/hidden-field.tsx
+++ b/src/components/fields/hidden-field/hidden-field.tsx
@@ -27,6 +27,9 @@ export const HiddenField = (props: IGenericFieldProps<THiddenFieldSchema>) => {
 	useEffect(() => {
 		let baseYupSchema: Yup.AnySchema;
 		switch (valueType) {
+			case "null":
+				baseYupSchema = Yup.mixed();
+				break;
 			case "number":
 				baseYupSchema = Yup.number();
 				break;
@@ -42,10 +45,12 @@ export const HiddenField = (props: IGenericFieldProps<THiddenFieldSchema>) => {
 	}, [validation, valueType]);
 
 	useEffect(() => {
-		if (!isNil(schemaValue) && value !== schemaValue) {
+		if (valueType === "null" && value !== null) {
+			setValue(id, null);
+		} else if (!isNil(schemaValue) && value !== schemaValue) {
 			setValue(id, schemaValue);
 		}
-	}, [setValue, id, schemaValue, value]);
+	}, [setValue, id, valueType, schemaValue, value]);
 
 	// =============================================================================
 	// RENDER FUNCTIONS
@@ -59,7 +64,7 @@ export const HiddenField = (props: IGenericFieldProps<THiddenFieldSchema>) => {
 			id={id}
 			data-testid={id}
 			name={name}
-			value={schemaValue ?? value}
+			value={schemaValue ?? value ?? ""}
 		/>
 	);
 };

--- a/src/components/fields/hidden-field/types.ts
+++ b/src/components/fields/hidden-field/types.ts
@@ -6,33 +6,33 @@ export interface IHiddenFieldValidationRule extends IYupValidationRule {
 	matchesSchema?: boolean | undefined;
 }
 
-type StringField = {
+type TStringField = {
 	valueType: "string";
-	value?: string;
+	value?: string | undefined;
 };
 
-type NumberField = {
+type TNumberField = {
 	valueType: "number";
-	value?: number;
+	value?: number | undefined;
 };
 
-type BooleanField = {
+type TBooleanField = {
 	valueType: "boolean";
-	value?: boolean;
+	value?: boolean | undefined;
 };
 
-type NoValueField = {
+type TNoValueField = {
 	valueType?: never | undefined;
 	value?: never | undefined;
 };
 
-type FieldType = StringField | NumberField | BooleanField | NoValueField;
+type TFieldType = TStringField | TNumberField | TBooleanField | TNoValueField;
 
 export type THiddenFieldSchema<V = undefined> = Pick<
 	IBaseFieldSchema<"hidden-field", V, IHiddenFieldValidationRule>,
 	"showIf" | "validation" | "uiType"
 > &
-	FieldType;
+	TFieldType;
 
 /** @deprecated use THiddenFieldSchema */
 export type IHiddenFieldSchema<V = undefined> = THiddenFieldSchema<V>;

--- a/src/components/fields/hidden-field/types.ts
+++ b/src/components/fields/hidden-field/types.ts
@@ -21,12 +21,17 @@ type TBooleanField = {
 	value?: boolean | undefined;
 };
 
+type TNullField = {
+	valueType: "null";
+	value?: null | undefined;
+};
+
 type TNoValueField = {
 	valueType?: never | undefined;
 	value?: never | undefined;
 };
 
-type TFieldType = TStringField | TNumberField | TBooleanField | TNoValueField;
+type TFieldType = TStringField | TNumberField | TBooleanField | TNullField | TNoValueField;
 
 export type THiddenFieldSchema<V = undefined> = Pick<
 	IBaseFieldSchema<"hidden-field", V, IHiddenFieldValidationRule>,

--- a/src/components/fields/hidden-field/types.ts
+++ b/src/components/fields/hidden-field/types.ts
@@ -1,6 +1,38 @@
+import { IYupValidationRule } from "../../types";
 import { IBaseFieldSchema } from "../types";
 
-export interface IHiddenFieldSchema<V = undefined>
-	extends Pick<IBaseFieldSchema<"hidden-field", V>, "showIf" | "validation" | "uiType"> {
-	valueType?: "string" | "number" | "boolean" | undefined;
+export interface IHiddenFieldValidationRule extends IYupValidationRule {
+	/** for customising error message when submitted value does not match schema value */
+	matchesSchema?: boolean | undefined;
 }
+
+type StringField = {
+	valueType: "string";
+	value?: string;
+};
+
+type NumberField = {
+	valueType: "number";
+	value?: number;
+};
+
+type BooleanField = {
+	valueType: "boolean";
+	value?: boolean;
+};
+
+type NoValueField = {
+	valueType?: never | undefined;
+	value?: never | undefined;
+};
+
+type FieldType = StringField | NumberField | BooleanField | NoValueField;
+
+export type THiddenFieldSchema<V = undefined> = Pick<
+	IBaseFieldSchema<"hidden-field", V, IHiddenFieldValidationRule>,
+	"showIf" | "validation" | "uiType"
+> &
+	FieldType;
+
+/** @deprecated use THiddenFieldSchema */
+export type IHiddenFieldSchema<V = undefined> = THiddenFieldSchema<V>;

--- a/src/components/fields/hidden-field/types.ts
+++ b/src/components/fields/hidden-field/types.ts
@@ -3,7 +3,7 @@ import { IBaseFieldSchema } from "../types";
 
 export interface IHiddenFieldValidationRule extends IYupValidationRule {
 	/** for customising error message when submitted value does not match schema value */
-	matchesSchema?: boolean | undefined;
+	equalsSchemaValue?: boolean | undefined;
 }
 
 type TStringField = {

--- a/src/stories/3-fields/hidden-field/hidden-field.stories.tsx
+++ b/src/stories/3-fields/hidden-field/hidden-field.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgTypes, Stories, Title } from "@storybook/addon-docs";
 import { Meta } from "@storybook/react";
-import { IHiddenFieldSchema } from "../../../components/fields";
+import { THiddenFieldSchema } from "../../../components/fields";
 import { CommonFieldStoryProps, DefaultStoryTemplate } from "../../common";
 
 const meta: Meta = {
@@ -41,12 +41,12 @@ const meta: Meta = {
 };
 export default meta;
 
-export const Default = DefaultStoryTemplate<IHiddenFieldSchema>("hidden-default").bind({});
+export const Default = DefaultStoryTemplate<THiddenFieldSchema>("hidden-default").bind({});
 Default.args = {
 	uiType: "hidden-field",
 };
 
-export const DefaultValue = DefaultStoryTemplate<IHiddenFieldSchema>("hidden-default-value").bind({});
+export const DefaultValue = DefaultStoryTemplate<THiddenFieldSchema>("hidden-default-value").bind({});
 DefaultValue.args = {
 	uiType: "hidden-field",
 	defaultValues: "This is the default value",
@@ -62,7 +62,7 @@ DefaultValue.argTypes = {
 	},
 };
 
-export const NumericValue = DefaultStoryTemplate<IHiddenFieldSchema, number>("hidden-numeric-value").bind({});
+export const NumericValue = DefaultStoryTemplate<THiddenFieldSchema, number>("hidden-numeric-value").bind({});
 NumericValue.args = {
 	uiType: "hidden-field",
 	valueType: "number",
@@ -74,7 +74,7 @@ NumericValue.argTypes = {
 	},
 };
 
-export const BooleanValue = DefaultStoryTemplate<IHiddenFieldSchema, boolean>("hidden-boolean-value").bind({});
+export const BooleanValue = DefaultStoryTemplate<THiddenFieldSchema, boolean>("hidden-boolean-value").bind({});
 BooleanValue.args = {
 	uiType: "hidden-field",
 	valueType: "boolean",
@@ -86,7 +86,20 @@ BooleanValue.argTypes = {
 	},
 };
 
-export const Validation = DefaultStoryTemplate<IHiddenFieldSchema>("hidden-validation").bind({});
+export const SchemaValue = DefaultStoryTemplate<THiddenFieldSchema, string>("schema-value").bind({});
+SchemaValue.args = {
+	uiType: "hidden-field",
+	valueType: "string",
+	value: "unchanged",
+	defaultValues: "edited",
+};
+SchemaValue.argTypes = {
+	defaultValues: {
+		table: { disable: true },
+	},
+};
+
+export const Validation = DefaultStoryTemplate<THiddenFieldSchema>("hidden-validation").bind({});
 Validation.args = {
 	uiType: "hidden-field",
 	validation: [{ required: true }],


### PR DESCRIPTION
**Changes**

- add `value` prop to `hidden-field`
- this will take precedence over form values and effectively force it to be uneditable
- for type safety, the typing has been updated so that `value` matches `valueType`. however this required converting the interface to a type
-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Set `hidden-field` value from schema to make the field uneditable