### PR TITLE
Array field enhancements for legacy/v1

### DIFF
--- a/src/__tests__/components/custom/array-field/array-field.spec.tsx
+++ b/src/__tests__/components/custom/array-field/array-field.spec.tsx
@@ -284,6 +284,29 @@ describe(UI_TYPE, () => {
 			expect(getErrorMessage(true)).not.toBeInTheDocument();
 			expect(VALUE_CHANGE_FN).toHaveBeenCalledWith(expect.anything(), true);
 		});
+
+		it("should show confirmation modal when removing a section", async () => {
+			renderComponent();
+
+			fireEvent.click(getRemoveButton(0));
+
+			expect(screen.queryByText("Remove entry?")).toBeVisible();
+		});
+
+		it("should not show confirmation modal when disabled prop is true", async () => {
+			renderComponent({
+				removeConfirmationModal: { skip: true },
+			});
+
+			fireEvent.click(getRemoveButton(0));
+
+			expect(screen.queryByText("Remove entry?")).not.toBeInTheDocument();
+			expect(screen.queryByText("The information you’ve entered will be deleted.")).not.toBeVisible();
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: [] }));
+		});
 	});
 
 	it("should support customisation of buttons and confirmation modal", async () => {
@@ -314,7 +337,24 @@ describe(UI_TYPE, () => {
 			expect(getRemoveButton(0)).not.toBeInTheDocument();
 		});
 
-		it("should show error when min rule is not fulfilled", async () => {
+		it("should show default error when min rule is not fulfilled", async () => {
+			renderComponent(
+				{
+					validation: [{ min: 2 }],
+				},
+				{
+					defaultValues: {
+						[COMPONENT_ID]: [{ [TEXT_FIELD_ID]: "Hello" }],
+					},
+				}
+			);
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(screen.getByText("At least 2 entries must be provided")).toBeInTheDocument();
+		});
+
+		it("should show custom error when min rule is not fulfilled", async () => {
 			renderComponent({ validation: [{ min: 2, errorMessage: ERROR_MESSAGE }] });
 
 			fireEvent.change(getTextField(0), { target: { value: "Hello" } });
@@ -349,7 +389,20 @@ describe(UI_TYPE, () => {
 			expect(getRemoveButton(0)).toBeInTheDocument();
 		});
 
-		it("should show error when max rule is not fulfilled", async () => {
+		it("should show default error when max rule is not fulfilled", async () => {
+			renderComponent(
+				{ validation: [{ max: 1 }] },
+				{
+					defaultValues: { [COMPONENT_ID]: [{ [TEXT_FIELD_ID]: "Hello" }, { [TEXT_FIELD_ID]: "World" }] },
+				}
+			);
+
+			await waitFor(() => fireEvent.click(getSubmitButton()));
+
+			expect(screen.getByText("No more than 1 entry can be provided")).toBeInTheDocument();
+		});
+
+		it("should show custom error when max rule is not fulfilled", async () => {
 			renderComponent(
 				{ validation: [{ max: 1, errorMessage: ERROR_MESSAGE }] },
 				{

--- a/src/components/custom/array-field/array-field-element.tsx
+++ b/src/components/custom/array-field/array-field-element.tsx
@@ -1,7 +1,7 @@
 import isEqual from "lodash/isEqual";
 import { ForwardedRef, forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { useFormState } from "react-hook-form";
-import { useFormSchema, usePrevious } from "../../../utils/hooks";
+import { useCustomComponents, useFormSchema, usePrevious } from "../../../utils/hooks";
 import { FrontendEngine, TErrorPayload } from "../../frontend-engine";
 import { IFrontendEngineRef, TFrontendEngineFieldSchema, TFrontendEngineValues } from "../../types";
 
@@ -20,6 +20,7 @@ const Component = (
 	// CONST, STATE, REFS
 	// =============================================================================
 	const formRef = useRef<IFrontendEngineRef>(null);
+	const { customComponents } = useCustomComponents();
 	const [sectionValues, setSectionValues] = useState<TFrontendEngineValues>({});
 	const [defaultValues, setDefaultValues] = useState<TFrontendEngineValues>();
 	const { isSubmitting, isDirty } = useFormState();
@@ -92,6 +93,7 @@ const Component = (
 			}}
 			onValueChange={handleChange}
 			wrapInForm={false}
+			components={customComponents}
 		/>
 	);
 };

--- a/src/components/custom/array-field/array-field.styles.ts
+++ b/src/components/custom/array-field/array-field.styles.ts
@@ -12,6 +12,10 @@ interface InsetStyleProps {
 	$inset?: string | number;
 }
 
+interface RemoveButtonStyleProps {
+	$alignment?: "left" | "right";
+}
+
 // =============================================================================
 // STYLING
 // =============================================================================
@@ -39,7 +43,9 @@ export const SectionHeader = styled.div`
 	}
 `;
 
-export const RemoveButton = styled(ButtonWithIcon.Small)`
+export const RemoveButton = styled(ButtonWithIcon.Small)<RemoveButtonStyleProps>`
+	${({ $alignment }) => $alignment === "right" && "margin-left: auto;"}
+	${({ $alignment }) => $alignment === "left" && "margin-right: auto;"}
 	padding-left: 2rem;
 	padding-right: 2rem;
 

--- a/src/components/custom/array-field/array-field.tsx
+++ b/src/components/custom/array-field/array-field.tsx
@@ -90,7 +90,15 @@ export const ArrayField = (props: IGenericCustomFieldProps<IArrayFieldSchema>) =
 
 						return value.length > 0 && value.some((item) => !isEmpty(item));
 					}
-				),
+				)
+				.test("min-length", minRule?.errorMessage || ERROR_MESSAGES.ARRAY_FIELD.MIN(min), (value) => {
+					if (!value || min === undefined) return true;
+					return value.length >= min;
+				})
+				.test("max-length", maxRule?.errorMessage || ERROR_MESSAGES.ARRAY_FIELD.MAX(max), (value) => {
+					if (!value || max === undefined) return true;
+					return value.length <= max;
+				}),
 			validation
 		);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -156,18 +164,27 @@ export const ArrayField = (props: IGenericCustomFieldProps<IArrayFieldSchema>) =
 		onChange({ target: { value: newFormValues } });
 	};
 
+	const removeSectionAtIndex = (index: number) => {
+		const updatedValues = stateValue.filter((_, i) => i !== index);
+		const updatedKeys = stateKeys.filter((_, i) => i !== index);
+		setStateValue(updatedValues);
+		setStateKeys(updatedKeys);
+		onChange({ target: { value: updatedValues } });
+	};
+
 	const handleRemoveSection = (index: number) => {
-		setShowRemovePrompt(true);
+		if (removeConfirmationModal?.skip) {
+			removeSectionAtIndex(index);
+			return;
+		}
+
 		setIndexToRemove(index);
+		setShowRemovePrompt(true);
 	};
 
 	const handleConfirmRemove = () => {
-		const updatedValues = stateValue.filter((_, i) => i !== indexToRemove);
-		const updatedKeys = stateKeys.filter((_, i) => i !== indexToRemove);
-		setStateValue(updatedValues);
-		setStateKeys(updatedKeys);
+		removeSectionAtIndex(indexToRemove);
 		setShowRemovePrompt(false);
-		onChange({ target: { value: updatedValues } });
 	};
 
 	const handleCancelRemove = () => {
@@ -201,12 +218,29 @@ export const ArrayField = (props: IGenericCustomFieldProps<IArrayFieldSchema>) =
 	// =============================================================================
 	const showRemoveButton = min >= 0 ? stateValue.length > min : true;
 	const showAddButton = max >= 1 ? stateValue.length < max : true;
+	const removeButtonPosition = removeButton?.position ?? "top";
+	const removeButtonAlignment = removeButton?.alignment ?? "right";
+	const skipRemoveConfirmationModal = removeConfirmationModal?.skip === true;
 
 	const renderIcon = (icon: keyof typeof Icons) => {
 		const Element = Icons[icon];
 
 		return <Element />;
 	};
+
+	const renderRemoveButton = (index: number) => (
+		<RemoveButton
+			className="array-field-remove-button"
+			type="button"
+			styleType={removeButton?.styleType ?? "light"}
+			danger
+			$alignment={removeButtonAlignment}
+			icon={removeButton?.icon ? renderIcon(removeButton.icon) : undefined}
+			onClick={() => handleRemoveSection(index)}
+		>
+			{removeButton?.label ?? "Remove"}
+		</RemoveButton>
+	);
 
 	return (
 		<>
@@ -215,27 +249,20 @@ export const ArrayField = (props: IGenericCustomFieldProps<IArrayFieldSchema>) =
 				return (
 					<Fragment key={stateKeys[index]}>
 						<Inset $inset={sectionInset}>
-							<SectionHeader>
-								{sectionTitle && <Text.Body weight="bold">{sectionTitle}</Text.Body>}
-								{showRemoveButton && (
-									<RemoveButton
-										type="button"
-										styleType="light"
-										danger
-										icon={removeButton?.icon ? renderIcon(removeButton.icon) : undefined}
-										onClick={() => handleRemoveSection(index)}
-									>
-										{removeButton?.label ?? "Remove"}
-									</RemoveButton>
-								)}
-							</SectionHeader>
-							<ArrayFieldElement
-								ref={(formRef) => (formRefs.current[index] = formRef)}
-								formValues={sectionValues}
-								schema={fieldSchema}
-								onChange={handleSectionChange(index)}
-								error={fieldErrors?.[index]}
-							/>
+							<div className="array-field-section-container">
+								<SectionHeader>
+									{sectionTitle && <Text.Body weight="bold">{sectionTitle}</Text.Body>}
+									{showRemoveButton && removeButtonPosition === "top" && renderRemoveButton(index)}
+								</SectionHeader>
+								<ArrayFieldElement
+									ref={(formRef) => (formRefs.current[index] = formRef)}
+									formValues={sectionValues}
+									schema={fieldSchema}
+									onChange={handleSectionChange(index)}
+									error={fieldErrors?.[index]}
+								/>
+								{showRemoveButton && removeButtonPosition === "bottom" && renderRemoveButton(index)}
+							</div>
 						</Inset>
 						{showDivider && !isLastItem ? <SectionDivider /> : null}
 					</Fragment>
@@ -244,8 +271,9 @@ export const ArrayField = (props: IGenericCustomFieldProps<IArrayFieldSchema>) =
 			{showAddButton && (
 				<Inset $inset={sectionInset}>
 					<AddButton
+						className="array-field-add-button"
 						type="button"
-						styleType="light"
+						styleType={addButton?.styleType ?? "light"}
 						icon={addButton?.icon ? renderIcon(addButton.icon) : <PlusCircleFillIcon />}
 						onClick={handleAddSection}
 					>
@@ -267,7 +295,7 @@ export const ArrayField = (props: IGenericCustomFieldProps<IArrayFieldSchema>) =
 				id={`${id}-remove-prompt`}
 				size="large"
 				image={<CustomErrorDisplay type="warning" title={<></>} description={<></>} />}
-				title={removeConfirmationModal?.title ?? "Remove entry?"}
+				title={skipRemoveConfirmationModal ? undefined : removeConfirmationModal?.title ?? "Remove entry?"}
 				description="The information you’ve entered will be deleted."
 				show={showRemovePrompt}
 				buttons={[

--- a/src/components/custom/array-field/types.ts
+++ b/src/components/custom/array-field/types.ts
@@ -1,3 +1,4 @@
+import { ButtonStyleType } from "@lifesg/react-design-system/button/types";
 import * as Icons from "@lifesg/react-icons";
 import { IYupValidationRule, TFrontendEngineFieldSchema } from "../../frontend-engine/types";
 import { IBaseCustomFieldSchema } from "../types";
@@ -10,20 +11,26 @@ export interface IArrayFieldValidationRule extends IYupValidationRule {
 export interface IArrayFieldButton {
 	label?: string | undefined;
 	icon?: keyof typeof Icons | undefined;
+	styleType?: ButtonStyleType | undefined;
 }
 
-export interface IArrayFieldRemoveConfirmationModal {
-	title?: string | undefined;
+export interface IArrayFieldRemoveButton extends IArrayFieldButton {
+	position?: "top" | "bottom" | undefined;
+	alignment?: "left" | "right" | undefined;
 }
 
-export interface IArrayFieldSchema<V = undefined>
+export type IArrayFieldRemoveConfirmationModal =
+	| { skip: true }
+	| { skip?: false | undefined; title?: string | undefined };
+
+export interface IArrayFieldSchema<V = undefined, C = undefined>
 	extends IBaseCustomFieldSchema<"array-field", V, IArrayFieldValidationRule> {
 	// TODO: introduce unique rule for children of fieldSchema
-	fieldSchema: Record<string, TFrontendEngineFieldSchema>;
+	fieldSchema: Record<string, TFrontendEngineFieldSchema<V, C>>;
 	sectionInset?: number | string | undefined;
 	sectionTitle?: string | undefined;
 	showDivider?: boolean | undefined;
 	addButton?: IArrayFieldButton | undefined;
-	removeButton?: IArrayFieldButton | undefined;
+	removeButton?: IArrayFieldRemoveButton | undefined;
 	removeConfirmationModal?: IArrayFieldRemoveConfirmationModal | undefined;
 }

--- a/src/components/custom/types.ts
+++ b/src/components/custom/types.ts
@@ -35,7 +35,7 @@ export enum ECustomFieldType {
  * union type to represent all custom elements / fields schema
  */
 export type TCustomSchema<V = undefined, C = undefined> =
-	| IArrayFieldSchema<V>
+	| IArrayFieldSchema<V, C>
 	| ICustomElementJsonSchema<string>
 	| IFilterSchema<V, C>
 	| IIframeSchema

--- a/src/components/shared/error-messages.tsx
+++ b/src/components/shared/error-messages.tsx
@@ -109,5 +109,7 @@ export const ERROR_MESSAGES = {
 	ARRAY_FIELD: {
 		INVALID: "One or more of the sections is incomplete",
 		REQUIRED: "At least one section must be filled in",
+		MIN: (min: number) => `At least ${min} ${min === 1 ? "entry" : "entries"} must be provided`,
+		MAX: (max: number) => `No more than ${max} ${max === 1 ? "entry" : "entries"} can be provided`,
 	},
 };

--- a/src/stories/5-custom/array-field/array-field.stories.tsx
+++ b/src/stories/5-custom/array-field/array-field.stories.tsx
@@ -73,12 +73,13 @@ const meta: Meta = {
 				<ul>
 					<li>\`label\` prop overrides the text</li>
 					<li>\`icon\` prop overrides the icon, based on <a href='https://designsystem.life.gov.sg/reacticons/index.html?path=/story/collection--page' target='_blank' rel='noopener noreferrer'>React Icons</a></li>
+					<li>\`styleType\` prop sets the button style (\`default\`, \`secondary\`, \`light\`, \`link\`)</li>
 				</ul>
 			`,
 
 			table: {
 				type: {
-					summary: "{ label?: string, icon?: string }",
+					summary: "{ label?: string, icon?: string, styleType?: ButtonStyleType }",
 				},
 			},
 		},
@@ -87,11 +88,15 @@ const meta: Meta = {
 				<ul>
 					<li>\`label\` prop overrides the text</li>
 					<li>\`icon\` prop sets the icon, based on <a href='https://designsystem.life.gov.sg/reacticons/index.html?path=/story/collection--page' target='_blank' rel='noopener noreferrer'>React Icons</a></li>
+					<li>\`styleType\` prop sets the button style (\`default\`, \`secondary\`, \`light\`, \`link\`)</li>
+					<li>\`position\` prop sets button position: \`top\` (default) or \`bottom\`</li>
+					<li>\`alignment\` prop sets button alignment: \`left\` or \`right\` (default)</li>
 				</ul>
 			`,
 			table: {
 				type: {
-					summary: "{ label?: string, icon?: string }",
+					summary:
+						"{ label?: string, icon?: string, styleType?: ButtonStyleType, position?: 'top' | 'bottom', alignment?: 'left' | 'right' }",
 				},
 			},
 		},
@@ -99,12 +104,13 @@ const meta: Meta = {
 			description: `Customisation options for the confirmation modal when item is removed<br/>
 				<ul>
 					<li>\`title\` prop overrides the confirmation text title</li>
+					<li>\`skip\` prop skips the confirmation modal and removes the item immediately</li>
 				</ul>
 			`,
 
 			table: {
 				type: {
-					summary: "{ title?: string }",
+					summary: "{ title?: string } | { skip: true }",
 				},
 			},
 		},
@@ -285,6 +291,35 @@ HideDivider.args = {
 	sectionTitle: "New fruit",
 	showDivider: false,
 	fieldSchema: SCHEMA,
+};
+
+export const RemoveButtonLocation = DefaultStoryTemplate<IArrayFieldSchema>("array-field-remove-button-location").bind(
+	{}
+);
+RemoveButtonLocation.args = {
+	referenceKey: "array-field",
+	sectionTitle: "New fruit",
+	fieldSchema: SCHEMA,
+	removeButton: { position: "bottom", alignment: "left" },
+};
+
+export const ButtonStyleType = DefaultStoryTemplate<IArrayFieldSchema>("array-field-button-style-type").bind({});
+ButtonStyleType.args = {
+	referenceKey: "array-field",
+	sectionTitle: "New fruit",
+	fieldSchema: SCHEMA,
+	addButton: { styleType: "secondary" },
+	removeButton: { styleType: "link" },
+};
+
+export const DisabledConfirmationModal = DefaultStoryTemplate<IArrayFieldSchema>(
+	"array-field-disabled-confirmation-modal"
+).bind({});
+DisabledConfirmationModal.args = {
+	referenceKey: "array-field",
+	sectionTitle: "New fruit",
+	fieldSchema: SCHEMA,
+	removeConfirmationModal: { skip: true },
 };
 
 export const Warning = WarningStoryTemplate<IArrayFieldSchema>("array-field-with-warning").bind({});


### PR DESCRIPTION
**Changes**
Added some enhancements for the `ArrayField` component for greater customisability: 
- `skip` prop for `removeConfirmationModal`
- `classNames` for section div, remove & add buttons
- `styleType` prop for remove & add buttons
- `position` & `alignment` props for remove button
- Default error messages for min/max validation
- Support for custom components within sections

-   [delete] branch

<!-- Remove if not required -->

**Changelog entry**

-   Add various customisability options, default min/max validation and custom component support for `ArrayField`

**Additional information**

-   You may refer to this [BOOKINGSG-8633](https://sgtechstack.atlassian.net/browse/BOOKINGSG-8633)
