### PR TITLE
Ccube 1449: Add clearErrors() method to Frontend Engine

### DIFF
--- a/src/__tests__/common/helper.tsx
+++ b/src/__tests__/common/helper.tsx
@@ -58,11 +58,11 @@ export const getField = (
 	return screen.getByRole(role, options);
 };
 
-export const getErrorMessage = (isQuery = false): HTMLElement => {
+export const getErrorMessage = (isQuery = false, errorMessage = ERROR_MESSAGE): HTMLElement => {
 	if (isQuery) {
-		return screen.queryByText(ERROR_MESSAGE);
+		return screen.queryByText(errorMessage);
 	}
-	return screen.getByText(ERROR_MESSAGE);
+	return screen.getByText(errorMessage);
 };
 
 export const flushPromise = (delay = 0) => new Promise((resolve) => setTimeout(resolve, delay));

--- a/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
+++ b/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
@@ -1065,12 +1065,47 @@ describe("frontend-engine", () => {
 	describe("clearErrors", () => {
 		it("should support clear all the errors", async () => {
 			const handleClickDefault = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-				ref.current.setErrors({ [FIELD_ONE_ID]: ERROR_MESSAGE });
+				ref.current.clearErrors();
 			};
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClickDefault} />);
+			render(<FrontendEngineWithCustomButton data={MULTI_FIELD_SCHEMA} onClick={handleClickDefault} />);
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+			expect(getErrorMessage()).toBeInTheDocument();
+			expect(getErrorMessage(false, ERROR_MESSAGE_2)).toBeInTheDocument();
+
 			await waitFor(() => fireEvent.click(getCustomButton()));
 
-			expect(getFieldOne().parentElement.nextSibling.textContent).toMatch(ERROR_MESSAGE);
+			expect(getErrorMessage(true)).not.toBeInTheDocument();
+			expect(getErrorMessage(true, ERROR_MESSAGE_2)).not.toBeInTheDocument();
+		});
+
+		it("should support clear individual error", async () => {
+			const handleClickDefault = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
+				ref.current.clearErrors(FIELD_ONE_ID);
+			};
+			render(<FrontendEngineWithCustomButton data={MULTI_FIELD_SCHEMA} onClick={handleClickDefault} />);
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+			expect(getErrorMessage()).toBeInTheDocument();
+			expect(getErrorMessage(false, ERROR_MESSAGE_2)).toBeInTheDocument();
+
+			await waitFor(() => fireEvent.click(getCustomButton()));
+
+			expect(getErrorMessage(true)).not.toBeInTheDocument();
+			expect(getErrorMessage(true, ERROR_MESSAGE_2)).toBeInTheDocument();
+		});
+
+		it("should support clear multiple errors", async () => {
+			const handleClickDefault = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
+				ref.current.clearErrors([FIELD_ONE_ID, FIELD_TWO_ID]);
+			};
+			render(<FrontendEngineWithCustomButton data={MULTI_FIELD_SCHEMA} onClick={handleClickDefault} />);
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+			expect(getErrorMessage()).toBeInTheDocument();
+			expect(getErrorMessage(false, ERROR_MESSAGE_2)).toBeInTheDocument();
+
+			await waitFor(() => fireEvent.click(getCustomButton()));
+
+			expect(getErrorMessage(true)).not.toBeInTheDocument();
+			expect(getErrorMessage(true, ERROR_MESSAGE_2)).not.toBeInTheDocument();
 		});
 	});
 

--- a/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
+++ b/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
@@ -1062,6 +1062,18 @@ describe("frontend-engine", () => {
 		});
 	});
 
+	describe("clearErrors", () => {
+		it("should support clear all the errors", async () => {
+			const handleClickDefault = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
+				ref.current.setErrors({ [FIELD_ONE_ID]: ERROR_MESSAGE });
+			};
+			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClickDefault} />);
+			await waitFor(() => fireEvent.click(getCustomButton()));
+
+			expect(getFieldOne().parentElement.nextSibling.textContent).toMatch(ERROR_MESSAGE);
+		});
+	});
+
 	describe("setWarnings", () => {
 		it("should support setting of warnings", async () => {
 			const handleSetWarnings = (ref: React.MutableRefObject<IFrontendEngineRef>) => {

--- a/src/components/frontend-engine/frontend-engine.tsx
+++ b/src/components/frontend-engine/frontend-engine.tsx
@@ -66,7 +66,16 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 		},
 	});
 	const { setFormSchema } = useFormSchema();
-	const { reset, handleSubmit: reactFormHookSubmit, getValues, setValue, setError, trigger, formState } = formMethods;
+	const {
+		reset,
+		handleSubmit: reactFormHookSubmit,
+		getValues,
+		setValue,
+		setError,
+		trigger,
+		formState,
+		clearErrors,
+	} = formMethods;
 	const { resetFields, setFields, getFormValues, registeredFields } = useFormValues(formMethods);
 	const registeredFieldsRef = useRef(registeredFields); // using ref ensures the latest values can be retrieved in setErrors and setWarnings
 	const { checkIsFormValid } = useFormChange(props, formMethods);
@@ -93,6 +102,7 @@ const FrontendEngineInner = forwardRef<IFrontendEngineRef, IFrontendEngineProps>
 			}
 		},
 		setErrors,
+		clearErrors,
 		setWarnings,
 		setValue,
 		submit: reactFormHookSubmit(handleSubmit, handleSubmitError),

--- a/src/components/frontend-engine/types.ts
+++ b/src/components/frontend-engine/types.ts
@@ -142,6 +142,8 @@ export interface IFrontendEngineRef
 	reset: UseFormReset<TFrontendEngineValues>;
 	/** allows setting of custom errors */
 	setErrors: (errors: TErrorPayload) => void;
+	/** clear form errors */
+	clearErrors: (error?: string | string[] | undefined) => void;
 	/** allows setting of custom warnings */
 	setWarnings: (warnings: TWarningPayload) => void;
 	/** sets field value by id */

--- a/src/stories/1-intro/form-builder/components/form-builder-tool.tsx
+++ b/src/stories/1-intro/form-builder/components/form-builder-tool.tsx
@@ -8,6 +8,7 @@ import { Unstyled } from "@storybook/blocks";
 import { useRef, useState } from "react";
 import { ContentWrapper, FrontendEnginePreview, ModeButton, Toolbar, Wrapper } from "./form-builder-tool.styles";
 import { SchemaView } from "./schema-view";
+import { IFrontendEngineData } from "../../../../components";
 
 export type TFormBuilderMode = "form-builder" | "preview" | "schema";
 
@@ -80,7 +81,7 @@ export const FormBuilderTool = () => {
 		return (
 			<ContentWrapper $flexbox={true}>
 				<Text.H2>Generate Form</Text.H2>
-				{formBuilderOutput && <FrontendEnginePreview data={formBuilderOutput.schema} />}
+				{formBuilderOutput && <FrontendEnginePreview data={formBuilderOutput.schema as IFrontendEngineData} />}
 			</ContentWrapper>
 		);
 	};
@@ -90,7 +91,7 @@ export const FormBuilderTool = () => {
 		return (
 			<ContentWrapper $flexbox={true}>
 				<SchemaView
-					schema={formBuilderOutput.schema}
+					schema={formBuilderOutput.schema as IFrontendEngineData}
 					onChange={setFormBuilderOutput}
 					formBuilderRef={formBuilderRef}
 				/>

--- a/src/stories/2-frontend-engine/frontend-engine.stories.tsx
+++ b/src/stories/2-frontend-engine/frontend-engine.stories.tsx
@@ -710,6 +710,71 @@ SetCustomErrors.parameters = {
 	controls: { hideNoControlsWarning: true },
 };
 
+export const ClearErros: StoryFn<IFrontendEngineProps> = () => {
+	const ref = useRef<IFrontendEngineRef>();
+	const handleTriggerError = () => {
+		try {
+			throw {
+				field1: "API error",
+				field2: "API error",
+				field3: "API error",
+			};
+		} catch (error) {
+			ref.current.setErrors(error);
+		}
+	};
+
+	return (
+		<>
+			<FrontendEngine
+				data={{
+					sections: {
+						section: {
+							uiType: "section",
+							children: {
+								field1: {
+									label: "Field 1",
+									uiType: "text-field",
+								},
+								field2: {
+									label: "Field 2",
+									uiType: "text-field",
+								},
+								field3: {
+									label: "Field 3",
+									uiType: "text-field",
+								},
+								...SUBMIT_BUTTON_SCHEMA,
+							},
+						},
+					},
+					validationMode: "onSubmit",
+				}}
+				ref={ref}
+			/>
+			<br />
+			<Button.Default styleType="secondary" onClick={handleTriggerError}>
+				Trigger API error upon click
+			</Button.Default>
+			<br />
+			<Button.Default styleType="secondary" onClick={() => ref.current.clearErrors("field1")}>
+				Clear field 1 error
+			</Button.Default>
+			<br />
+			<Button.Default styleType="secondary" onClick={() => ref.current.clearErrors(["field1", "field2"])}>
+				Clear field 1 and field 2 errors
+			</Button.Default>
+			<br />
+			<Button.Default styleType="secondary" onClick={() => ref.current.clearErrors()}>
+				Clear all errors
+			</Button.Default>
+		</>
+	);
+};
+SetCustomErrors.parameters = {
+	controls: { hideNoControlsWarning: true },
+};
+
 export const SetWarnings: StoryFn<IFrontendEngineProps> = () => {
 	const ref = useRef<IFrontendEngineRef>();
 	const handleClick = () => {


### PR DESCRIPTION
**Changes**
Description of changes...

-   Expose clearErrors() from react-hook-form
-   Accept same set of arguments from react-hook-form’s clearErrors()

**Additional information**

-   You may refer to this [CCUBE-1449](https://sgtechstack.atlassian.net/browse/CCUBE-1449)
