### PR TITLE
[MOL-19749][TC]Fix Location Picker during rapid mobile selections

### DIFF
--- a/src/components/fields/location-field/location-modal/location-modal.styles.ts
+++ b/src/components/fields/location-field/location-modal/location-modal.styles.ts
@@ -45,9 +45,10 @@ export const StyledLocationPicker = styled(LocationPicker)<ISinglePanelStyle>`
 	width: 48.89%;
 
 	${MediaQuery.MaxWidth.lg}, (orientation: landscape) and (max-height: ${Breakpoint["sm-max"]}px) {
-		display: ${({ panelInputMode }) => (panelInputMode !== "map" ? "none" : "block")};
-		position: relative;
-		left: 0;
+		/* Keep map mounted but control visibility to prevent coordinate corruption */
+		display: block;
+		visibility: ${({ panelInputMode }) => (panelInputMode !== "map" ? "hidden" : "visible")};
+		pointer-events: ${({ panelInputMode }) => (panelInputMode !== "map" ? "none" : "auto")};
 		width: 100%;
 		margin-top: ${Spacing["spacing-16"]};
 		height: calc(100% - 13rem);


### PR DESCRIPTION
**Changes**
Fixed "Invalid LatLng object: (NaN, NaN)" errors during rapid mobile location selections by updating CSS approach for map container visibility.

- Changed from `display: none` to `visibility: hidden` + `pointer-events: none` in mobile media queries
- Preserves container dimensions required for Leaflet coordinate calculations
- Eliminates timing race conditions during rapid panel mode switches

**Changelog entry**

-   Fixed NaN coordinate errors during rapid mobile selections in location field component

**Additional information**

-   **Root Cause**: `display: none` caused map container to have 0px dimensions, breaking Leaflet's coordinate transformation math during rapid mobile interactions
-   **Solution**: Container now maintains dimensions (576.09px × 0px) when hidden, allowing valid coordinate calculations while preserving clean mobile UX
-   **Validation**: No console errors during rapid mobile selections, smooth map animations maintained
- You can refer to this [ticket](https://sgtechstack.atlassian.net/browse/MOL-19749)
and this [thread](https://gahmen.slack.com/archives/CKQNKC8TE/p1761788209896079)