### PR TITLE
[MOL-19094][TIEN] add font weight for ChipText

### DIFF
--- a/src/components/shared/chip/chip.styles.ts
+++ b/src/components/shared/chip/chip.styles.ts
@@ -1,4 +1,4 @@
-import { Border, Colour, Font } from "@lifesg/react-design-system/theme";
+import { Border, Colour } from "@lifesg/react-design-system/theme";
 import { Typography } from "@lifesg/react-design-system/typography";
 import styled, { css } from "styled-components";
 import { IChipButtonProps } from "./types";

--- a/src/components/shared/chip/chip.tsx
+++ b/src/components/shared/chip/chip.tsx
@@ -7,6 +7,6 @@ interface IProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, IChipBut
 
 export const Chip = ({ children, ...otherProps }: IProps) => (
 	<ChipButton type="button" aria-pressed={otherProps?.isActive} {...otherProps}>
-		<ChipText>{children}</ChipText>
+		<ChipText weight="semibold">{children}</ChipText>
 	</ChipButton>
 );


### PR DESCRIPTION
**CHANGE**

- After migrating DS to v3, `ChipText` component is missing the weight. 
- Previously, the weight was applied via the `Open Sans Semibold` font, but in v3 it should be applied using the weight prop.

**Solution**
- Add weight="semibold" to `ChipText`