### PR TITLE
[MOL-18369][GW] Update filter-item and filter-checkbox to forward zIndex to label's popover

### DIFF
--- a/src/components/custom/filter/filter-helper.tsx
+++ b/src/components/custom/filter/filter-helper.tsx
@@ -21,6 +21,7 @@ export namespace FilterHelper {
 					  {
 							type: "popover",
 							content: <StyledHint className="label-hint">{label.hint?.content}</StyledHint>,
+							zIndex: label.hint?.zIndex,
 							"data-testid": id + "-popover",
 					  }
 					: /* eslint-enable indent */

--- a/src/components/custom/filter/types.ts
+++ b/src/components/custom/filter/types.ts
@@ -1,4 +1,8 @@
+import { FormLabelAddonProps } from "@lifesg/react-design-system/form/types";
+
+interface IPopoverHint extends Pick<FormLabelAddonProps, "content" | "zIndex"> {}
+
 export interface IFilterItemLabel {
 	mainLabel: string;
-	hint?: { content: string } | undefined;
+	hint?: IPopoverHint | undefined;
 }

--- a/src/stories/5-custom/filter/filter-checkbox-item.stories.tsx
+++ b/src/stories/5-custom/filter/filter-checkbox-item.stories.tsx
@@ -26,6 +26,15 @@ const meta: Meta = {
 	},
 	argTypes: {
 		...CommonCustomStoryProps("filter-checkbox"),
+		label: {
+			description:
+				"A name/description of the purpose of the element. Accepts a string for a default label, or an object with a main label and a hint displayed in a popover.",
+			table: {
+				type: {
+					summary: "string | { mainLabel: string, hint?: { content: string, zIndex?: number } }",
+				},
+			},
+		},
 		children: {
 			description: "Elements or string that is the descendant of this component",
 			table: {

--- a/src/stories/5-custom/filter/filter-item.stories.tsx
+++ b/src/stories/5-custom/filter/filter-item.stories.tsx
@@ -20,6 +20,15 @@ const meta: Meta = {
 	},
 	argTypes: {
 		...CommonCustomStoryProps("filter-item"),
+		label: {
+			description:
+				"A name/description of the purpose of the element. Accepts a string for a default label, or an object with a main label and a hint displayed in a popover.",
+			table: {
+				type: {
+					summary: "string | { mainLabel: string, hint?: { content: string, zIndex?: number } }",
+				},
+			},
+		},
 		children: {
 			description: "Elements or string that is the descendant of this component",
 			table: {


### PR DESCRIPTION
**Changes**
 Update filter-item and filter-checkbox to forward zIndex to label's popover

-    delete branch

**Changelog entry**

-    Update filter-item and filter-checkbox to forward zIndex to label's popover

**Additional information**

-   You may refer to this [ticket](https://sgtechstack.atlassian.net/browse/MOL-18201)
