### PR TITLE
Fix incorrect validation when rule is not available on Yup schema

### DIFF
--- a/src/__tests__/components/frontend-engine/yup/yup-helper.spec.ts
+++ b/src/__tests__/components/frontend-engine/yup/yup-helper.spec.ts
@@ -386,6 +386,15 @@ describe("YupHelper", () => {
 				TestHelper.getError(() => schema.validateSync({ field1: undefined, field2: "b", field3: "c" })).message
 			).toBe(ERROR_MESSAGE);
 		});
+
+		it("should only apply rules if available on the schema", () => {
+			const schema = YupHelper.mapRules(Yup.mixed(), [
+				{ filled: true, errorMessage: ERROR_MESSAGE },
+				{ matches: "/hello/", errorMessage: ERROR_MESSAGE_2 },
+				{ notMatches: "/hello/", errorMessage: ERROR_MESSAGE_3 },
+			]);
+			expect(TestHelper.getError(() => schema.validateSync(null))?.message).toBe(ERROR_MESSAGE);
+		});
 	});
 
 	describe("addCondition", () => {

--- a/src/context-providers/yup/helper.ts
+++ b/src/context-providers/yup/helper.ts
@@ -237,8 +237,8 @@ export namespace YupHelper {
 			const customRuleKey = Object.keys(rule).filter((k) =>
 				customYupConditions.includes(k as TYupCondition)
 			)?.[0] as TYupCondition;
-			if (customRuleKey) {
-				yupSchema = (yupSchema as unknown)[customRuleKey]?.(rule[customRuleKey], rule.errorMessage);
+			if (customRuleKey && (yupSchema as unknown)[customRuleKey]) {
+				yupSchema = (yupSchema as unknown)[customRuleKey](rule[customRuleKey], rule.errorMessage);
 			}
 			// prevent applying non-required validation for empty fields
 			if (yupSchema) {


### PR DESCRIPTION
**Changes**

The Yup schema becomes undefined when trying to apply a custom rule that is not applicable to the schema type, this manifests as conditional rendering not working as expected

-   [delete] branch

Example story to test the behaviour

```
export const Example = Template.bind({});
Example.args = {
	field: {
		uiType: "hidden-field",
		valueType: "null",
		// valueType: "string", // uncomment to compare behaviour
		// value: "Error", // uncomment to compare behaviour
		validation: [
			{
				equalsSchemaValue: true,
				errorMessage: "Does not match",
			},
		],
	},
	error: {
		uiType: "error-field",
		showIf: [{ field: [{ filled: true }, { notMatches: "/^[a-z]+$/" }] }],
		children: {
			list: {
				uiType: "ordered-list",
				children: [
					"This is a list item",
					{
						errorMessage: {
							uiType: "list-item",
							showIf: [{ field: [{ filled: true }, { notMatches: "/^[a-z]+$/" }] }],
							children: {
								alert: {
									uiType: "text-body",
									children: "Contains invalid characters",
								},
							},
						},
					},
				],
			},
		},
	},
};
```

<!-- Remove if not required -->

**Changelog entry**

-   Fix validation failure when rule is not available on Yup schema