### PR TITLE
[MOL-19058][MA] Add zoom duration to location field props

### DIFF
--- a/src/components/fields/location-field/location-modal/location-picker/location-picker.tsx
+++ b/src/components/fields/location-field/location-modal/location-picker/location-picker.tsx
@@ -210,7 +210,7 @@ export const LocationPicker = ({
 				? map.getZoom()
 				: panZoomValue;
 
-		map.flyTo(L.latLng(zoomCenter.lat, zoomCenter.lng), zoomValue);
+		map.flyTo(L.latLng(zoomCenter.lat, zoomCenter.lng), zoomValue, { duration: mapPanZoom?.duration });
 		setTimeout(() => map.invalidateSize(), 500);
 	};
 

--- a/src/components/fields/location-field/location-modal/location-picker/types.ts
+++ b/src/components/fields/location-field/location-modal/location-picker/types.ts
@@ -15,6 +15,7 @@ export interface ILocationPickerProps extends React.InputHTMLAttributes<HTMLDivE
 				nonMobile?: number | undefined;
 				min?: number | undefined;
 				max?: number | undefined;
+				duration?: number | undefined;
 		  }
 		| undefined;
 	panelInputMode: TPanelInputMode;

--- a/src/stories/3-fields/location-field/location-field.stories.tsx
+++ b/src/stories/3-fields/location-field/location-field.stories.tsx
@@ -131,6 +131,18 @@ const meta: Meta = {
 				type: "number",
 			},
 		},
+		zoomDuration: {
+			description:
+				"Specifies the duration of the zoom animation when the map is panned to a new location. Defaults to 2.5 seconds if undefined.",
+			table: {
+				type: {
+					summary: "undefined | number",
+				},
+			},
+			control: {
+				type: "number",
+			},
+		},
 	},
 };
 export default meta;

--- a/src/stories/3-fields/location-field/location-field.stories.tsx
+++ b/src/stories/3-fields/location-field/location-field.stories.tsx
@@ -73,7 +73,7 @@ const meta: Meta = {
 			description: "Specifies the map pan zoom value.",
 			table: {
 				type: {
-					summary: `{mobile?: number, nonMobile?: number, min?: number, max?: number}`,
+					summary: `{mobile?: number, nonMobile?: number, min?: number, max?: number, duration?: number}`,
 				},
 			},
 			control: { type: "object" },
@@ -126,18 +126,6 @@ const meta: Meta = {
 					summary: "number",
 				},
 				defaultValue: { summary: "500" },
-			},
-			control: {
-				type: "number",
-			},
-		},
-		zoomDuration: {
-			description:
-				"Specifies the duration of the zoom animation when the map is panned to a new location. Defaults to 2.5 seconds if undefined.",
-			table: {
-				type: {
-					summary: "undefined | number",
-				},
 			},
 			control: {
 				type: "number",
@@ -311,7 +299,7 @@ WithCustomMapPanZoom.args = {
 	label: "WithCustomMapPanZoom",
 	reverseGeoCodeEndpoint,
 	convertLatLngToXYEndpoint,
-	mapPanZoom: { mobile: 17, nonMobile: 17, min: 12, max: 14 },
+	mapPanZoom: { mobile: 17, nonMobile: 17, min: 12, max: 14, duration: 1 },
 };
 
 export const DisableSearch = DefaultStoryTemplate<ILocationFieldSchema>("disable-text-search").bind({});


### PR DESCRIPTION
**Changes**
Add `duration` to location field `mapPanZoom` prop. This allows us to control how long it takes for the map modal to zoom and center on a specified lat lng using the leaflet api

-   delete branch

<!-- Remove if not required -->

**Changelog entry**

-   Add optional `duration` to location field `mapPanZoom` props

**Additional information**
