### PR TITLE
[MOL-19467][MA] Replace location input with dummy input to prevent iOS26 location modal resize issue

### DIFF
--- a/src/components/fields/location-field/location-field.tsx
+++ b/src/components/fields/location-field/location-field.tsx
@@ -106,13 +106,12 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 		setValue(id, updatedValues, { shouldDirty });
 	};
 
-	const handleFocus = (e?: React.FocusEvent<HTMLInputElement, Element>) => {
+	const handleFocus = () => {
 		if (readOnly || disabled) {
 			return;
 		}
 		setShowLocationModal(true);
 		dispatchFieldEvent("show-location-modal", id);
-		e?.currentTarget.blur();
 	};
 
 	const handleClose = () => {

--- a/src/components/fields/location-field/location-input/dummy-location-field.tsx
+++ b/src/components/fields/location-field/location-input/dummy-location-field.tsx
@@ -1,10 +1,5 @@
 import { PinFillIcon } from "@lifesg/react-icons/pin-fill";
-import {
-	DummyLocationInput,
-	LocationIconWrapper,
-	LocationInputGroup,
-	LocationInputText,
-} from "./location-input.styles";
+import { DummyLocationInput, LocationIconWrapper, LocationInputText } from "./location-input.styles";
 
 interface IDummyLocationFieldProps {
 	disabled?: boolean;
@@ -13,10 +8,11 @@ interface IDummyLocationFieldProps {
 	value?: string | number | readonly string[];
 	error?: boolean;
 	onFocus: (e: React.FocusEvent<HTMLInputElement, Element>) => void;
+	className?: string;
 }
 
 export const DummyLocationField = (props: IDummyLocationFieldProps) => {
-	const { disabled, readOnly, onFocus, value, placeholder, error } = props;
+	const { className, disabled, readOnly, onFocus, value, placeholder, error } = props;
 
 	const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
 		if (disabled) return;
@@ -34,28 +30,30 @@ export const DummyLocationField = (props: IDummyLocationFieldProps) => {
 	};
 
 	return (
-		<LocationInputGroup>
-			<DummyLocationInput
-				$disabled={disabled}
-				$readOnly={readOnly}
-				$error={error}
-				onFocus={onFocus}
-				onClick={handleClick}
-				onKeyDown={handleKeyDown}
-				tabIndex={disabled ? -1 : 0}
-				aria-disabled={disabled || undefined}
-			>
-				{placeholder && !value ? (
-					<LocationInputText $placeholder $disabled={disabled} aria-label={placeholder}>
-						{placeholder}
-					</LocationInputText>
-				) : (
-					<LocationInputText $disabled={disabled}>{value}</LocationInputText>
-				)}
-				<LocationIconWrapper $disabled={disabled} $readOnly={readOnly} aria-hidden="true">
-					<PinFillIcon />
-				</LocationIconWrapper>
-			</DummyLocationInput>
-		</LocationInputGroup>
+		<DummyLocationInput
+			className={className}
+			$disabled={disabled}
+			$readOnly={readOnly}
+			$error={error}
+			onFocus={onFocus}
+			onClick={handleClick}
+			onKeyDown={handleKeyDown}
+			tabIndex={disabled ? -1 : 0}
+			aria-disabled={disabled || undefined}
+			role="combobox"
+			aria-haspopup="dialog"
+			aria-readonly={readOnly}
+		>
+			{placeholder && !value ? (
+				<LocationInputText $placeholder $disabled={disabled}>
+					{placeholder}
+				</LocationInputText>
+			) : (
+				<LocationInputText $disabled={disabled}>{value}</LocationInputText>
+			)}
+			<LocationIconWrapper $disabled={disabled} $readOnly={readOnly} aria-hidden="true">
+				<PinFillIcon />
+			</LocationIconWrapper>
+		</DummyLocationInput>
 	);
 };

--- a/src/components/fields/location-field/location-input/dummy-location-field.tsx
+++ b/src/components/fields/location-field/location-input/dummy-location-field.tsx
@@ -1,0 +1,61 @@
+import { PinFillIcon } from "@lifesg/react-icons/pin-fill";
+import {
+	DummyLocationInput,
+	LocationIconWrapper,
+	LocationInputGroup,
+	LocationInputText,
+} from "./location-input.styles";
+
+interface IDummyLocationFieldProps {
+	disabled?: boolean;
+	readOnly?: boolean;
+	placeholder?: string;
+	value?: string | number | readonly string[];
+	error?: boolean;
+	onFocus: (e: React.FocusEvent<HTMLInputElement, Element>) => void;
+}
+
+export const DummyLocationField = (props: IDummyLocationFieldProps) => {
+	const { disabled, readOnly, onFocus, value, placeholder, error } = props;
+
+	const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+		if (disabled) return;
+
+		e.currentTarget.focus();
+	};
+
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+		if (disabled) return;
+
+		if (e.key === "Enter" || e.key === " ") {
+			e.preventDefault();
+			e.currentTarget.click();
+		}
+	};
+
+	return (
+		<LocationInputGroup>
+			<DummyLocationInput
+				$disabled={disabled}
+				$readOnly={readOnly}
+				$error={error}
+				onFocus={onFocus}
+				onClick={handleClick}
+				onKeyDown={handleKeyDown}
+				tabIndex={disabled ? -1 : 0}
+				aria-disabled={disabled || undefined}
+			>
+				{placeholder && !value ? (
+					<LocationInputText $placeholder $disabled={disabled} aria-label={placeholder}>
+						{placeholder}
+					</LocationInputText>
+				) : (
+					<LocationInputText $disabled={disabled}>{value}</LocationInputText>
+				)}
+				<LocationIconWrapper $disabled={disabled} $readOnly={readOnly} aria-hidden="true">
+					<PinFillIcon />
+				</LocationIconWrapper>
+			</DummyLocationInput>
+		</LocationInputGroup>
+	);
+};

--- a/src/components/fields/location-field/location-input/location-input.styles.ts
+++ b/src/components/fields/location-field/location-input/location-input.styles.ts
@@ -1,0 +1,131 @@
+import { Color, DesignToken, TextStyleHelper } from "@lifesg/react-design-system";
+import styled, { css } from "styled-components";
+
+interface InputWrapperStyleProps {
+	$disabled?: boolean | undefined;
+	$error?: boolean | undefined;
+	$readOnly?: boolean | undefined;
+	$focused?: boolean | undefined;
+}
+
+const readOnlyFocusCss = css`
+	border: 1px solid ${Color.Accent.Light[1]};
+	box-shadow: none;
+`;
+
+const disabledFocusCss = css`
+	border: 1px solid ${Color.Neutral[5]};
+	box-shadow: none;
+`;
+
+const errorFocusCss = css`
+	border: 1px solid ${Color.Validation.Red.Border};
+	box-shadow: ${DesignToken.InputErrorBoxShadow};
+`;
+
+export const LocationInputGroup = styled.div`
+	display: flex;
+	flex-direction: column;
+	:last-child {
+		margin-bottom: 2rem;
+	}
+`;
+
+export const DummyLocationInput = styled.div<InputWrapperStyleProps>`
+	border: 1px solid ${Color.Neutral[5]};
+	background: transparent;
+	height: 3rem;
+	border-radius: 4px;
+	padding: 0 1rem;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	${(props) => {
+		if (props.$readOnly) {
+			return css`
+				border: 1px solid transparent;
+				background: transparent !important;
+
+				:focus-within {
+					${readOnlyFocusCss}
+				}
+				${props.$focused && readOnlyFocusCss}
+			`;
+		} else if (props.$disabled) {
+			return css`
+				background: ${Color.Neutral[6]};
+				cursor: not-allowed;
+
+				:focus-within {
+					${disabledFocusCss}
+				}
+				${props.$focused && disabledFocusCss}
+			`;
+		} else if (props.$error) {
+			return css`
+				border: 1px solid ${Color.Validation.Red.Border};
+
+				:focus-within {
+					${errorFocusCss}
+				}
+				${props.$focused && errorFocusCss}
+			`;
+		}
+	}}
+`;
+
+export const LocationInputText = styled.span<{ $placeholder?: boolean; $disabled?: boolean }>`
+	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: clip;
+	white-space: nowrap;
+	cursor: text;
+	${TextStyleHelper.getTextStyle("Body", "regular")}
+	color: ${Color.Neutral[1]};
+	${(props) =>
+		props.$placeholder &&
+		css`
+			color: ${Color.Neutral[3]};
+		`}
+	${(props) =>
+		props.$disabled &&
+		css`
+			cursor: not-allowed;
+		`}
+`;
+
+export const LocationIconWrapper = styled.div<{ $disabled?: boolean; $readOnly?: boolean }>`
+	display: flex;
+	align-items: center;
+	svg {
+		height: 1.5rem;
+		width: 1.5rem;
+		#path {
+			fill: ${Color.Neutral[1]};
+		}
+	}
+	${(props) => {
+		if (props.$disabled) {
+			return css`
+				color: ${Color.Neutral[4](props)};
+				svg {
+					#path {
+						fill: ${Color.Neutral[4](props)};
+					}
+				}
+			`;
+		}
+		if (props.$readOnly) {
+			return css`
+				margin-left: ${props.$readOnly ? "0.25rem" : "0.75rem"};
+			`;
+		}
+	}}
+
+	${(props) => {
+		return css`
+			margin-left: ${props.$readOnly ? "0.25rem" : "0.75rem"};
+		`;
+	}}
+`;

--- a/src/components/fields/location-field/location-input/location-input.styles.ts
+++ b/src/components/fields/location-field/location-input/location-input.styles.ts
@@ -23,23 +23,16 @@ const errorFocusCss = css`
 	box-shadow: ${DesignToken.InputErrorBoxShadow};
 `;
 
-export const LocationInputGroup = styled.div`
-	display: flex;
-	flex-direction: column;
-	:last-child {
-		margin-bottom: 2rem;
-	}
-`;
-
 export const DummyLocationInput = styled.div<InputWrapperStyleProps>`
 	border: 1px solid ${Color.Neutral[5]};
-	background: transparent;
+	background: ${Color.Neutral[8]};
 	height: 3rem;
 	border-radius: 4px;
 	padding: 0 1rem;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
+	margin-bottom: 2rem;
 	${(props) => {
 		if (props.$readOnly) {
 			return css`

--- a/src/components/fields/location-field/location-input/location-input.tsx
+++ b/src/components/fields/location-field/location-input/location-input.tsx
@@ -9,7 +9,17 @@ export interface ILocationInputProps extends FormInputGroupProps<string, string>
 }
 
 export const LocationInput = (props: ILocationInputProps) => {
-	const { id, label, locationInputPlaceholder = "", onFocus, value, errorMessage, disabled, readOnly } = props;
+	const {
+		id,
+		label,
+		className,
+		locationInputPlaceholder = "",
+		onFocus,
+		value,
+		errorMessage,
+		disabled,
+		readOnly,
+	} = props;
 
 	return (
 		<Form.CustomField
@@ -25,6 +35,7 @@ export const LocationInput = (props: ILocationInputProps) => {
 				onFocus={onFocus}
 				value={value}
 				error={!!errorMessage}
+				className={className}
 			/>
 		</Form.CustomField>
 	);

--- a/src/components/fields/location-field/location-input/location-input.tsx
+++ b/src/components/fields/location-field/location-input/location-input.tsx
@@ -1,7 +1,7 @@
-import { PinFillIcon } from "@lifesg/react-icons/pin-fill";
 import { Form } from "@lifesg/react-design-system";
 import { FormInputGroupProps } from "@lifesg/react-design-system/form/types";
 import { TestHelper } from "../../../../utils";
+import { DummyLocationField } from "./dummy-location-field";
 
 export interface ILocationInputProps extends FormInputGroupProps<string, string> {
 	locationInputPlaceholder?: string | undefined;
@@ -9,38 +9,23 @@ export interface ILocationInputProps extends FormInputGroupProps<string, string>
 }
 
 export const LocationInput = (props: ILocationInputProps) => {
-	const {
-		className,
-		id,
-		label,
-		locationInputPlaceholder = "",
-		onFocus,
-		value,
-		errorMessage,
-		disabled,
-		readOnly,
-	} = props;
+	const { id, label, locationInputPlaceholder = "", onFocus, value, errorMessage, disabled, readOnly } = props;
 
 	return (
-		<Form.InputGroup
+		<Form.CustomField
 			id={TestHelper.generateId(id, "location-input")}
 			data-testid={TestHelper.generateId(id, "location-input")}
-			className={`${className}-location-input`}
-			role="button"
 			label={label}
-			addon={{
-				type: "custom",
-				attributes: {
-					children: <PinFillIcon />,
-				},
-				position: "right",
-			}}
-			disabled={disabled}
-			readOnly={readOnly}
-			onFocus={onFocus}
-			placeholder={locationInputPlaceholder}
-			value={value}
 			errorMessage={errorMessage}
-		/>
+		>
+			<DummyLocationField
+				disabled={disabled}
+				readOnly={readOnly}
+				placeholder={locationInputPlaceholder}
+				onFocus={onFocus}
+				value={value}
+				error={!!errorMessage}
+			/>
+		</Form.CustomField>
 	);
 };


### PR DESCRIPTION
**Changes**
Description of changes

- Replaced the location input field with a dummy input component
- Ensures the field behaves like an input visually, but does not trigger the keyboard

<!-- Remove if not required -->

**Changelog entry**

- Fixed an issue on iOS26 where opening the keyboard caused the location modal to resize incorrectly by replacing the location input with a non-editable dummy input

**Additional information**

-   You may refer to this [ticket](https://sgtechstack.atlassian.net/browse/MOL-19467)
-   Any other information you would like to include
