### PR TITLE
[MOL-19835][TIEN] track user interaction using isInteracted instead o…

### DIFF
--- a/src/components/fields/date-field/date-field.tsx
+++ b/src/components/fields/date-field/date-field.tsx
@@ -34,6 +34,7 @@ export const DateField = (props: IGenericFieldProps<IDateFieldSchema>) => {
 	const { setValue } = useFormContext();
 	const [stateValue, setStateValue] = useState<string>(value || ""); // always uuuu-MM-dd because it is passed to Form.DateInput
 	const [derivedProps, setDerivedProps] = useState<Pick<DateInputProps, "minDate" | "maxDate" | "disabledDates">>();
+	const [isInteracted, setIsInteracted] = useState<boolean>(false);
 	const { setFieldValidationConfig } = useValidationConfig();
 	// =============================================================================
 	// EFFECTS
@@ -180,7 +181,7 @@ export const DateField = (props: IGenericFieldProps<IDateFieldSchema>) => {
 		if (!dateFormat) return;
 
 		if (!value) {
-			if (!isDirty) {
+			if (!isInteracted) {
 				// runs on mount and reset
 				if (useCurrentDate) {
 					const currentDate = DateTimeHelper.formatDateTime(LocalDate.now().toString(), dateFormat, "date");
@@ -210,12 +211,13 @@ export const DateField = (props: IGenericFieldProps<IDateFieldSchema>) => {
 			);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [useCurrentDate, value, dateFormat, isDirty]);
+	}, [useCurrentDate, value, dateFormat, isInteracted]);
 
 	// =============================================================================
 	// EVENT HANDLER
 	// =============================================================================
 	const handleChange = (value: string) => {
+		setIsInteracted(true);
 		onChange({
 			target: {
 				value: DateTimeHelper.formatDateTime(value, dateFormat, "date", ERROR_MESSAGES.DATE.INVALID),


### PR DESCRIPTION
**Change log**

**Issue**
- `isDirty` does not behave correctly: when `useCurrentDate` is enabled and the user manually clears the field and blurs, field takes the value as current date instead of undefined, and `isDirty` not change.
- This also prevents required validation from triggering and the error message "_This field is required_" does not appear.
- Can refer to this ticket [MOL-19835](https://sgtechstack.atlassian.net/jira/software/c/projects/MOL/boards/1861?selectedIssue=MOL-19835&sprints=27533)

**Change**
- Apply a local state `isInteracted` to track whether the user has interacted with the field.
- This replaces reliance on `isDirty` and ensures that once the user clears the input, the field set value `undefined`, allowing required validation