### PR TITLE
Fix incorrect parent checkbox state

### DIFF
--- a/src/components/custom/filter/filter-checkbox/filter-checkbox.tsx
+++ b/src/components/custom/filter/filter-checkbox/filter-checkbox.tsx
@@ -88,6 +88,7 @@ export const FilterCheckbox = (props: IGenericCustomFieldProps<IFilterCheckboxSc
 			expanded={expandedState}
 			onExpandChange={setExpandedState}
 			onSelect={handleChange}
+			valueExtractor={(item) => (isParentOption(item) ? item.key : item.value)}
 			labelExtractor={(item) => (
 				<Sanitize inline sanitizeOptions={{ allowedAttributes: false }}>
 					{item.label}


### PR DESCRIPTION
**Changes**

- sets the `valueExtractor` so that the DS can pick up the item value as part of the key path
-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Fix incorrect parent checkbox state in `filter-checkbox`