### PR TITLE
[CCUBE-1703] Remove deprecated codes

### DIFF
--- a/src/__tests__/components/custom/filter/filter-checkbox.spec.tsx
+++ b/src/__tests__/components/custom/filter/filter-checkbox.spec.tsx
@@ -81,7 +81,7 @@ describe(REFERENCE_KEY, () => {
 			const checkBox = getCheckboxByVal(val);
 			expect(checkBox.checked).toBeTruthy();
 		});
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
 	});
 
 	it("should be able to render hint", () => {
@@ -103,15 +103,15 @@ describe(REFERENCE_KEY, () => {
 		await waitFor(() => fireEvent.click(checkboxes[0]));
 		await waitFor(() => fireEvent.click(checkboxes[1]));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Apple", "Berry"] }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Apple", "Berry"] }));
 
 		await waitFor(() => fireEvent.click(checkboxes[0]));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Berry"] }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Berry"] }));
 
 		await waitFor(() => fireEvent.click(checkboxes[1]));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
 	});
 
 	it("should support default values matching initial overrides", async () => {
@@ -191,13 +191,15 @@ describe(REFERENCE_KEY, () => {
 
 				selected.forEach((value) => fireEvent.click(getCheckboxByVal(value)));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
 				);
 
 				fireEvent.click(screen.getByRole("button", { name: "Update options" }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate })
+				);
 			}
 		);
 	});
@@ -218,11 +220,11 @@ describe(REFERENCE_KEY, () => {
 			const checkboxes = getCheckboxes();
 			await waitFor(() => fireEvent.click(checkboxes[1]));
 			await waitFor(() => fireEvent.click(getSubmitButton()));
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: changedValue }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: changedValue }));
 
 			fireEvent.click(screen.getByRole("button", { name: "Clear" }));
 			await waitFor(() => fireEvent.click(getSubmitButton()));
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValue }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValue }));
 		});
 	});
 

--- a/src/__tests__/components/custom/filter/filter-item.spec.tsx
+++ b/src/__tests__/components/custom/filter/filter-item.spec.tsx
@@ -75,7 +75,7 @@ describe(REFERENCE_KEY, () => {
 		expect(screen.getAllByDisplayValue(defaultValue)[0]).toBeInTheDocument();
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 	});
 
 	it("should pass other props into the field", async () => {

--- a/src/__tests__/components/elements/wrapper/conditional-renderer.spec.tsx
+++ b/src/__tests__/components/elements/wrapper/conditional-renderer.spec.tsx
@@ -416,7 +416,7 @@ describe("conditional-renderer", () => {
 		fireEvent.change(getFieldOne(), { target: { value: "hi" } });
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [FIELD_ONE_ID]: "hi" }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [FIELD_ONE_ID]: "hi" }));
 
 		const values = SUBMIT_FN.mock.lastCall[0];
 		expect(values).not.toHaveProperty(FIELD_TWO_ID);
@@ -454,7 +454,7 @@ describe("conditional-renderer", () => {
 		renderComponent(fields, defaultValues);
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [FIELD_ONE_ID]: "hi" }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [FIELD_ONE_ID]: "hi" }));
 
 		const values = SUBMIT_FN.mock.lastCall[0];
 		expect(values).not.toHaveProperty(FIELD_TWO_ID);
@@ -866,20 +866,20 @@ describe("conditional-renderer", () => {
 			fireEvent.change(getFieldTwo(), { target: { value: userInput } });
 
 			await waitFor(() => fireEvent.click(getSubmitButton()));
-			expect(SUBMIT_FN).toBeCalledWith(
+			expect(SUBMIT_FN).toHaveBeenCalledWith(
 				expect.objectContaining({ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: userInput })
 			);
 
 			fireEvent.change(getFieldOne(), { target: { value: "hi" } });
 
 			await waitFor(() => fireEvent.click(getSubmitButton()));
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [FIELD_ONE_ID]: "hi" }));
-			expect(SUBMIT_FN).toBeCalledWith(expect.not.objectContaining({ [FIELD_TWO_ID]: expect.anything() }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [FIELD_ONE_ID]: "hi" }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.not.objectContaining({ [FIELD_TWO_ID]: expect.anything() }));
 
 			fireEvent.click(screen.queryByText("Reset"));
 
 			await waitFor(() => fireEvent.click(getSubmitButton()));
-			expect(SUBMIT_FN).toBeCalledWith(
+			expect(SUBMIT_FN).toHaveBeenCalledWith(
 				expect.objectContaining({ [FIELD_ONE_ID]: "hello", [FIELD_TWO_ID]: defaultValue })
 			);
 		});

--- a/src/__tests__/components/fields/checkbox-group/checkbox-group.spec.tsx
+++ b/src/__tests__/components/fields/checkbox-group/checkbox-group.spec.tsx
@@ -104,7 +104,7 @@ describe(UI_TYPE, () => {
 				expect(checkbox.parentElement.getAttribute("aria-checked")).toBe("false");
 			}
 		});
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
 	});
 
 	it("should be able to support validation schema", async () => {
@@ -129,7 +129,7 @@ describe(UI_TYPE, () => {
 		expect(checkboxes[0]).toBeEnabled();
 		expect(checkboxes[1]).toBeDisabled();
 
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 	});
 
 	it("should be disabled if configured", async () => {
@@ -142,7 +142,7 @@ describe(UI_TYPE, () => {
 			expect(checkbox).toBeDisabled();
 		});
 
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 	});
 
 	it("should be disabled if configured for both component/options", async () => {
@@ -161,7 +161,7 @@ describe(UI_TYPE, () => {
 			expect(checkbox).toBeDisabled();
 		});
 
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 	});
 
 	it("should be able to toggle the checkboxes", async () => {
@@ -171,15 +171,15 @@ describe(UI_TYPE, () => {
 		await waitFor(() => fireEvent.click(checkboxes[0]));
 		await waitFor(() => fireEvent.click(checkboxes[1]));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Apple", "Berry"] }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Apple", "Berry"] }));
 
 		await waitFor(() => fireEvent.click(checkboxes[0]));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Berry"] }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Berry"] }));
 
 		await waitFor(() => fireEvent.click(checkboxes[1]));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
 	});
 
 	it("should be able to render HTML string in option label", () => {
@@ -275,12 +275,14 @@ describe(UI_TYPE, () => {
 
 				selected.forEach((value) => fireEvent.click(screen.getByLabelText(value)));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
 				);
 				fireEvent.click(screen.getByRole("button", { name: "Update options" }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate })
+				);
 			}
 		);
 	});
@@ -314,13 +316,15 @@ describe(UI_TYPE, () => {
 
 				selected.forEach((value) => fireEvent.click(screen.getByLabelText(value)));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
 				);
 
 				fireEvent.click(screen.getByRole("button", { name: "Update options" }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate })
+				);
 			}
 		);
 	});
@@ -337,7 +341,7 @@ describe(UI_TYPE, () => {
 
 			expect(checkboxes[0].parentElement.getAttribute("aria-checked")).toBe("false");
 			expect(checkboxes[1].parentElement.getAttribute("aria-checked")).toBe("false");
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it("should revert to default value on reset", async () => {
@@ -351,7 +355,7 @@ describe(UI_TYPE, () => {
 
 			expect(checkboxes[0].parentElement.getAttribute("aria-checked")).toBe("true");
 			expect(checkboxes[1].parentElement.getAttribute("aria-checked")).toBe("false");
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
 		});
 	});
 

--- a/src/__tests__/components/fields/checkbox-group/checkbox-toggle-group.spec.tsx
+++ b/src/__tests__/components/fields/checkbox-group/checkbox-toggle-group.spec.tsx
@@ -103,7 +103,7 @@ describe("checkbox toggle group", () => {
 		const toggles = getToggles();
 		const checkbox = toggles.find((chkbx) => chkbx.nextElementSibling.querySelector("label").textContent === "A");
 		expect(checkbox).toBeChecked();
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
 	});
 
 	it("should be able to support validation schema", async () => {
@@ -128,7 +128,7 @@ describe("checkbox toggle group", () => {
 		expect(toggles[0]).toBeEnabled();
 		expect(toggles[1]).toBeDisabled();
 
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 	});
 
 	it("should be disabled if configured", async () => {
@@ -141,7 +141,7 @@ describe("checkbox toggle group", () => {
 			expect(checkbox).toBeDisabled();
 		});
 
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 	});
 
 	it("should be disabled if configured for both component/options", async () => {
@@ -160,7 +160,7 @@ describe("checkbox toggle group", () => {
 			expect(checkbox).toBeDisabled();
 		});
 
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 	});
 
 	it("should be able to toggle the checkboxes", async () => {
@@ -170,15 +170,15 @@ describe("checkbox toggle group", () => {
 		await waitFor(() => fireEvent.click(toggles[0]));
 		await waitFor(() => fireEvent.click(toggles[1]));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Apple", "Berry"] }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Apple", "Berry"] }));
 
 		await waitFor(() => fireEvent.click(toggles[0]));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Berry"] }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Berry"] }));
 
 		await waitFor(() => fireEvent.click(toggles[1]));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
 	});
 
 	it("should be able to render HTML string in option label", () => {
@@ -256,13 +256,15 @@ describe("checkbox toggle group", () => {
 
 				selected.forEach((value) => fireEvent.click(screen.getByLabelText(value)));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
 				);
 
 				fireEvent.click(screen.getByRole("button", { name: "Update options" }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate })
+				);
 			}
 		);
 	});
@@ -296,13 +298,15 @@ describe("checkbox toggle group", () => {
 
 				selected.forEach((value) => fireEvent.click(screen.getByLabelText(value)));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
 				);
 
 				fireEvent.click(screen.getByRole("button", { name: "Update options" }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate })
+				);
 			}
 		);
 	});
@@ -423,7 +427,7 @@ describe("checkbox toggle group", () => {
 
 			expect(checkboxes[0]).not.toBeChecked();
 			expect(checkboxes[1]).not.toBeChecked();
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it("should revert to default value on reset", async () => {
@@ -437,7 +441,7 @@ describe("checkbox toggle group", () => {
 
 			expect(checkboxes[0]).toBeChecked();
 			expect(checkboxes[1]).not.toBeChecked();
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
 		});
 	});
 

--- a/src/__tests__/components/fields/chips/chips.spec.tsx
+++ b/src/__tests__/components/fields/chips/chips.spec.tsx
@@ -108,7 +108,7 @@ describe(UI_TYPE, () => {
 		await waitFor(() => fireEvent.click(getSubmitButton()));
 
 		expect(getChipA(true)).toBeInTheDocument();
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
 	});
 
 	it("should be able to support default values in textarea", async () => {
@@ -128,7 +128,7 @@ describe(UI_TYPE, () => {
 
 		expect(getTextareaChip(true)).toBeInTheDocument();
 		expect(getTextarea()).toHaveValue(defaultTextAreaValue);
-		expect(SUBMIT_FN).toBeCalledWith(
+		expect(SUBMIT_FN).toHaveBeenCalledWith(
 			expect.objectContaining({
 				[COMPONENT_ID]: defaultValues,
 				[`${COMPONENT_ID}-textarea`]: defaultTextAreaValue,
@@ -184,15 +184,15 @@ describe(UI_TYPE, () => {
 		await waitFor(() => fireEvent.click(apple));
 		await waitFor(() => fireEvent.click(berry));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Apple", "Berry"] }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Apple", "Berry"] }));
 
 		await waitFor(() => fireEvent.click(apple));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Berry"] }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Berry"] }));
 
 		await waitFor(() => fireEvent.click(berry));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
 	});
 
 	it("should be able to support single selection", async () => {
@@ -202,11 +202,11 @@ describe(UI_TYPE, () => {
 
 		await waitFor(() => fireEvent.click(apple));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Apple"] }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Apple"] }));
 
 		await waitFor(() => fireEvent.click(berry));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Berry"] }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Berry"] }));
 	});
 
 	it("should be able to render textarea upon selection", async () => {
@@ -300,13 +300,15 @@ describe(UI_TYPE, () => {
 
 				selected.forEach((name) => fireEvent.click(screen.getByRole("button", { name })));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
 				);
 
 				fireEvent.click(screen.getByRole("button", { name: "Update options" }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate })
+				);
 			}
 		);
 	});
@@ -340,13 +342,15 @@ describe(UI_TYPE, () => {
 
 				selected.forEach((name) => fireEvent.click(screen.getByRole("button", { name })));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
 				);
 
 				fireEvent.click(screen.getByRole("button", { name: "Update options" }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate })
+				);
 			}
 		);
 	});
@@ -362,7 +366,7 @@ describe(UI_TYPE, () => {
 
 			expect(getField("button", { name: "A", pressed: true }, true)).not.toBeInTheDocument();
 			expect(getField("button", { name: "B", pressed: true }, true)).not.toBeInTheDocument();
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it("should revert to default value on reset", async () => {
@@ -375,7 +379,7 @@ describe(UI_TYPE, () => {
 
 			expect(getChipA(true)).toBeInTheDocument();
 			expect(getField("button", { name: "B", pressed: true }, true)).not.toBeInTheDocument();
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
 		});
 
 		it("should revert to default textarea value on reset", async () => {
@@ -399,7 +403,7 @@ describe(UI_TYPE, () => {
 
 			expect(getTextareaChip(true)).toBeInTheDocument();
 			expect(getTextarea()).toHaveValue(defaultTextAreaValue);
-			expect(SUBMIT_FN).toBeCalledWith(
+			expect(SUBMIT_FN).toHaveBeenCalledWith(
 				expect.objectContaining({
 					[COMPONENT_ID]: defaultValues,
 					[`${COMPONENT_ID}-textarea`]: defaultTextAreaValue,

--- a/src/__tests__/components/fields/date-field/date-field.spec.tsx
+++ b/src/__tests__/components/fields/date-field/date-field.spec.tsx
@@ -102,7 +102,7 @@ describe(UI_TYPE, () => {
 		expect(getDayInput()).toHaveAttribute("value", defaultDay);
 		expect(getMonthInput()).toHaveAttribute("value", defaultMonth);
 		expect(getYearInput()).toHaveAttribute("value", defaultYear);
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 	});
 
 	it("should show current date if useCurrentDate=true", async () => {
@@ -112,7 +112,7 @@ describe(UI_TYPE, () => {
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
 
-		expect(SUBMIT_FN).toBeCalledWith(
+		expect(SUBMIT_FN).toHaveBeenCalledWith(
 			expect.objectContaining({
 				field: date,
 			})
@@ -142,7 +142,7 @@ describe(UI_TYPE, () => {
 				await changeDate("25", "01", "2022");
 				await waitFor(() => fireEvent.click(getSubmitButton()));
 
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: value }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: value }));
 			});
 
 			it("should format current date accordingly if useCurrentDate=true", async () => {
@@ -152,7 +152,7 @@ describe(UI_TYPE, () => {
 
 				await waitFor(() => fireEvent.click(getSubmitButton()));
 
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: value }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: value }));
 			});
 
 			it("should accept defaultValue in the format as defined by dateFormat", async () => {
@@ -160,7 +160,7 @@ describe(UI_TYPE, () => {
 
 				await waitFor(() => fireEvent.click(getSubmitButton()));
 
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: value }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: value }));
 			});
 
 			it("should reject defaultValue if it did not follow dateFormat", async () => {
@@ -211,7 +211,7 @@ describe(UI_TYPE, () => {
 			await changeDate(invalid[0], invalid[1], invalid[2]);
 			fireEvent.click(getField("button", "Done"));
 			await waitFor(() => fireEvent.click(getSubmitButton()));
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it(`should show error message on submit if there is validation error for ${condition} dates and invalid default dates`, async () => {
@@ -232,7 +232,7 @@ describe(UI_TYPE, () => {
 			fireEvent.click(getField("button", "Done"));
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 
 			await changeDate(valid[0], valid[1], valid[2]);
 
@@ -248,13 +248,13 @@ describe(UI_TYPE, () => {
 		fireEvent.click(getField("button", "Done"));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
 
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 
 		await changeDate("15", "01", "2022");
 		fireEvent.click(getField("button", "Done"));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
 
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: "2022-01-15" }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: "2022-01-15" }));
 	});
 
 	it("should derive the earliest of the allowed dates if there are maxDate, past and notFuture rules", async () => {
@@ -265,13 +265,13 @@ describe(UI_TYPE, () => {
 		fireEvent.click(getField("button", "Done"));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
 
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 
 		await changeDate("15", "12", "2021");
 		fireEvent.click(getField("button", "Done"));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
 
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: "2021-12-15" }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: "2021-12-15" }));
 	});
 
 	describe("reset", () => {
@@ -285,7 +285,7 @@ describe(UI_TYPE, () => {
 			expect(getDayInput()).toHaveAttribute("value", "");
 			expect(getMonthInput()).toHaveAttribute("value", "");
 			expect(getYearInput()).toHaveAttribute("value", "");
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it("should revert to default value on reset", async () => {
@@ -302,7 +302,7 @@ describe(UI_TYPE, () => {
 			expect(getDayInput()).toHaveAttribute("value", defaultDay);
 			expect(getMonthInput()).toHaveAttribute("value", defaultMonth);
 			expect(getYearInput()).toHaveAttribute("value", defaultYear);
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 		});
 
 		it("should revert to current date on reset", async () => {
@@ -320,7 +320,7 @@ describe(UI_TYPE, () => {
 			expect(getDayInput()).toHaveAttribute("value", currentDay);
 			expect(getMonthInput()).toHaveAttribute("value", currentMonth);
 			expect(getYearInput()).toHaveAttribute("value", currentYear);
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: currentDate }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: currentDate }));
 		});
 	});
 

--- a/src/__tests__/components/fields/date-range-field/date-range-field.spec.tsx
+++ b/src/__tests__/components/fields/date-range-field/date-range-field.spec.tsx
@@ -87,7 +87,7 @@ describe(uiType, () => {
 		expect(getDayInput(TDateRangeInputType.START)).toHaveAttribute("value", defaultDay);
 		expect(getMonthInput(TDateRangeInputType.START)).toHaveAttribute("value", defaultMonth);
 		expect(getYearInput(TDateRangeInputType.START)).toHaveAttribute("value", defaultYear);
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: { from, to } }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: { from, to } }));
 	});
 
 	describe("dateFormat", () => {
@@ -121,7 +121,7 @@ describe(uiType, () => {
 				fireEvent.click(screen.getByText("Done"));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
 
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: value }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: value }));
 			});
 
 			it("should accept defaultValue in the format as defined by dateFormat", async () => {
@@ -129,7 +129,7 @@ describe(uiType, () => {
 
 				await waitFor(() => fireEvent.click(getSubmitButton()));
 
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: value }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: value }));
 			});
 
 			it("should reject defaultValue if it did not follow dateFormat", async () => {
@@ -190,7 +190,7 @@ describe(uiType, () => {
 			fireEvent.click(getField("button", "Done"));
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
-			expect(SUBMIT_FN).toBeCalledWith(
+			expect(SUBMIT_FN).toHaveBeenCalledWith(
 				expect.objectContaining({ [COMPONENT_ID]: { from: undefined, to: undefined } })
 			);
 		});
@@ -244,7 +244,7 @@ describe(uiType, () => {
 			fireEvent.click(getField("button", "Done"));
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
-			expect(SUBMIT_FN).toBeCalledWith(
+			expect(SUBMIT_FN).toHaveBeenCalledWith(
 				expect.objectContaining({ [COMPONENT_ID]: { from: undefined, to: undefined } })
 			);
 
@@ -347,7 +347,7 @@ describe(uiType, () => {
 			expect(getDayInput(TDateRangeInputType.END)).toHaveAttribute("value", "");
 			expect(getMonthInput(TDateRangeInputType.END)).toHaveAttribute("value", "");
 			expect(getYearInput(TDateRangeInputType.END)).toHaveAttribute("value", "");
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it("should revert to default value on reset", async () => {
@@ -375,7 +375,7 @@ describe(uiType, () => {
 			expect(getDayInput(TDateRangeInputType.END)).toHaveAttribute("value", defaultDay);
 			expect(getMonthInput(TDateRangeInputType.END)).toHaveAttribute("value", defaultMonth);
 			expect(getYearInput(TDateRangeInputType.END)).toHaveAttribute("value", defaultYear);
-			expect(SUBMIT_FN).toBeCalledWith(
+			expect(SUBMIT_FN).toHaveBeenCalledWith(
 				expect.objectContaining({ [COMPONENT_ID]: { from: defaultValue, to: defaultValue } })
 			);
 		});

--- a/src/__tests__/components/fields/multi-select/multi-select.spec.tsx
+++ b/src/__tests__/components/fields/multi-select/multi-select.spec.tsx
@@ -111,7 +111,7 @@ describe(UI_TYPE, () => {
 		expect(getCheckboxA()).toHaveAttribute("aria-selected", "true");
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
 	});
 
 	it("should be able to support validation schema", async () => {
@@ -145,15 +145,15 @@ describe(UI_TYPE, () => {
 		await waitFor(() => fireEvent.click(apple));
 		await waitFor(() => fireEvent.click(berry));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Apple", "Berry"] }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Apple", "Berry"] }));
 
 		await waitFor(() => fireEvent.click(apple));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Berry"] }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: ["Berry"] }));
 
 		await waitFor(() => fireEvent.click(berry));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
 	});
 
 	it("should be able to toggle all the checkboxes at once", async () => {
@@ -164,13 +164,13 @@ describe(UI_TYPE, () => {
 
 		fireEvent.click(selectAllButton);
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(
+		expect(SUBMIT_FN).toHaveBeenCalledWith(
 			expect.objectContaining({ [COMPONENT_ID]: ["Apple", "Berry", "Cherry", "Durian"] })
 		);
 
 		fireEvent.click(selectAllButton);
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
 	});
 
 	it("should support default values matching initial overrides", async () => {
@@ -224,13 +224,15 @@ describe(UI_TYPE, () => {
 
 				selected.forEach((name) => fireEvent.click(screen.getByRole("option", { name })));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
 				);
 
 				fireEvent.click(screen.getByRole("button", { name: "Update options" }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate })
+				);
 			}
 		);
 	});
@@ -266,13 +268,15 @@ describe(UI_TYPE, () => {
 
 				selected.forEach((name) => fireEvent.click(screen.getByRole("option", { name })));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
 				);
 
 				fireEvent.click(screen.getByRole("button", { name: "Update options" }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate })
+				);
 			}
 		);
 	});
@@ -293,7 +297,7 @@ describe(UI_TYPE, () => {
 			expect(screen.getByText("Select")).toBeInTheDocument();
 			expect(apple).toHaveAttribute("aria-selected", "false");
 			expect(berry).toHaveAttribute("aria-selected", "false");
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it("should revert to default value on reset", async () => {
@@ -311,7 +315,7 @@ describe(UI_TYPE, () => {
 			expect(screen.getByText("1 selected")).toBeInTheDocument();
 			expect(apple).toHaveAttribute("aria-selected", "true");
 			expect(berry).toHaveAttribute("aria-selected", "false");
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
 		});
 	});
 

--- a/src/__tests__/components/fields/radio-button/radio-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-button.spec.tsx
@@ -99,7 +99,7 @@ describe(UI_TYPE, () => {
 		expect(getRadioButtonA()).toBeChecked();
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 	});
 
 	it("should be able to support validation schema", async () => {
@@ -202,13 +202,15 @@ describe(UI_TYPE, () => {
 
 				fireEvent.click(screen.getByLabelText(selected));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
 				);
 
 				fireEvent.click(screen.getByRole("button", { name: "Update options" }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate })
+				);
 			}
 		);
 	});
@@ -255,13 +257,15 @@ describe(UI_TYPE, () => {
 
 				fireEvent.click(screen.getByLabelText(selected));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
 				);
 
 				fireEvent.click(screen.getByRole("button", { name: "Update options" }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate })
+				);
 			}
 		);
 	});
@@ -276,7 +280,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			expect(apple).not.toBeChecked();
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it("should revert to default value on reset", async () => {
@@ -292,7 +296,7 @@ describe(UI_TYPE, () => {
 
 			expect(apple).toBeChecked();
 			expect(berry).not.toBeChecked();
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 		});
 	});
 

--- a/src/__tests__/components/fields/radio-button/radio-image-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-image-button.spec.tsx
@@ -100,7 +100,7 @@ describe("radio toggle button", () => {
 		renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: defaultValue } });
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 	});
 
 	it("should be able to support validation schema", async () => {
@@ -175,13 +175,15 @@ describe("radio toggle button", () => {
 
 				fireEvent.click(screen.getByText(selected));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
 				);
 
 				fireEvent.click(screen.getByRole("button", { name: "Update options" }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate })
+				);
 			}
 		);
 	});
@@ -211,13 +213,15 @@ describe("radio toggle button", () => {
 				);
 				fireEvent.click(screen.getByText(selected));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
 				);
 
 				fireEvent.click(screen.getByRole("button", { name: "Update options" }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate })
+				);
 			}
 		);
 	});

--- a/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
@@ -107,7 +107,7 @@ describe("radio toggle button", () => {
 		expect(getRadioButtonA()).toBeChecked();
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 	});
 
 	it("should be able to support validation schema", async () => {
@@ -223,13 +223,15 @@ describe("radio toggle button", () => {
 
 				fireEvent.click(screen.getByLabelText(selected));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
 				);
 
 				fireEvent.click(screen.getByRole("button", { name: "Update options" }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate })
+				);
 			}
 		);
 	});
@@ -259,13 +261,15 @@ describe("radio toggle button", () => {
 				);
 				fireEvent.click(screen.getByLabelText(selected));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
 				);
 
 				fireEvent.click(screen.getByRole("button", { name: "Update options" }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate })
+				);
 			}
 		);
 	});
@@ -383,7 +387,7 @@ describe("radio toggle button", () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			expect(apple).not.toBeChecked();
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it("should revert to default value on reset", async () => {
@@ -399,7 +403,7 @@ describe("radio toggle button", () => {
 
 			expect(apple).toBeChecked();
 			expect(berry).not.toBeChecked();
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 		});
 	});
 

--- a/src/__tests__/components/fields/range-select/range-select.spec.tsx
+++ b/src/__tests__/components/fields/range-select/range-select.spec.tsx
@@ -121,7 +121,7 @@ describe(UI_TYPE, () => {
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
 		expect(screen.getByTestId(COMPONENT_ID)).toHaveTextContent("AC");
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
 	});
 
 	it("should be able to support validation schema", async () => {
@@ -159,7 +159,9 @@ describe(UI_TYPE, () => {
 		await waitFor(() => fireEvent.click(getOptionA()));
 		await waitFor(() => fireEvent.click(getOptionC()));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: { from: "Apple", to: "Cherry" } }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(
+			expect.objectContaining({ [COMPONENT_ID]: { from: "Apple", to: "Cherry" } })
+		);
 	});
 
 	it("should be able to clear all inputs when only 1st option is selected and then click away outside of component", async () => {
@@ -172,7 +174,7 @@ describe(UI_TYPE, () => {
 		expect(queryByText(getRangeSelector(), "A")).toBeNull();
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(
+		expect(SUBMIT_FN).toHaveBeenCalledWith(
 			expect.objectContaining({ [COMPONENT_ID]: { from: undefined, to: undefined } })
 		);
 	});
@@ -216,13 +218,15 @@ describe(UI_TYPE, () => {
 
 				selected.forEach((name) => fireEvent.click(screen.getAllByText(name)[0]));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
 				);
 
 				fireEvent.click(screen.getByRole("button", { name: "Update options" }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate })
+				);
 			}
 		);
 	});
@@ -284,13 +288,15 @@ describe(UI_TYPE, () => {
 
 				selected.forEach((name) => fireEvent.click(screen.getAllByText(name)[0]));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
 				);
 
 				fireEvent.click(screen.getByRole("button", { name: "Update options" }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate })
+				);
 			}
 		);
 	});
@@ -305,7 +311,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getResetButton()));
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it("should revert to default value on reset", async () => {
@@ -319,7 +325,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getResetButton()));
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValues }));
 		});
 	});
 
@@ -333,7 +339,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getClearButton()));
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
-			expect(SUBMIT_FN).toBeCalledWith(
+			expect(SUBMIT_FN).toHaveBeenCalledWith(
 				expect.objectContaining({ [COMPONENT_ID]: { from: undefined, to: undefined } })
 			);
 		});
@@ -348,7 +354,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getComponent()));
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
-			expect(SUBMIT_FN).toBeCalledWith(
+			expect(SUBMIT_FN).toHaveBeenCalledWith(
 				expect.objectContaining({ [COMPONENT_ID]: { from: undefined, to: undefined } })
 			);
 		});

--- a/src/__tests__/components/fields/reset/reset.spec.tsx
+++ b/src/__tests__/components/fields/reset/reset.spec.tsx
@@ -84,7 +84,7 @@ describe("reset", () => {
 
 		await waitFor(() => fireEvent.click(getResetButton()));
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [CHECKBOX_ID]: [], [TEXT_ID]: "" }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [CHECKBOX_ID]: [], [TEXT_ID]: "" }));
 	});
 
 	it("should be disabled if configured", async () => {

--- a/src/__tests__/components/fields/select/select.spec.tsx
+++ b/src/__tests__/components/fields/select/select.spec.tsx
@@ -100,7 +100,7 @@ describe(UI_TYPE, () => {
 		await waitFor(() => fireEvent.click(getSubmitButton()));
 
 		expect(screen.getByTestId("selector")).toHaveTextContent(defaultLabel);
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 	});
 
 	it("should be able to support validation schema", async () => {
@@ -171,13 +171,15 @@ describe(UI_TYPE, () => {
 				await waitFor(() => fireEvent.click(getSelectToggle()));
 				fireEvent.click(screen.getByRole("option", { name: selected }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
 				);
 
 				fireEvent.click(screen.getByRole("button", { name: "Update options" }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate })
+				);
 			}
 		);
 	});
@@ -210,13 +212,15 @@ describe(UI_TYPE, () => {
 				await waitFor(() => fireEvent.click(getSelectToggle()));
 				fireEvent.click(screen.getByRole("option", { name: selected }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
 					expect.objectContaining({ [COMPONENT_ID]: expectedValueBeforeUpdate })
 				);
 
 				fireEvent.click(screen.getByRole("button", { name: "Update options" }));
 				await waitFor(() => fireEvent.click(getSubmitButton()));
-				expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate }));
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({ [COMPONENT_ID]: expectedValueAfterUpdate })
+				);
 			}
 		);
 	});
@@ -231,7 +235,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			expect(screen.getByTestId("selector")).toHaveTextContent("Select");
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it("should revert to default value on reset", async () => {
@@ -244,7 +248,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			expect(screen.getByTestId("selector")).toHaveTextContent("A");
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 		});
 	});
 

--- a/src/__tests__/components/fields/switch/switch.spec.tsx
+++ b/src/__tests__/components/fields/switch/switch.spec.tsx
@@ -76,7 +76,7 @@ describe(UI_TYPE, () => {
 		expect(getSwitchButton("Yes")).toBeChecked();
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 	});
 
 	it("should be able to support validation schema", async () => {
@@ -105,7 +105,7 @@ describe(UI_TYPE, () => {
 		expect(getSwitchButton(switchButtonType)).toBeChecked();
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValue }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: expectedValue }));
 	});
 
 	describe("reset", () => {
@@ -118,7 +118,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			expect(yes).not.toBeChecked();
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it("should revert to default value on reset", async () => {
@@ -134,7 +134,7 @@ describe(UI_TYPE, () => {
 
 			expect(yes).toBeChecked();
 			expect(no).not.toBeChecked();
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 		});
 	});
 

--- a/src/__tests__/components/fields/text-field/email-field.spec.tsx
+++ b/src/__tests__/components/fields/text-field/email-field.spec.tsx
@@ -117,7 +117,7 @@ describe(UI_TYPE, () => {
 		expect(screen.getByDisplayValue(defaultValue)).toBeInTheDocument();
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 	});
 
 	it("should pass other props into the field", () => {
@@ -223,7 +223,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			expect(getEmailField()).toHaveValue("");
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it("should revert to default value on reset", async () => {
@@ -235,7 +235,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			expect(getEmailField()).toHaveValue(defaultValue);
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 		});
 	});
 

--- a/src/__tests__/components/fields/text-field/numeric-field.spec.tsx
+++ b/src/__tests__/components/fields/text-field/numeric-field.spec.tsx
@@ -77,7 +77,7 @@ describe(UI_TYPE, () => {
 		fireEvent.change(getNumericField(), { target: { value: 1 } });
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: 1 }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: 1 }));
 	});
 
 	it("should support validation schema", async () => {
@@ -113,7 +113,7 @@ describe(UI_TYPE, () => {
 		expect(screen.getByDisplayValue(defaultValue)).toBeInTheDocument();
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 	});
 
 	it("should pass other props into the field", () => {
@@ -219,7 +219,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			expect(getNumericField()).toHaveValue(null);
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it("should revert to default value on reset", async () => {
@@ -231,7 +231,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			expect(getNumericField()).toHaveValue(defaultValue);
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 		});
 	});
 

--- a/src/__tests__/components/fields/text-field/text-field.spec.tsx
+++ b/src/__tests__/components/fields/text-field/text-field.spec.tsx
@@ -103,7 +103,7 @@ describe(UI_TYPE, () => {
 		expect(screen.getByDisplayValue(defaultValue)).toBeInTheDocument();
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 	});
 
 	it("should pass other props into the field", () => {
@@ -223,7 +223,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			expect(getTextfield()).toHaveValue("");
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it("should revert to default value on reset", async () => {
@@ -235,7 +235,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			expect(getTextfield()).toHaveValue(defaultValue);
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 		});
 	});
 

--- a/src/__tests__/components/fields/textarea/textarea.spec.tsx
+++ b/src/__tests__/components/fields/textarea/textarea.spec.tsx
@@ -85,7 +85,7 @@ describe(UI_TYPE, () => {
 		expect(screen.getByText(defaultValue)).toBeInTheDocument();
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 	});
 
 	it("should apply maxLength attribute if max validation is specified", () => {
@@ -148,7 +148,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			expect(getTextarea()).toHaveValue("");
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it("should revert to default value on reset", async () => {
@@ -160,7 +160,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			expect(getTextarea()).toHaveValue(defaultValue);
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 		});
 	});
 

--- a/src/__tests__/components/fields/time-field/time-field.spec.tsx
+++ b/src/__tests__/components/fields/time-field/time-field.spec.tsx
@@ -96,7 +96,7 @@ describe(UI_TYPE, () => {
 
 		await waitFor(() => fireEvent.click(getSubmitButton()));
 
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 	});
 
 	it("should be able to support validation schema", async () => {
@@ -125,7 +125,7 @@ describe(UI_TYPE, () => {
 		await pickValidTime();
 		await waitFor(() => fireEvent.click(getSubmitButton()));
 
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: "01:00AM" }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: "01:00AM" }));
 	});
 
 	it("should be able to display current time if useCurrentTime=true", async () => {
@@ -141,7 +141,7 @@ describe(UI_TYPE, () => {
 		await pickValidTime();
 		await waitFor(() => fireEvent.click(getSubmitButton()));
 
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: "01:00" }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: "01:00" }));
 	});
 
 	describe("reset", () => {
@@ -152,7 +152,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			await waitFor(() => expect(getTimePicker()).toHaveValue(""));
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it("should revert to default value on reset", async () => {
@@ -163,7 +163,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			await waitFor(() => expect(getTimePicker()).toHaveValue(defaultValue));
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 		});
 
 		it("should revert to current time on reset", async () => {
@@ -175,7 +175,7 @@ describe(UI_TYPE, () => {
 			await waitFor(() => expect(getTimePicker()).toHaveValue(`${currentTime}pm`));
 
 			await waitFor(() => fireEvent.click(getSubmitButton()));
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: `${currentTime}PM` }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: `${currentTime}PM` }));
 		});
 	});
 

--- a/src/__tests__/components/fields/unit-number-field/unit-number.spec.tsx
+++ b/src/__tests__/components/fields/unit-number-field/unit-number.spec.tsx
@@ -89,7 +89,7 @@ describe(UI_TYPE, () => {
 
 		expect(getFloorInputField()).toHaveAttribute("value", defaultFloor);
 		expect(getUnitInputField()).toHaveAttribute("value", defaultUnit);
-		expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 	});
 
 	it("should be disabled if configured", async () => {
@@ -117,7 +117,7 @@ describe(UI_TYPE, () => {
 			setFieldValue(floorNumber, unitNumber);
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: unitNumberValue }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: unitNumberValue }));
 		});
 
 		it("03- should be an invalid unit number", async () => {
@@ -156,7 +156,7 @@ describe(UI_TYPE, () => {
 
 			expect(getFloorInputField()).toHaveValue("");
 			expect(getUnitInputField()).toHaveValue("");
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
 		it("should revert to default value on reset", async () => {
@@ -171,7 +171,7 @@ describe(UI_TYPE, () => {
 
 			expect(getFloorInputField()).toHaveValue(defaultFloor);
 			expect(getUnitInputField()).toHaveValue(defaultUnit);
-			expect(SUBMIT_FN).toBeCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 		});
 	});
 

--- a/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
+++ b/src/__tests__/components/frontend-engine/frontend-engine.spec.tsx
@@ -416,7 +416,7 @@ describe("frontend-engine", () => {
 
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
-			expect(onSubmitError).toBeCalledWith({
+			expect(onSubmitError).toHaveBeenCalledWith({
 				[FIELD_ONE_ID]: {
 					message: ERROR_MESSAGE,
 					ref: expect.anything(),
@@ -434,7 +434,7 @@ describe("frontend-engine", () => {
 				fireEvent.change(getFieldOne(), { target: { value: "hello" } });
 				await waitFor(() => fireEvent.click(getSubmitButton()));
 
-				expect(submitFn).toBeCalledWith({ [FIELD_ONE_ID]: "hello", submit: undefined });
+				expect(submitFn).toHaveBeenCalledWith({ [FIELD_ONE_ID]: "hello", submit: undefined });
 			});
 
 			it("should include form values of unregistered fields if stripUnknown is not true", async () => {
@@ -455,7 +455,7 @@ describe("frontend-engine", () => {
 				fireEvent.click(getCustomButton());
 				await waitFor(() => fireEvent.click(getSubmitButton()));
 
-				expect(submitFn).toBeCalledWith({
+				expect(submitFn).toHaveBeenCalledWith({
 					[FIELD_ONE_ID]: "hello",
 					nonExistentField: "hello world",
 					nonExistentField2: "john doe",
@@ -485,7 +485,7 @@ describe("frontend-engine", () => {
 				fireEvent.click(getCustomButton());
 				await waitFor(() => fireEvent.click(getSubmitButton()));
 
-				expect(submitFn).toBeCalledWith({
+				expect(submitFn).toHaveBeenCalledWith({
 					[FIELD_ONE_ID]: "hello",
 					submit: undefined,
 				});
@@ -708,7 +708,7 @@ describe("frontend-engine", () => {
 		fireEvent.click(getCustomButton());
 		await waitFor(() => fireEvent.click(getSubmitButton()));
 
-		expect(onSubmit).toBeCalledWith(expect.objectContaining({ [FIELD_ONE_ID]: "hello" }));
+		expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ [FIELD_ONE_ID]: "hello" }));
 	});
 
 	it("should return form validity through checkValid method", async () => {

--- a/src/components/custom/review/types.ts
+++ b/src/components/custom/review/types.ts
@@ -8,9 +8,6 @@ import type { ICustomElementJsonSchema } from "../types";
 type TReviewSectionChildren = TBlockElementSchema | TInlineElementSchema | TWrapperSchema;
 export type TReviewSchema = IReviewSchemaAccordion | IReviewSchemaBox;
 
-/** @deprecated use TReviewSchema */
-export type IReviewSchema = TReviewSchema;
-
 export interface IUnmaskConfig {
 	url: string;
 	body?: unknown | undefined;

--- a/src/components/elements/wrapper/types.ts
+++ b/src/components/elements/wrapper/types.ts
@@ -11,9 +11,6 @@ export type TInlineWrapperType = "span";
 
 export type TWrapperSchema<V = undefined, C = undefined> = IBlockWrapperSchema<V, C> | IInlineWrapperSchema;
 
-/** @deprecated use `TWrapperSchema` */
-export type IWrapperSchema<V = undefined, C = undefined> = IBlockWrapperSchema<V, C> | IInlineWrapperSchema;
-
 export interface IBlockWrapperSchema<V = undefined, C = undefined>
 	extends TComponentOmitProps<React.HTMLAttributes<HTMLElement>, "children"> {
 	uiType: TBlockWrapperType;

--- a/src/components/fields/checkbox-group/types.ts
+++ b/src/components/fields/checkbox-group/types.ts
@@ -40,8 +40,3 @@ interface ICheckboxGroupToggleSchema<V = undefined, C = undefined>
 export type TCheckboxGroupSchema<V = undefined, C = undefined> =
 	| ICheckboxGroupDefaultSchema<V>
 	| ICheckboxGroupToggleSchema<V, C>;
-
-/** @deprecated will be removed in a future release. Use `TCheckboxGroupSchema` instead */
-export type ICheckboxGroupSchema<V = undefined, C = undefined> =
-	| ICheckboxGroupDefaultSchema<V>
-	| ICheckboxGroupToggleSchema<V, C>;

--- a/src/components/fields/hidden-field/types.ts
+++ b/src/components/fields/hidden-field/types.ts
@@ -38,6 +38,3 @@ export type THiddenFieldSchema<V = undefined> = Pick<
 	"showIf" | "validation" | "uiType"
 > &
 	TFieldType;
-
-/** @deprecated use THiddenFieldSchema */
-export type IHiddenFieldSchema<V = undefined> = THiddenFieldSchema<V>;

--- a/src/components/fields/location-field/location-helper.ts
+++ b/src/components/fields/location-field/location-helper.ts
@@ -272,7 +272,6 @@ export namespace LocationHelper {
 				YCOORD: geocodeInfo.Y,
 				LATITUDE: geocodeInfo.LATITUDE,
 				LONGITUDE: geocodeInfo.LONGITUDE,
-				LONGTITUDE: geocodeInfo.LONGTITUDE,
 			};
 		}
 		const { BLOCK, BUILDINGNAME, POSTALCODE, ROAD } = convertedGeoCodeInfo as OneMapGeocodeInfo;

--- a/src/components/fields/radio-button/types.ts
+++ b/src/components/fields/radio-button/types.ts
@@ -57,9 +57,3 @@ export type TRadioButtonGroupSchema<V = undefined, C = undefined> =
 	| IRadioButtonDefaultSchema<V>
 	| IRadioButtonToggleSchema<V, C>
 	| IRadioButtonImageButtonSchema<V>;
-
-/** @deprecated will be removed in a future release. Use `TRadioButtonGroupSchema` instead */
-export type IRadioButtonGroupSchema<V = undefined, C = undefined> =
-	| IRadioButtonDefaultSchema<V>
-	| IRadioButtonToggleSchema<V, C>
-	| IRadioButtonImageButtonSchema<V>;

--- a/src/components/fields/types.ts
+++ b/src/components/fields/types.ts
@@ -11,7 +11,7 @@ import { TDateRangeFieldSchema } from "./date-range-field";
 import { IESignatureFieldSchema } from "./e-signature-field/types";
 import { IErrorFieldSchema } from "./error-field";
 import { IFileUploadSchema, TFileUploadEvents } from "./file-upload";
-import { IHiddenFieldSchema } from "./hidden-field/types";
+import { THiddenFieldSchema } from "./hidden-field";
 import { IHistogramSliderSchema } from "./histogram-slider";
 import { IImageUploadSchema, TImageUploadEvents, TImageUploadTriggers } from "./image-upload";
 import { ILocationFieldSchema, TLocationEvents, TLocationFieldTriggers } from "./location-field";
@@ -81,7 +81,7 @@ export type TFieldSchema<V = undefined, C = undefined> =
 	| IESignatureFieldSchema<V>
 	| IErrorFieldSchema
 	| IFileUploadSchema<V>
-	| IHiddenFieldSchema<V>
+	| THiddenFieldSchema<V>
 	| IHistogramSliderSchema<V>
 	| IImageUploadSchema<V>
 	| ILocationFieldSchema<V>

--- a/src/services/onemap/types.ts
+++ b/src/services/onemap/types.ts
@@ -7,10 +7,6 @@ export type OneMapGeocodeInfo = {
 	YCOORD: string;
 	LATITUDE: string;
 	LONGITUDE: string;
-	/**
-	 * @deprecated LONGTITUDE is deprecated and will be replaced by LONGITUDE
-	 */
-	LONGTITUDE: string;
 };
 
 export type OneMapSearchParam = {
@@ -43,7 +39,6 @@ export type OneMapSearchBuildingResult = {
 	Y: string;
 	LATITUDE: string;
 	LONGITUDE: string;
-	LONGTITUDE: string;
 	DISPLAY_ADDRESS?: string;
 };
 


### PR DESCRIPTION
**Changes**
- Removed deprecated types
- Replace deprecated `toBeCalledWith()`
- Note: It'll be easier to review by commits
