### PR TITLE
[BOOKINGSG-7967][JEFF] fix empty array options throw error when submit

### DIFF
--- a/src/components/fields/multi-select/multi-select.tsx
+++ b/src/components/fields/multi-select/multi-select.tsx
@@ -1,7 +1,7 @@
 import { Form } from "@lifesg/react-design-system/form";
 import { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
-import useDeepCompareEffect from "use-deep-compare-effect";
+import { useDeepCompareEffectNoCheck } from "use-deep-compare-effect";
 import * as Yup from "yup";
 import { IGenericFieldProps } from "..";
 import { TestHelper } from "../../../utils";
@@ -19,7 +19,7 @@ export const MultiSelect = (props: IGenericFieldProps<IMultiSelectSchema>) => {
 		formattedLabel,
 		id,
 		onChange,
-		schema: { label: _label, options, validation, ...otherSchema },
+		schema: { label: _label, options = [], validation, ...otherSchema },
 		value,
 		warning,
 		...otherProps
@@ -53,7 +53,7 @@ export const MultiSelect = (props: IGenericFieldProps<IMultiSelectSchema>) => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [validation]);
 
-	useDeepCompareEffect(() => {
+	useDeepCompareEffectNoCheck(() => {
 		const updatedValues = value?.filter((v) => options.find((option) => option.value === v));
 		setValue(id, updatedValues);
 	}, [options]);

--- a/src/components/fields/nested-multi-select/nested-multi-select.tsx
+++ b/src/components/fields/nested-multi-select/nested-multi-select.tsx
@@ -2,7 +2,7 @@ import { L1OptionProps } from "@lifesg/react-design-system";
 import { Form } from "@lifesg/react-design-system/form";
 import { useCallback, useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
-import useDeepCompareEffect from "use-deep-compare-effect";
+import { useDeepCompareEffectNoCheck } from "use-deep-compare-effect";
 import * as Yup from "yup";
 import { IGenericFieldProps } from "..";
 import { TestHelper } from "../../../utils";
@@ -15,7 +15,7 @@ export const NestedMultiSelect = (props: IGenericFieldProps<INestedMultiSelectSc
 	// CONST, STATE, REFS
 	// =============================================================================
 	const {
-		schema: { label: _label, validation, options, ...otherSchema },
+		schema: { label: _label, validation, options = [], ...otherSchema },
 		id,
 		value,
 		formattedLabel,
@@ -73,7 +73,7 @@ export const NestedMultiSelect = (props: IGenericFieldProps<INestedMultiSelectSc
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [validation]);
 
-	useDeepCompareEffect(() => {
+	useDeepCompareEffectNoCheck(() => {
 		const findValueInOptions = (options: TL1OptionProps[], nested: TNestedValues): TNestedValues | string => {
 			const result: TNestedValues = {};
 


### PR DESCRIPTION
**Changes**
Description of changes

- Replaced useDeepCompareEffect to useDeepCompareEffectNoCheck in MultiSelect and NestedMultiSelect component
- Add default options value to an empty array

<!-- Remove if not required -->

**Changelog entry**

-   Fix empty array options throw error when validating in MultiSelect and NestedMultiSelect component

**Additional information**

-   You may refer to this [ticket](https://sgtechstack.atlassian.net/browse/BOOKINGSG-7967)
- Previously, when the options prop was empty, the validation inside useDeepCompareEffect failed, causing an error. By switching to useDeepCompareEffectNoCheck and ensuring options defaults to an empty array, the components can safely handle scenarios where the API fails or returns no data. This allows the process to continue without blocking the workflow, and services can still be added later once data becomes available.
