### PR TITLE
Use fixed spacing for accordion content

### DIFF
--- a/src/components/elements/accordion/accordion.styles.ts
+++ b/src/components/elements/accordion/accordion.styles.ts
@@ -1,7 +1,9 @@
-import { Spacing } from "@lifesg/react-design-system/theme";
+import { MediaQuery, Spacing } from "@lifesg/react-design-system/theme";
 import styled from "styled-components";
 
 export const Container = styled.div`
-	flex: 1;
-	padding: ${Spacing["spacing-32"]} 0;
+	padding: ${Spacing["spacing-32"]};
+	${MediaQuery.MaxWidth.sm} {
+		padding: ${Spacing["spacing-32"]} ${Spacing["spacing-20"]};
+	}
 `;

--- a/src/components/elements/accordion/accordion.tsx
+++ b/src/components/elements/accordion/accordion.tsx
@@ -1,6 +1,5 @@
 import { BoxContainer } from "@lifesg/react-design-system/box-container";
 import { Button } from "@lifesg/react-design-system/button";
-import { V2_Layout } from "@lifesg/react-design-system/v2_layout";
 import { useFieldEvent } from "../../../utils/hooks";
 import { IGenericElementProps } from "../types";
 import { Wrapper } from "../wrapper";
@@ -39,11 +38,9 @@ export const Accordion = (props: IGenericElementProps<IAccordionSchema>) => {
 			{disableContentInset ? (
 				<Wrapper id={id}>{children}</Wrapper>
 			) : (
-				<V2_Layout.Content>
-					<Container>
-						<Wrapper id={id}>{children}</Wrapper>
-					</Container>
-				</V2_Layout.Content>
+				<Container>
+					<Wrapper id={id}>{children}</Wrapper>
+				</Container>
 			)}
 		</BoxContainer>
 	);


### PR DESCRIPTION
**Changes**

- fixes misalignment of spacing, most obvious on tablet/mobile when container stretches the full width of the viewport
-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Update `accordion` to align default horizontal spacing of content with title