### PR TITLE
[MOL-19938]Add fieldType to e-signature and file-upload multipart upload requests

### DIFF
--- a/src/__tests__/components/fields/e-signature-field/e-signature-field.spec.tsx
+++ b/src/__tests__/components/fields/e-signature-field/e-signature-field.spec.tsx
@@ -3,7 +3,7 @@ import { setupJestCanvasMock } from "jest-canvas-mock";
 import cloneDeep from "lodash/cloneDeep";
 import merge from "lodash/merge";
 import { FrontendEngine, IFrontendEngineData, IFrontendEngineRef } from "../../../../components";
-import { IESignatureFieldSchema } from "../../../../components/fields";
+import { EFieldType, IESignatureFieldSchema } from "../../../../components/fields";
 import { ERROR_MESSAGES } from "../../../../components/shared";
 import { AxiosApiClient, FileHelper } from "../../../../utils";
 import {
@@ -167,6 +167,8 @@ describe(UI_TYPE, () => {
 					headers: { "Content-Type": "multipart/form-data" },
 				})
 			);
+			const formData = [...(uploadSpy.mock.lastCall[1] as FormData).entries()];
+			expect(formData).toContainEqual(["fieldType", EFieldType["E-SIGNATURE-FIELD"]]);
 		});
 
 		it("should show error message with retry button and dismiss the loading indicator if upload fails", async () => {

--- a/src/__tests__/components/fields/file-upload/file-upload.spec.tsx
+++ b/src/__tests__/components/fields/file-upload/file-upload.spec.tsx
@@ -5,7 +5,12 @@ import { useEffect, useRef } from "react";
 import { FrontendEngine } from "../../../../components";
 import { IFileUploadSchema, TFileUploadErrorMessage, TUploadType } from "../../../../components/fields";
 import { ERROR_MESSAGES } from "../../../../components/shared";
-import { IFrontendEngineData, IFrontendEngineProps, IFrontendEngineRef } from "../../../../components/types";
+import {
+	EFieldType,
+	IFrontendEngineData,
+	IFrontendEngineProps,
+	IFrontendEngineRef,
+} from "../../../../components/types";
 import { AxiosApiClient, FileHelper, ImageHelper } from "../../../../utils";
 import {
 	ERROR_MESSAGE,
@@ -529,6 +534,9 @@ describe(UI_TYPE, () => {
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
 			expect(uploadSpy).toHaveBeenCalledTimes(2);
+
+			const formData = [...(uploadSpy.mock.lastCall[1] as FormData).entries()];
+			expect(formData).toContainEqual(["fieldType", EFieldType["FILE-UPLOAD"]]);
 			expect(SUBMIT_FN).toHaveBeenCalledWith(
 				expect.objectContaining({
 					field: expect.arrayContaining([

--- a/src/components/fields/e-signature-field/e-signature-field.tsx
+++ b/src/components/fields/e-signature-field/e-signature-field.tsx
@@ -7,7 +7,7 @@ import * as Yup from "yup";
 import { AxiosApiClient, FileHelper, generateRandomId } from "../../../utils";
 import { useValidationConfig } from "../../../utils/hooks";
 import { ERROR_MESSAGES, Warning } from "../../shared";
-import { IGenericFieldProps } from "../types";
+import { EFieldType, IGenericFieldProps } from "../types";
 import { ESignatureWrapper, ErrorWrapper, RefreshAlert, TryAgain } from "./e-signature-field.styles";
 import { IESignatureFieldSchema, IESignatureFieldValidationRule, IESignatureValue } from "./types";
 
@@ -123,6 +123,7 @@ export const ESignatureField = (props: IGenericFieldProps<IESignatureFieldSchema
 			const blob = await FileHelper.dataUrlToBlob(signatureDataURL);
 			const file = FileHelper.blobToFile(blob, { name: fileId, lastModified: Date.now() });
 			formData.append("file", file, fileId);
+			formData.append("fieldType", EFieldType["E-SIGNATURE-FIELD"]);
 		}
 
 		const response = await new AxiosApiClient("", undefined, undefined, true).post(upload.url, formData, {

--- a/src/components/fields/file-upload/file-upload-manager.ts
+++ b/src/components/fields/file-upload/file-upload-manager.ts
@@ -13,6 +13,7 @@ import {
 	IFileUploadValue,
 	TUploadErrorDetail,
 } from "./types";
+import { EFieldType } from "../types";
 
 interface IProps {
 	compressImages: boolean;
@@ -308,6 +309,7 @@ const FileUploadManager = (props: IProps) => {
 		if (upload.type === "base64") {
 			formData.append("dataURL", fileToUpload.dataURL);
 		} else if (upload.type === "multipart") {
+			formData.append("fieldType", EFieldType["FILE-UPLOAD"]);
 			formData.append("file", fileToUpload.rawFile, fileToUpload.fileItem?.name);
 		}
 


### PR DESCRIPTION
**Changes**
- Add `fieldType` to `formData` of e-signature-field and file-upload for bạckend identification.
- Updated unit test to verify`fieldType` is included in multipart upload request

**Additional information**

-  Details in [MOL-19938](https://sgtechstack.atlassian.net/browse/MOL-19938)