### PR TITLE
Sanitise names of uploaded files or images

### DIFF
--- a/src/__tests__/utils/file-helper.spec.ts
+++ b/src/__tests__/utils/file-helper.spec.ts
@@ -34,13 +34,11 @@ describe("FileHelper", () => {
 	describe("sanitizeFileName", () => {
 		it.each`
 			scenario                                   | input                         | expected
-			${"keep allowed characters"}               | ${"this is OK_-123.png"}      | ${"this is OK_-123.png"}
-			${"strip leading and trailing spaces"}     | ${"\t\n  test \t\n.png"}      | ${"test.png"}
-			${"strip special characters"}              | ${"`~!@#$%^&*()=+test✨.png"} | ${"test.png"}
-			${"remove periods"}                        | ${"test.test.png"}            | ${"testtest.png"}
-			${"fallback to default with extension"}    | ${"   .txt"}                  | ${"file.txt"}
-			${"fallback to default without extension"} | ${"   "}                      | ${"file"}
-			${"handle file without extension"}         | ${".!env"}                    | ${"env"}
+			${"keep allowed characters"}               | ${"Ok123_- !@#$%^&*()~..png"} | ${"Ok123_- !@#$%^&*()~..png"}
+			${"strip special characters"}              | ${"test\u00A0✨可.png"}       | ${"test.png"}
+			${"fallback to default with extension"}    | ${"✨.txt"}                   | ${"file.txt"}
+			${"fallback to default without extension"} | ${"✨"}                       | ${"file"}
+			${"handle file without extension"}         | ${".env"}                     | ${".env"}
 		`("should $scenario", ({ input, expected }) => {
 			expect(FileHelper.sanitizeFileName(input)).toEqual(expected);
 		});

--- a/src/__tests__/utils/file-helper.spec.ts
+++ b/src/__tests__/utils/file-helper.spec.ts
@@ -1,0 +1,18 @@
+import { FileHelper } from "../../utils";
+
+describe("FileHelper", () => {
+	describe("sanitizeFileName", () => {
+		it.each`
+			scenario                                   | input                         | expected
+			${"keep allowed characters"}               | ${"this is OK_-123.png"}      | ${"this is OK_-123.png"}
+			${"strip leading and trailing spaces"}     | ${"\t\n  test \t\n.png"}      | ${"test.png"}
+			${"strip special characters"}              | ${"`~!@#$%^&*()=+test✨.png"} | ${"test.png"}
+			${"remove periods"}                        | ${"test.test.png"}            | ${"testtest.png"}
+			${"fallback to default with extension"}    | ${"   .txt"}                  | ${"file.txt"}
+			${"fallback to default without extension"} | ${"   "}                      | ${"file"}
+			${"handle file without extension"}         | ${".!env"}                    | ${"env"}
+		`("should $scenario", ({ input, expected }) => {
+			expect(FileHelper.sanitizeFileName(input)).toEqual(expected);
+		});
+	});
+});

--- a/src/__tests__/utils/file-helper.spec.ts
+++ b/src/__tests__/utils/file-helper.spec.ts
@@ -1,6 +1,36 @@
 import { FileHelper } from "../../utils";
 
 describe("FileHelper", () => {
+	describe("deduplicateFileName", () => {
+		it("should return original file name if it is unique", () => {
+			const fileName = "two.png";
+			const fileNameList = ["one.png", "two.png"];
+			const index = 1;
+			expect(FileHelper.deduplicateFileName(fileNameList, index, fileName)).toEqual("two.png");
+		});
+
+		it("should return deduplicated file name if it is not unique", () => {
+			const fileName = "one.png";
+			const fileNameList = ["one.png", "one.png"];
+			const index = 1;
+			expect(FileHelper.deduplicateFileName(fileNameList, index, fileName)).toEqual("one (1).png");
+		});
+
+		it("should return deduplicated file name if multiple files are not unique", () => {
+			const fileName = "one.png";
+			const fileNameList = ["one.png", "one (1).png", "one.png"];
+			const index = 2;
+			expect(FileHelper.deduplicateFileName(fileNameList, index, fileName)).toEqual("one (2).png");
+		});
+
+		it("should append correctly to file name containing special characters", () => {
+			const fileName = "test.test .png";
+			const fileNameList = [fileName, fileName];
+			const index = 1;
+			expect(FileHelper.deduplicateFileName(fileNameList, index, fileName)).toEqual("test.test  (1).png");
+		});
+	});
+
 	describe("sanitizeFileName", () => {
 		it.each`
 			scenario                                   | input                         | expected

--- a/src/components/fields/file-upload/file-upload-manager.ts
+++ b/src/components/fields/file-upload/file-upload-manager.ts
@@ -248,7 +248,7 @@ const FileUploadManager = (props: IProps) => {
 					name: FileHelper.deduplicateFileName(
 						files.map(({ fileItem }) => fileItem?.name),
 						index,
-						compressedFile.rawFile.name
+						FileHelper.sanitizeFileName(compressedFile.rawFile.name)
 					),
 					size: compressedFile.rawFile.size,
 					type: fileType.mime,

--- a/src/components/fields/image-upload/image-manager/image-manager.ts
+++ b/src/components/fields/image-upload/image-manager/image-manager.ts
@@ -102,7 +102,7 @@ export const ImageManager = (props: IProps) => {
 										name: FileHelper.deduplicateFileName(
 											images.map(({ name }) => name),
 											index,
-											image.name
+											FileHelper.sanitizeFileName(image.name)
 										),
 										type: mimeType,
 										status: image.addedFrom !== "schema" ? image.status : EImageStatus.UPLOADED,

--- a/src/utils/file-helper.ts
+++ b/src/utils/file-helper.ts
@@ -170,6 +170,31 @@ export namespace FileHelper {
 		}
 	};
 
+	export const sanitizeFileName = (fileName: string): string => {
+		const parts = fileName.split(".");
+		let ext: string;
+		let name: string;
+
+		if (parts.length === 2 && parts[0] === "") {
+			// file without extension but with leading .
+			name = parts[1];
+		} else if (parts.length > 1) {
+			// file with extension
+			ext = parts.pop();
+			name = parts.join(".");
+		} else {
+			// file without extension
+			name = parts.join(".");
+		}
+
+		let sanitized = name.replace(/[^A-Za-z0-9 _-]*/g, "").trim();
+		if (!sanitized) {
+			sanitized = "file";
+		}
+
+		return ext ? `${sanitized}.${ext}` : `${sanitized}`;
+	};
+
 	export const blobToFile = (blob: Blob, metadata: { name: string; lastModified: number }): File => {
 		const { name, lastModified } = metadata;
 		return new File([blob], name, {

--- a/src/utils/file-helper.ts
+++ b/src/utils/file-helper.ts
@@ -163,7 +163,7 @@ export namespace FileHelper {
 			const name = originalFilename.split(".");
 			const ext = name.pop();
 			if (!ext) return fileName;
-			fileName = name.join().concat(` (${counter}).`).concat(ext);
+			fileName = name.join(".").concat(` (${counter}).`).concat(ext);
 			return deduplicateFileName(fileNameList, index, fileName, originalFilename, ++counter);
 		} else {
 			return fileName;

--- a/src/utils/file-helper.ts
+++ b/src/utils/file-helper.ts
@@ -177,7 +177,7 @@ export namespace FileHelper {
 
 		if (parts.length === 2 && parts[0] === "") {
 			// file without extension but with leading .
-			name = parts[1];
+			name = fileName;
 		} else if (parts.length > 1) {
 			// file with extension
 			ext = parts.pop();
@@ -187,7 +187,8 @@ export namespace FileHelper {
 			name = parts.join(".");
 		}
 
-		let sanitized = name.replace(/[^A-Za-z0-9 _-]*/g, "").trim();
+		// allow ascii characters only
+		let sanitized = name.replace(/[^\u0020-\u007E]*/g, "");
 		if (!sanitized) {
 			sanitized = "file";
 		}


### PR DESCRIPTION
**Changes**

This issue was discovered when uploading a MacOS screenshot in multipart upload. The backend received a filename containing additional characters that were not in the original filename.

```
original: Screenshot 2025-06-06 at 4.08.20 PM.png
received: Screenshot 2025-06-06 at 4.08.20â¯PM.png
```

On further inspection, the raw HTTP request contains the following data
```
------WebKitFormBoundary9BnO3UzfnbwLz22y
Content-Disposition: form-data; name="file"; filename="Screenshot 2025-06-06 at 4.08.20 PM.png"
```

Apparently the encoding needs to be specified in the filename like this when dealing with non-ASCII characters:
```
filename*=UTF-8''XXXXX
```

However, this is not supported by Axios. It also relies on the backend properly handling utf-8 encoding as well.

The lowest common denominator approach is to sanitise file names by removing non-ASCII-printable characters. latin-1 and utf-8 characters do not work.

-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Sanitise names of uploaded files or images