### PR TITLE
[MOL-19467][MA] Replace location input with dummy button to prevent iOS26 location modal resize issue

### DIFF
--- a/src/__tests__/components/fields/location-field/location-field.spec.tsx
+++ b/src/__tests__/components/fields/location-field/location-field.spec.tsx
@@ -307,7 +307,7 @@ const getLocationSearchButton = (query = false) => {
 };
 
 const getLocationInput = (query = false) => {
-	return within(testIdCmd(query)(TestHelper.generateId(COMPONENT_ID, "location-input"))).getByTestId("input");
+	return testIdCmd(query)(TestHelper.generateId(COMPONENT_ID, "location-input-base"));
 };
 
 const getLocationSearchClearButton = (query = false) => {
@@ -563,7 +563,7 @@ describe("location-input-group", () => {
 				expect(screen.getByTestId(COMPONENT_ID)).toBeInTheDocument();
 				expect(screen.getByLabelText(LABEL)).toBeInTheDocument();
 
-				screen.getByTestId("input").focus();
+				screen.getByTestId(TestHelper.generateId(COMPONENT_ID, "location-input-base")).focus();
 
 				expect(setCurrentLocationSpy).toBeCalled();
 
@@ -604,7 +604,7 @@ describe("location-input-group", () => {
 				expect(screen.getByTestId(COMPONENT_ID)).toBeInTheDocument();
 				expect(screen.getByLabelText(LABEL)).toBeInTheDocument();
 
-				screen.getByTestId("input").focus();
+				screen.getByTestId(TestHelper.generateId(COMPONENT_ID, "location-input-base")).focus();
 
 				expect(setCurrentLocationSpy).toBeCalled();
 
@@ -1625,7 +1625,7 @@ describe("location-input-group", () => {
 					await renderComponent();
 
 					await waitFor(() =>
-						fireEvent.click(screen.getByTestId(TestHelper.generateId(COMPONENT_ID, "location-input")))
+						fireEvent.click(screen.getByTestId(TestHelper.generateId(COMPONENT_ID, "location-input-base")))
 					);
 
 					await waitFor(() => window.dispatchEvent(new Event("offline")));
@@ -1639,7 +1639,7 @@ describe("location-input-group", () => {
 					await renderComponent();
 
 					await waitFor(() =>
-						fireEvent.click(screen.getByTestId(TestHelper.generateId(COMPONENT_ID, "location-input")))
+						fireEvent.click(screen.getByTestId(TestHelper.generateId(COMPONENT_ID, "location-input-base")))
 					);
 
 					await waitFor(() => window.dispatchEvent(new Event("offline")));

--- a/src/components/fields/location-field/location-field.tsx
+++ b/src/components/fields/location-field/location-field.tsx
@@ -106,13 +106,12 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 		setValue(id, updatedValues, { shouldDirty });
 	};
 
-	const handleFocus = (e?: React.FocusEvent<HTMLInputElement, Element>) => {
+	const handleFocus = () => {
 		if (readOnly || disabled) {
 			return;
 		}
 		setShowLocationModal(true);
 		dispatchFieldEvent("show-location-modal", id);
-		e?.currentTarget.blur();
 	};
 
 	const handleClose = () => {

--- a/src/components/fields/location-field/location-input/dummy-location-field.tsx
+++ b/src/components/fields/location-field/location-input/dummy-location-field.tsx
@@ -1,0 +1,53 @@
+import { PinFillIcon } from "@lifesg/react-icons/pin-fill";
+import { DummyLocationInput, LocationIconWrapper, LocationInputText } from "./location-input.styles";
+
+interface IDummyLocationFieldProps {
+	id?: string | undefined;
+	"data-testid"?: string | undefined;
+	disabled?: boolean | undefined;
+	readOnly?: boolean | undefined;
+	placeholder?: string | undefined;
+	value?: string | number | readonly string[] | undefined;
+	error?: boolean | undefined;
+	onFocus: React.FocusEventHandler<HTMLElement>;
+	className?: string | undefined;
+}
+
+export const DummyLocationField = (props: IDummyLocationFieldProps) => {
+	const { id, "data-testid": dataTestId, className, disabled, readOnly, onFocus, value, placeholder, error } = props;
+
+	const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+		if (disabled) return;
+
+		e.currentTarget.focus();
+	};
+
+	return (
+		<DummyLocationInput
+			id={id}
+			data-testid={dataTestId}
+			type="button"
+			className={className}
+			disabled={disabled}
+			$readOnly={readOnly}
+			$error={error}
+			onFocus={onFocus}
+			onClick={handleClick}
+			tabIndex={disabled ? -1 : 0}
+			aria-disabled={disabled || undefined}
+			aria-haspopup="dialog"
+			aria-readonly={readOnly}
+		>
+			{placeholder && !value ? (
+				<LocationInputText $placeholder $disabled={disabled}>
+					{placeholder}
+				</LocationInputText>
+			) : (
+				<LocationInputText $disabled={disabled}>{value}</LocationInputText>
+			)}
+			<LocationIconWrapper $disabled={disabled} $readOnly={readOnly} aria-hidden="true">
+				<PinFillIcon />
+			</LocationIconWrapper>
+		</DummyLocationInput>
+	);
+};

--- a/src/components/fields/location-field/location-input/location-input.styles.ts
+++ b/src/components/fields/location-field/location-input/location-input.styles.ts
@@ -1,0 +1,120 @@
+import { Border, Colour, Font, Radius, Shadow, Spacing } from "@lifesg/react-design-system/theme";
+import styled, { css } from "styled-components";
+
+interface InputWrapperStyleProps {
+	disabled?: boolean | undefined;
+	$error?: boolean | undefined;
+	$readOnly?: boolean | undefined;
+	$focused?: boolean | undefined;
+}
+
+const readOnlyFocusCss = css`
+	border: ${Border["width-010"]} ${Border["solid"]} ${Colour["border-focus"]};
+	box-shadow: none;
+`;
+
+const disabledFocusCss = css`
+	border: ${Border["width-010"]} ${Border["solid"]} ${Colour["border"]};
+	box-shadow: none;
+`;
+
+const errorFocusCss = css`
+	border: ${Border["width-010"]} ${Border["solid"]} ${Colour["border-error"]};
+	box-shadow: ${Shadow["xs-error-strong"]};
+`;
+
+export const DummyLocationInput = styled.button<InputWrapperStyleProps>`
+	border: ${Border["width-010"]} ${Border["solid"]} ${Colour["border"]};
+	border-radius: ${Radius["sm"]};
+	background: ${Colour["bg"]};
+	height: ${Spacing["spacing-48"]};
+	padding: ${Spacing["spacing-0"]} ${Spacing["spacing-16"]};
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	${(props) => {
+		if (props.$readOnly) {
+			return css`
+				border: ${Border["width-010"]} ${Border["solid"]} transparent;
+				background: transparent !important;
+				:focus-within {
+					${readOnlyFocusCss}
+				}
+				${props.$focused && readOnlyFocusCss}
+			`;
+		} else if (props.disabled) {
+			return css`
+				background: ${Colour["bg-stronger"]};
+				cursor: not-allowed;
+				:focus-within {
+					${disabledFocusCss}
+				}
+				${props.$focused && disabledFocusCss}
+			`;
+		} else if (props.$error) {
+			return css`
+				border: ${Border["width-010"]} ${Border["solid"]} ${Colour["border-error"]};
+				:focus-within {
+					${errorFocusCss}
+				}
+				${props.$focused && errorFocusCss};
+			`;
+		}
+	}}
+`;
+
+export const LocationInputText = styled.span<{ $placeholder?: boolean; $disabled?: boolean }>`
+	flex: 1 1 auto;
+	min-width: ${Spacing["spacing-0"]};
+	overflow: hidden;
+	text-overflow: clip;
+	white-space: nowrap;
+	cursor: text;
+	text-align: left;
+	${Font["body-baseline-regular"]};
+	color: ${Colour["text"]};
+	${(props) =>
+		props.$placeholder &&
+		css`
+			color: ${Colour["text-subtler"]};
+		`}
+	${(props) =>
+		props.$disabled &&
+		css`
+			cursor: not-allowed;
+		`}
+`;
+
+export const LocationIconWrapper = styled.div<{ $disabled?: boolean; $readOnly?: boolean }>`
+	display: flex;
+	align-items: center;
+	svg {
+		height: ${Spacing["spacing-24"]};
+		width: ${Spacing["spacing-24"]};
+		#path {
+			fill: ${Colour["text"]};
+		}
+	}
+	${(props) => {
+		if (props.$disabled) {
+			return css`
+				color: ${Colour.Primitive["neutral-70"](props)};
+				svg {
+					#path {
+						fill: ${Colour.Primitive["neutral-70"](props)};
+					}
+				}
+			`;
+		}
+		if (props.$readOnly) {
+			return css`
+				margin-left: ${props.$readOnly ? Spacing["spacing-4"] : Spacing["spacing-12"]};
+			`;
+		}
+	}}
+	${(props) => {
+		return css`
+			margin-left: ${props.$readOnly ? Spacing["spacing-4"] : Spacing["spacing-12"]};
+		`;
+	}}
+`;

--- a/src/components/fields/location-field/location-input/location-input.tsx
+++ b/src/components/fields/location-field/location-input/location-input.tsx
@@ -1,7 +1,7 @@
-import { PinFillIcon } from "@lifesg/react-icons/pin-fill";
 import { Form } from "@lifesg/react-design-system/form";
 import { FormInputGroupProps } from "@lifesg/react-design-system/form/types";
 import { TestHelper } from "../../../../utils";
+import { DummyLocationField } from "./dummy-location-field";
 
 export interface ILocationInputProps extends FormInputGroupProps<string, string> {
 	locationInputPlaceholder?: string | undefined;
@@ -22,25 +22,23 @@ export const LocationInput = (props: ILocationInputProps) => {
 	} = props;
 
 	return (
-		<Form.InputGroup
+		<Form.CustomField
 			id={TestHelper.generateId(id, "location-input")}
 			data-testid={TestHelper.generateId(id, "location-input")}
-			className={`${className}-location-input`}
-			role="button"
 			label={label}
-			addon={{
-				type: "custom",
-				attributes: {
-					children: <PinFillIcon />,
-				},
-				position: "right",
-			}}
-			disabled={disabled}
-			readOnly={readOnly}
-			onFocus={onFocus}
-			placeholder={locationInputPlaceholder}
-			value={value}
 			errorMessage={errorMessage}
-		/>
+		>
+			<DummyLocationField
+				id={TestHelper.generateId(id, "location-input-base")}
+				data-testid={TestHelper.generateId(id, "location-input-base")}
+				disabled={disabled}
+				readOnly={readOnly}
+				placeholder={locationInputPlaceholder}
+				onFocus={onFocus}
+				value={value}
+				error={!!errorMessage}
+				className={className}
+			/>
+		</Form.CustomField>
 	);
 };


### PR DESCRIPTION
**Changes**
Description of changes

- Replaced the location input field with a dummy button component
- Ensures the field behaves like an input visually, but does not trigger the keyboard
- Updated failing tests to reference the new dummy location field

<!-- Remove if not required -->

**Changelog entry**

- Fixed an issue on iOS26 where opening the keyboard caused the location modal to resize incorrectly by replacing the location input with a non-editable dummy button

**Additional information**

-   You may refer to this [ticket](https://sgtechstack.atlassian.net/browse/MOL-19467)
