### PR TITLE
[MOL-19011][NL] Correct cropping area for background images with smal…

### DIFF
--- a/src/components/fields/image-upload/image-review/image-editor/image-editor.tsx
+++ b/src/components/fields/image-upload/image-review/image-editor/image-editor.tsx
@@ -200,6 +200,7 @@ export const ImageEditor = forwardRef((props: IImageEditorProps, ref: ForwardedR
 				eraserBrush.current.width = PENCIL_BRUSH_SIZE * (img.scaleX || 1) * 2;
 			}
 
+			img.setCoords(); // Ensures the internal coordinate system matches the visual state after scaling
 			fabricCanvas.current.requestRenderAll();
 		}
 	};


### PR DESCRIPTION
**Changes**

Correct cropping area for background images with dimensions smaller than the canvas size.

-   [delete] branch

**Additional information**

-   You may refer to this [ticket](https://sgtechstack.atlassian.net/browse/MOL-19011)
- After scaling, the coordinates of the object's bounding rectangle are not automatically updated in Fabric.js v5. This results in mismatched coordinates when exporting the image using toDataURL. You can observe this by logging img.aCoords, img.oCoords, and img.getBoundingRect() before and after calling img.setCoords().
