### PR TITLE
[BOOKINGSG-7753][JEFF] enhance getParsedPhoneNumber function

### DIFF
--- a/src/__tests__/components/fields/contact-field/contact-field.spec.tsx
+++ b/src/__tests__/components/fields/contact-field/contact-field.spec.tsx
@@ -144,6 +144,13 @@ describe(UI_TYPE, () => {
 			expect(screen.getByText("+60")).toBeInTheDocument();
 		});
 
+		it("should support format phone number without spaces", async () => {
+			renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: "+84327016340" } });
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: "+84 327016340" }));
+		});
+
 		it("should not switch country if an invalid country code is specified in defaultValues", async () => {
 			renderComponent(undefined, { defaultValues: { [COMPONENT_ID]: "+999 91234567" } });
 

--- a/src/components/fields/contact-field/utils.ts
+++ b/src/components/fields/contact-field/utils.ts
@@ -1,5 +1,5 @@
 import { byCountry } from "country-code-lookup";
-import { CountryCode, parsePhoneNumber } from "libphonenumber-js";
+import { CountryCode, parsePhoneNumber, parsePhoneNumberFromString } from "libphonenumber-js";
 import { IParsedPhoneNumber } from "./types";
 
 const SINGAPORE_PHONE_NUMBER_REGEX = /^(?!\+?6599)(?!^\+65\d{6}$)^(?:\+?(?:65)?([9,8,6,3]{1}\d{7}))$/;
@@ -8,9 +8,17 @@ const SINGAPORE_MOBILE_NUMBER_REGEX = /^(?!\+?6599)(?!^\+65\d{6}$)^(?:\+?(?:65)?
 
 export namespace PhoneHelper {
 	export const getParsedPhoneNumber = (value: string): IParsedPhoneNumber => {
+		const parsedValue = parsePhoneNumberFromString(value);
+		if (parsedValue) {
+			// Use countryCallingCode (string, without '+')
+			return {
+				prefix: parsedValue.countryCallingCode || "",
+				number: parsedValue.nationalNumber || "",
+			};
+		}
+		// fallback to split for manual input
 		const parsedValues = value.split(" ");
 		const hasPrefix = parsedValues.length > 1;
-
 		return {
 			prefix: hasPrefix ? parsedValues[0] : "",
 			number: hasPrefix ? parsedValues[1] : value,


### PR DESCRIPTION
**Changes**  
Enhance `getParsedPhoneNumber` function to parse phone numbers both with and without a space between the country code and national number.

**Background**  
Currently, the `getParsedPhoneNumber` function from FEE only accepts phone numbers that have a space between the country code and the national number (e.g., `+65 91234567`).

**Issue**  
When a default value is set for the contact field (e.g., `+6591234567` without a space), the function cannot parse this format into country code and national number, resulting in validation failures later in the flow.

**Expected Behavior**  
`getParsedPhoneNumber` should accept and correctly parse phone numbers both with and without a space after the country code (e.g., both `+65 91234567` and `+6591234567`).

**Additional Information**  
- Related Jira ticket: [BOOKINGSG-7753](https://sgtechstack.atlassian.net/browse/BOOKINGSG-7753)