### PR TITLE
[CCUBE-1744][JON]Ensure same HTML elements are used for migrated Text…

### DIFF
--- a/src/__tests__/components/elements/accordion/accordion.spec.tsx
+++ b/src/__tests__/components/elements/accordion/accordion.spec.tsx
@@ -129,7 +129,7 @@ describe(UI_TYPE, () => {
 		const element = screen.getByText(ACCORDION_TITLE);
 		expect(element).toBeInTheDocument();
 		expect(element.tagName).toBe("SPAN");
-		expect(element.parentElement.tagName).toBe("H6");
+		expect(element.parentElement.tagName).toBe("H4");
 
 		const spanElement = screen.getByText(SPAN_TITLE);
 		expect(spanElement).toBeInTheDocument();

--- a/src/components/elements/text/data.ts
+++ b/src/components/elements/text/data.ts
@@ -1,4 +1,5 @@
 import { Typography } from "@lifesg/react-design-system/typography";
+import { TTextType } from "./types";
 
 export const TEXT_MAPPING = {
 	"TEXT-D1": Typography.HeadingXXL,
@@ -13,4 +14,19 @@ export const TEXT_MAPPING = {
 	"TEXT-BODY": Typography.BodyBL,
 	"TEXT-BODYSMALL": Typography.BodyMD,
 	"TEXT-XSMALL": Typography.BodyXS,
+};
+
+export const TAG_MAPPING: Record<TTextType, string> = {
+	"text-d1": "h1",
+	"text-d2": "h1",
+	"text-dbody": "h1",
+	"text-h1": "h1",
+	"text-h2": "h2",
+	"text-h3": "h3",
+	"text-h4": "h4",
+	"text-h5": "h5",
+	"text-h6": "h6",
+	"text-body": "p",
+	"text-bodysmall": "p",
+	"text-xsmall": "p",
 };

--- a/src/components/elements/text/text.tsx
+++ b/src/components/elements/text/text.tsx
@@ -7,7 +7,7 @@ import styled from "styled-components";
 import { TestHelper } from "../../../utils";
 import { Sanitize } from "../../shared";
 import { IGenericElementProps } from "../types";
-import { TEXT_MAPPING } from "./data";
+import { TAG_MAPPING, TEXT_MAPPING } from "./data";
 import { ITextSchema } from "./types";
 import { Wrapper } from "../wrapper";
 
@@ -25,6 +25,7 @@ export const Text = (props: IGenericElementProps<ITextSchema>) => {
 	const [showExpandButton, setShowExpandButton] = useState(false);
 
 	const Element = TEXT_MAPPING[uiType.toUpperCase()] || undefined;
+	const Tag = TAG_MAPPING[uiType] || undefined;
 
 	// =============================================================================
 	// EFFECTS / CALLBACKS
@@ -96,6 +97,7 @@ export const Text = (props: IGenericElementProps<ITextSchema>) => {
 				data-testid={getTestId(id)}
 				{...otherSchema}
 				// NOTE: Parent text body should be transformed into <div> to prevent validateDOMNesting error
+				{...(Tag && !hasNestedFields() && { as: Tag })}
 				{...(hasNestedFields() && { as: "div" })}
 			>
 				{renderText()}


### PR DESCRIPTION
… elements

**Changes**
With the [migration](https://github.com/LifeSG/react-design-system/wiki/Migrating-to-V3#text) of Text to Typography, the elements are decoupled from the underlying HTML elements, e.g. text-h1 is getting mapped to a h3 element. For backward compatibility, there is a need to ensure the correct HTML element is used

**Additional information**

-   You may refer to this [CCUBE-1744](https://sgtechstack.atlassian.net/browse/CCUBE-1744)
