### PR TITLE
[MOL-19095][TIEN] Fix imageReviewModalStyles type to use styled-components RuleSet

### DIFF
--- a/src/components/fields/image-upload/image-review/image-review.styles.ts
+++ b/src/components/fields/image-upload/image-review/image-review.styles.ts
@@ -1,25 +1,23 @@
-import { Border, Breakpoint, Colour, Font, MediaQuery, Radius, Spacing } from "@lifesg/react-design-system/theme";
 import { Button } from "@lifesg/react-design-system/button";
 import { IconButton } from "@lifesg/react-design-system/icon-button";
 import { Modal } from "@lifesg/react-design-system/modal";
+import { Border, Breakpoint, Colour, Font, MediaQuery, Radius, Spacing } from "@lifesg/react-design-system/theme";
 import { Typography } from "@lifesg/react-design-system/typography";
 import { BinIcon } from "@lifesg/react-icons/bin";
 import { EraserIcon } from "@lifesg/react-icons/eraser";
 import { PencilIcon } from "@lifesg/react-icons/pencil";
 import { PencilStrokeIcon } from "@lifesg/react-icons/pencil-stroke";
-import styled, { css } from "styled-components";
+import styled, { RuleSet, css } from "styled-components";
 
 interface IModalBoxStyle {
-	imageReviewModalStyles?: string | undefined;
+	imageReviewModalStyles?: RuleSet<object>;
 }
 
 export const ModalBox = styled(Modal.Box)<IModalBoxStyle>`
 	display: block;
 	max-height: fit-content;
 
-	${({ imageReviewModalStyles }) => {
-		if (imageReviewModalStyles) return `${imageReviewModalStyles}`;
-	}}
+	${(props) => props.imageReviewModalStyles}
 
 	${MediaQuery.MinWidth.xl} {
 		max-width: 42rem;

--- a/src/components/fields/image-upload/image-review/image-review.tsx
+++ b/src/components/fields/image-upload/image-review/image-review.tsx
@@ -32,6 +32,7 @@ import {
 	ReviewTitle,
 } from "./image-review.styles";
 import { ImageThumbnails } from "./image-thumbnails";
+import { RuleSet } from "styled-components";
 
 // lazy load to fix next.js SSR errors
 const ImageEditor = lazy(() => import("./image-editor"));
@@ -55,7 +56,7 @@ interface IProps extends ISharedImageProps {
 	show: boolean;
 	multiple?: boolean | undefined;
 	maxFilesErrorMessage?: string | undefined;
-	imageReviewModalStyles?: string | undefined;
+	imageReviewModalStyles?: RuleSet<object> | undefined;
 }
 
 export const ImageReview = (props: IProps) => {

--- a/src/components/fields/image-upload/types.ts
+++ b/src/components/fields/image-upload/types.ts
@@ -2,6 +2,7 @@ import { FabricObject } from "fabric";
 import { IBaseFieldSchema } from "../types";
 import { IYupValidationRule } from "../../../context-providers";
 import { TFieldEventListener } from "../../../utils";
+import { RuleSet } from "styled-components";
 
 export type TFileCapture = boolean | "user" | "environment" | undefined;
 export type TUploadMethod = "post" | "put" | "patch";
@@ -31,7 +32,7 @@ export interface IImageUploadSchema<V = undefined>
 	dimensions?: IImageDimensions | undefined;
 	capture?: TFileCapture | undefined;
 	multiple?: boolean | undefined;
-	imageReviewModalStyles?: string | undefined;
+	imageReviewModalStyles?: RuleSet<object> | undefined;
 }
 
 export interface ISharedImageProps {


### PR DESCRIPTION
**CHANGE**

- Updated the `imageReviewModalStyles` prop type from `string` to `RuleSet<object>` to correctly support styled-components interpolation.

**REASON**

- The previous implementation defined `imageReviewModalStyles` as a `string`, which does not properly support styled-components CSS interpolation. Switching to `RuleSet<object>` ensures better type safety and seamless integration with the css helper from styled-components.

- For example, passing MediaQuery.MaxWidth["sm"] as a string does not produce valid CSS because MediaQuery.MaxWidth["sm"] is a styled-components interpolation helper (i.e. a function). By using RuleSet<object>, we can pass a CSS block created with css\`` instead of a literal string, allowing styled-components to correctly process the styles.