### PR TITLE
[MOL-18369][GW] Allow filter hint content to render schema

### DIFF
--- a/src/components/custom/filter/filter-helper.tsx
+++ b/src/components/custom/filter/filter-helper.tsx
@@ -1,6 +1,7 @@
 import { Color } from "@lifesg/react-design-system/color";
 import { FormLabelAddonProps } from "@lifesg/react-design-system/form/types";
 import styled from "styled-components";
+import { Wrapper } from "../../elements/wrapper";
 import { Sanitize } from "../../shared";
 import { IFilterItemLabel } from "./types";
 
@@ -14,13 +15,19 @@ export namespace FilterHelper {
 				title: label,
 			};
 		} else if (!!label && typeof label === "object" && label.mainLabel) {
+			const content =
+				typeof label.hint.content === "string" ? (
+					<StyledHint className="label-hint">{label.hint.content}</StyledHint>
+				) : (
+					<Wrapper>{label.hint.content}</Wrapper>
+				);
 			return {
 				title: label.mainLabel,
 				addon: label.hint?.content
 					? /* eslint-disable indent */
 					  {
 							type: "popover",
-							content: <StyledHint className="label-hint">{label.hint?.content}</StyledHint>,
+							content,
 							zIndex: label.hint?.zIndex,
 							"data-testid": id + "-popover",
 					  }

--- a/src/components/custom/filter/types.ts
+++ b/src/components/custom/filter/types.ts
@@ -1,8 +1,9 @@
 import { FormLabelAddonProps } from "@lifesg/react-design-system/form/types";
-import { TElementSchema } from "../../elements";
+import { TBlockElementSchema, TInlineElementSchema } from "../../elements/types";
+import { TWrapperSchema } from "../../elements/wrapper/types";
 
 interface IPopoverHint extends Pick<FormLabelAddonProps, "zIndex"> {
-	content: string | Record<string, TElementSchema>;
+	content: string | Record<string, TBlockElementSchema | TInlineElementSchema | TWrapperSchema>;
 }
 
 export interface IFilterItemLabel {

--- a/src/components/custom/filter/types.ts
+++ b/src/components/custom/filter/types.ts
@@ -1,6 +1,9 @@
 import { FormLabelAddonProps } from "@lifesg/react-design-system/form/types";
+import { TElementSchema } from "../../elements";
 
-interface IPopoverHint extends Pick<FormLabelAddonProps, "content" | "zIndex"> {}
+interface IPopoverHint extends Pick<FormLabelAddonProps, "zIndex"> {
+	content: string | Record<string, TElementSchema>;
+}
 
 export interface IFilterItemLabel {
 	mainLabel: string;

--- a/src/stories/5-custom/filter/filter-checkbox-item.stories.tsx
+++ b/src/stories/5-custom/filter/filter-checkbox-item.stories.tsx
@@ -27,12 +27,17 @@ const meta: Meta = {
 	argTypes: {
 		...CommonCustomStoryProps("filter-checkbox"),
 		label: {
-			description:
-				'A name/description of the purpose of the element. Accepts a string for a default label, or an object with a main label and a hint displayed in a popover.\n\nAlso accepts an element schema for more customisation. (See <a href="../?path=/story/custom-filter-filtercheckbox--label-customisation-with-schema">Label Customisation With Schema</a>)',
+			description: `A name/description of the purpose of the section which may include an optional hint displayed in a popover.<br>
+				If string is provided, the entire label will be rendered.<br>
+				If object is provided:
+				<ul>
+					<li>mainLabel: Primary text to display.</li>
+					<li>hint.content: Displays an info icon and brings up the content as a popover on click. Accepts a string or schema for more customisation. (See <strong>Label Customisation With Schema</strong> story)</li>
+				</ul>`,
 			table: {
 				type: {
 					summary:
-						"string | { mainLabel: string, hint?: { content: string | Record<string, TElementSchema>, zIndex?: number } }",
+						"string | { mainLabel: string, hint?: { content: string | Record<string, TBlockElementSchema | TInlineElementSchema | TWrapperSchema>, zIndex?: number } }",
 				},
 			},
 		},
@@ -215,54 +220,48 @@ LabelCustomisationWithSchema.args = {
 		mainLabel: "Filter item",
 		hint: {
 			content: {
-				wrapperSpan: {
+				wrapper: {
 					children: {
-						titleInH3: {
-							children: '<h3 style="margin-bottom:1rem">Common questions in h3</h3>',
+						heading: {
 							uiType: "text-h3",
 							weight: "semibold",
+							children: "Heading",
+							style: {
+								marginBottom: "1rem",
+							},
 						},
-						anotherTitleInH4: {
-							children: '<h4 style="margin-bottom:1rem">Common questions in h4</h4>',
-							uiType: "text-h4",
-							weight: "semibold",
-						},
-						bodyText: {
-							children:
-								'<p style="margin-bottom:1rem">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</p>',
+						description: {
 							uiType: "text-body",
+							children:
+								"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+							style: {
+								marginBottom: "1rem",
+							},
 						},
-						lists: {
+						list: {
 							children: [
 								{
 									listItem: {
-										children: {
-											bodyText: {
-												children: '<p style="margin-bottom:0.5rem">a bullet list </p>',
-												uiType: "text-body",
-											},
-										},
+										children: "A bullet list",
 										uiType: "list-item",
+										style: {
+											marginBottom: "0.5rem",
+										},
 									},
 									listItem2: {
-										children: {
-											"just a text": {
-												children:
-													'<span><strong>A description: </strong><a href="https://www.google.com" target="_blank" rel="noopener noreferrer">a link to google</span>',
-												uiType: "text-body",
-											},
-										},
+										children:
+											'<strong>A description: </strong><a href="https://www.google.com" target="_blank" rel="noopener noreferrer">a link to google</a>',
 										uiType: "list-item",
 									},
 								},
 							],
 							uiType: "unordered-list",
+							size: "BodySmall",
 						},
 					},
 					uiType: "div",
 				},
 			},
-			zIndex: 9999,
 		},
 	},
 	referenceKey: "filter-checkbox",

--- a/src/stories/5-custom/filter/filter-checkbox-item.stories.tsx
+++ b/src/stories/5-custom/filter/filter-checkbox-item.stories.tsx
@@ -28,10 +28,11 @@ const meta: Meta = {
 		...CommonCustomStoryProps("filter-checkbox"),
 		label: {
 			description:
-				"A name/description of the purpose of the element. Accepts a string for a default label, or an object with a main label and a hint displayed in a popover.",
+				'A name/description of the purpose of the element. Accepts a string for a default label, or an object with a main label and a hint displayed in a popover.\n\nAlso accepts an element schema for more customisation. (See <a href="../?path=/story/custom-filter-filtercheckbox--label-customisation-with-schema">Label Customisation With Schema</a>)',
 			table: {
 				type: {
-					summary: "string | { mainLabel: string, hint?: { content: string, zIndex?: number } }",
+					summary:
+						"string | { mainLabel: string, hint?: { content: string | Record<string, TElementSchema>, zIndex?: number } }",
 				},
 			},
 		},
@@ -200,6 +201,69 @@ LabelCustomisation.args = {
 	label: {
 		mainLabel: "Filter item",
 		hint: { content: "A helpful tip<br>Another helpful tip on next line" },
+	},
+	referenceKey: "filter-checkbox",
+	options: [
+		{ label: "Red", value: "red" },
+		{ label: "Blue", value: "blue" },
+	],
+};
+
+export const LabelCustomisationWithSchema = Template("filter-checkbox-label-customisation-with-schema").bind({});
+LabelCustomisationWithSchema.args = {
+	label: {
+		mainLabel: "Filter item",
+		hint: {
+			content: {
+				wrapperSpan: {
+					children: {
+						titleInH3: {
+							children: '<h3 style="margin-bottom:1rem">Common questions in h3</h3>',
+							uiType: "text-h3",
+							weight: "semibold",
+						},
+						anotherTitleInH4: {
+							children: '<h4 style="margin-bottom:1rem">Common questions in h4</h4>',
+							uiType: "text-h4",
+							weight: "semibold",
+						},
+						bodyText: {
+							children:
+								'<p style="margin-bottom:1rem">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</p>',
+							uiType: "text-body",
+						},
+						lists: {
+							children: [
+								{
+									listItem: {
+										children: {
+											bodyText: {
+												children: '<p style="margin-bottom:0.5rem">a bullet list </p>',
+												uiType: "text-body",
+											},
+										},
+										uiType: "list-item",
+									},
+									listItem2: {
+										children: {
+											"just a text": {
+												children:
+													'<span><strong>A description: </strong><a href="https://www.google.com" target="_blank" rel="noopener noreferrer">a link to google</span>',
+												uiType: "text-body",
+											},
+										},
+										uiType: "list-item",
+									},
+								},
+							],
+							uiType: "unordered-list",
+						},
+					},
+					uiType: "div",
+				},
+			},
+			zIndex: 9999,
+		},
 	},
 	referenceKey: "filter-checkbox",
 	options: [

--- a/src/stories/5-custom/filter/filter-item.stories.tsx
+++ b/src/stories/5-custom/filter/filter-item.stories.tsx
@@ -21,12 +21,17 @@ const meta: Meta = {
 	argTypes: {
 		...CommonCustomStoryProps("filter-item"),
 		label: {
-			description:
-				'A name/description of the purpose of the element. Accepts a string for a default label, or an object with a main label and a hint displayed in a popover.\n\nAlso accepts an element schema for more customisation.  (See <a href="../?path=/story/custom-filter-filter-item--label-customisation-with-schema">Label Customisation With Schema</a>)',
+			description: `A name/description of the purpose of the section which may include an optional hint displayed in a popover.<br>
+				If string is provided, the entire label will be rendered.<br>
+				If object is provided:
+				<ul>
+					<li>mainLabel: Primary text to display.</li>
+					<li>hint.content: Displays an info icon and brings up the content as a popover on click. Accepts a string or schema for more customisation. (See <strong>Label Customisation With Schema</strong> story)</li>
+				</ul>`,
 			table: {
 				type: {
 					summary:
-						"string | { mainLabel: string, hint?: { content: string | Record<string, TElementSchema>, zIndex?: number } }",
+						"string | { mainLabel: string, hint?: { content: string | Record<string, TBlockElementSchema | TInlineElementSchema | TWrapperSchema>, zIndex?: number } }",
 				},
 			},
 		},
@@ -174,48 +179,43 @@ LabelCustomisationWithSchema.args = {
 		mainLabel: "Filter item",
 		hint: {
 			content: {
-				wrapperSpan: {
+				wrapper: {
 					children: {
-						titleInH3: {
-							children: '<h3 style="margin-bottom:1rem">Common questions in h3</h3>',
+						heading: {
 							uiType: "text-h3",
 							weight: "semibold",
+							children: "Heading",
+							style: {
+								marginBottom: "1rem",
+							},
 						},
-						anotherTitleInH4: {
-							children: '<h4 style="margin-bottom:1rem">Common questions in h4</h4>',
-							uiType: "text-h4",
-							weight: "semibold",
-						},
-						bodyText: {
-							children:
-								'<p style="margin-bottom:1rem">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</p>',
+						description: {
 							uiType: "text-body",
+							children:
+								"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+							style: {
+								marginBottom: "1rem",
+							},
 						},
-						lists: {
+						list: {
 							children: [
 								{
 									listItem: {
-										children: {
-											bodyText: {
-												children: '<p style="margin-bottom:0.5rem">a bullet list </p>',
-												uiType: "text-body",
-											},
-										},
+										children: "A bullet list",
 										uiType: "list-item",
+										style: {
+											marginBottom: "0.5rem",
+										},
 									},
 									listItem2: {
-										children: {
-											"just a text": {
-												children:
-													'<span><strong>A description: </strong><a href="https://www.google.com" target="_blank" rel="noopener noreferrer">a link to google</span>',
-												uiType: "text-body",
-											},
-										},
+										children:
+											'<strong>A description: </strong><a href="https://www.google.com" target="_blank" rel="noopener noreferrer">a link to google</a>',
 										uiType: "list-item",
 									},
 								},
 							],
 							uiType: "unordered-list",
+							size: "BodySmall",
 						},
 					},
 					uiType: "div",

--- a/src/stories/5-custom/filter/filter-item.stories.tsx
+++ b/src/stories/5-custom/filter/filter-item.stories.tsx
@@ -22,10 +22,11 @@ const meta: Meta = {
 		...CommonCustomStoryProps("filter-item"),
 		label: {
 			description:
-				"A name/description of the purpose of the element. Accepts a string for a default label, or an object with a main label and a hint displayed in a popover.",
+				'A name/description of the purpose of the element. Accepts a string for a default label, or an object with a main label and a hint displayed in a popover.\n\nAlso accepts an element schema for more customisation.  (See <a href="../?path=/story/custom-filter-filter-item--label-customisation-with-schema">Label Customisation With Schema</a>)',
 			table: {
 				type: {
-					summary: "string | { mainLabel: string, hint?: { content: string, zIndex?: number } }",
+					summary:
+						"string | { mainLabel: string, hint?: { content: string | Record<string, TElementSchema>, zIndex?: number } }",
 				},
 			},
 		},
@@ -157,6 +158,70 @@ LabelCustomisation.args = {
 	label: {
 		mainLabel: "Filter item",
 		hint: { content: "A helpful tip<br>Another helpful tip on next line" },
+	},
+	referenceKey: "filter-item",
+	children: {
+		text: {
+			uiType: "text-body",
+			children: "This is a filter item",
+		},
+	},
+};
+
+export const LabelCustomisationWithSchema = Template("filter-item-label-customisation-with-schema").bind({});
+LabelCustomisationWithSchema.args = {
+	label: {
+		mainLabel: "Filter item",
+		hint: {
+			content: {
+				wrapperSpan: {
+					children: {
+						titleInH3: {
+							children: '<h3 style="margin-bottom:1rem">Common questions in h3</h3>',
+							uiType: "text-h3",
+							weight: "semibold",
+						},
+						anotherTitleInH4: {
+							children: '<h4 style="margin-bottom:1rem">Common questions in h4</h4>',
+							uiType: "text-h4",
+							weight: "semibold",
+						},
+						bodyText: {
+							children:
+								'<p style="margin-bottom:1rem">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum</p>',
+							uiType: "text-body",
+						},
+						lists: {
+							children: [
+								{
+									listItem: {
+										children: {
+											bodyText: {
+												children: '<p style="margin-bottom:0.5rem">a bullet list </p>',
+												uiType: "text-body",
+											},
+										},
+										uiType: "list-item",
+									},
+									listItem2: {
+										children: {
+											"just a text": {
+												children:
+													'<span><strong>A description: </strong><a href="https://www.google.com" target="_blank" rel="noopener noreferrer">a link to google</span>',
+												uiType: "text-body",
+											},
+										},
+										uiType: "list-item",
+									},
+								},
+							],
+							uiType: "unordered-list",
+						},
+					},
+					uiType: "div",
+				},
+			},
+		},
 	},
 	referenceKey: "filter-item",
 	children: {


### PR DESCRIPTION
**Changes**
Allow filter item/checkbox's label hint content to render schema, while not breaking any existing functionality
This allows us to configure the stylings within the content!!!

-   delete branch


**Changelog entry**

-   Allow filter hint content to render schema

**Additional information**
