### PR TITLE
Register validation for `filter-checkbox` to trigger onChange

### DIFF
--- a/src/components/custom/filter/filter-checkbox/filter-checkbox.tsx
+++ b/src/components/custom/filter/filter-checkbox/filter-checkbox.tsx
@@ -2,7 +2,9 @@ import { Filter } from "@lifesg/react-design-system/filter";
 import { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import useDeepCompareEffect from "use-deep-compare-effect";
+import * as Yup from "yup";
 import { TestHelper } from "../../../../utils";
+import { useValidationConfig } from "../../../../utils/hooks";
 import { Sanitize } from "../../../shared";
 import { IGenericCustomFieldProps } from "../../types";
 import { FilterHelper } from "../filter-helper";
@@ -13,7 +15,7 @@ export const FilterCheckbox = (props: IGenericCustomFieldProps<IFilterCheckboxSc
 	// CONST, STATE, REFS
 	// =============================================================================
 	const {
-		schema: { label, options, expanded, ...otherSchema },
+		schema: { label, options, expanded, validation, ...otherSchema },
 		id,
 		value,
 		onChange,
@@ -22,6 +24,7 @@ export const FilterCheckbox = (props: IGenericCustomFieldProps<IFilterCheckboxSc
 	const { setValue } = useFormContext();
 	const [selectedOptions, setSelectedOptions] = useState<IOption[]>(); // Current selected value state
 	const [expandedState, setExpandedState] = useState(expanded);
+	const { setFieldValidationConfig } = useValidationConfig();
 	const { title, addon } = FilterHelper.constructFormattedLabel(label, id);
 
 	// =============================================================================
@@ -45,6 +48,10 @@ export const FilterCheckbox = (props: IGenericCustomFieldProps<IFilterCheckboxSc
 	// =============================================================================
 	// EFFECTS
 	// =============================================================================
+	useEffect(() => {
+		setFieldValidationConfig(id, Yup.array().of(Yup.string()), validation);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [validation]);
 
 	useDeepCompareEffect(() => {
 		const flatOptions = flattenOptions(options);

--- a/src/components/custom/filter/filter-checkbox/types.ts
+++ b/src/components/custom/filter/filter-checkbox/types.ts
@@ -2,8 +2,7 @@ import { IBaseCustomFieldSchema } from "../../types";
 import { TClearBehavior } from "../filter/types";
 import { IFilterItemLabel } from "../types";
 
-export interface IFilterCheckboxSchema<V = undefined>
-	extends Omit<IBaseCustomFieldSchema<"filter-checkbox", V>, "validation"> {
+export interface IFilterCheckboxSchema<V = undefined> extends IBaseCustomFieldSchema<"filter-checkbox", V> {
 	label: string | IFilterItemLabel;
 	options: IOption[];
 	collapsible?: boolean | undefined;


### PR DESCRIPTION
**Changes**

`onChange` won’t be triggered in FEE when using only the Filter Checkbox because of this line in `src/components/frontend-engine/use-form-change.ts`

```
if (onChange && Object.keys(formValidationConfig || {}).length) {
```

The Filter Checkbox does not contribute to `formValidationConfig` so the listener is never subscribed

The solution here is to register the field, even though it technically does not have validation

-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Fix issue where `onChange` is not triggered when only `filter-checkbox` is used
