### PR TITLE
[MOL-19744][TC]Fix Image-upload trigger when press enter

### DIFF
--- a/src/components/fields/image-upload/image-input/image-input.tsx
+++ b/src/components/fields/image-upload/image-input/image-input.tsx
@@ -145,6 +145,7 @@ export const ImageInput = (props: IImageInputProps) => {
 		return (
 			<UploadWrapper>
 				<AddButton
+					type="button"
 					onClick={handleClick}
 					styleType="secondary"
 					id={TestHelper.generateId(id, "file-input-add-button")}


### PR DESCRIPTION
**Changes**
Fixed image upload button being triggered when pressing Enter in other form fields. Added `type="button"` attribute to prevent the "Add photos" button and other custom buttons in image upload components from being treated as submit buttons.

**Changelog entry**
- Fixed image upload dialog opening unexpectedly when pressing Enter in other form fields

**Additional information**
- This fixes the issue where pressing Enter while focused on any input field in a form would unintentionally trigger the image upload file dialog
- Added `type="button"` to the following buttons:
  - `AddButton` in `ImageInput` component (main "Add photos" button)
- Buttons using design system components (`Button.Default`, `IconButton`) already had correct type attributes
- This change improves form UX by preventing accidental file dialog triggers during normal form navigation

You may refer to this [ticket](https://sgtechstack.atlassian.net/browse/MOL-19744)