### PR TITLE
Relax Floating UI peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
 				"@babel/preset-env": "^7.19.3",
 				"@babel/preset-react": "^7.18.6",
 				"@babel/preset-typescript": "^7.18.6",
-				"@floating-ui/dom": "^1.6.10",
 				"@floating-ui/react": "^0.26.23",
 				"@lifesg/react-design-system": "^3.0.0-alpha.22",
 				"@lifesg/react-icons": "^1.9.0",
@@ -101,8 +100,7 @@
 				"typescript": "^4.8.4"
 			},
 			"peerDependencies": {
-				"@floating-ui/dom": "^1.6.10",
-				"@floating-ui/react": "^0.26.23",
+				"@floating-ui/react": ">=0.26.23 <1.0.0",
 				"@lifesg/react-design-system": "^3.0.0-alpha.22",
 				"@lifesg/react-icons": "^1.9.0",
 				"react": "^17.0.2 || ^18.0.0",

--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
 		"yup": "^0.32.11"
 	},
 	"peerDependencies": {
-		"@floating-ui/dom": "^1.6.10",
-		"@floating-ui/react": "^0.26.23",
+		"@floating-ui/react": ">=0.26.23 <1.0.0",
 		"@lifesg/react-design-system": "^3.0.0-alpha.22",
 		"@lifesg/react-icons": "^1.9.0",
 		"react": "^17.0.2 || ^18.0.0",
@@ -70,7 +69,6 @@
 		"@babel/preset-env": "^7.19.3",
 		"@babel/preset-react": "^7.18.6",
 		"@babel/preset-typescript": "^7.18.6",
-		"@floating-ui/dom": "^1.6.10",
 		"@floating-ui/react": "^0.26.23",
 		"@lifesg/react-design-system": "^3.0.0-alpha.22",
 		"@lifesg/react-icons": "^1.9.0",


### PR DESCRIPTION
**Changes**

- updated peer dependencies
- removed @floating-ui/dom as it's not actually needed for @floating-ui/react
- relaxed the version for @floating-ui/react to allow all minors, the caret doesn't work for 0.x version
-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Update `@floating-ui/react` peer dependency range to allow `>=0.26` minor versions and remove `@floating-ui/dom`
