### PR TITLE
[MOL-19714][NL] Wait for all images to load before showing the review modal

### DIFF
--- a/src/components/fields/image-upload/image-upload.tsx
+++ b/src/components/fields/image-upload/image-upload.tsx
@@ -160,6 +160,9 @@ export const ImageUploadInner = (props: IGenericFieldProps<IImageUploadSchema>) 
 	}, [validation]);
 
 	useEffect(() => {
+		const hasUnloadedImages = images.some((img) => img.status === EImageStatus.NONE);
+		if (hasUnloadedImages) return; // Waiting for all images to load
+
 		images.some((image, index) => {
 			const previousFile = previousImages?.[index];
 			if (image.status !== previousFile?.status || image.dataURL !== previousFile.dataURL) {


### PR DESCRIPTION
**Changes**
- Wait for all images to load before showing the review modal by checking if any image has a None status — the default status when images are are being uploaded.

-   delete branch

**Additional information**

-   You may refer to this [MOL-19714](https://sgtechstack.atlassian.net/browse/MOL-19714)
-  The issue:  if a user uploads multiple images and one or more load slower than the others (specifically with HEIC images), the review modal on mobile (or review prompt on larger screens) can pop up twice.
- Another way to fix this is by updating reviewSaveDisabled in image-review.tsx to cover images added via dragInput, but this only works on mobile view — it won’t prevent the review prompt from appearing twice on larger screens.
