### PR TITLE
[CCUBE-2080][XY] Expose customLabels for FileUpload

### DIFF
--- a/src/components/fields/file-upload/file-upload.tsx
+++ b/src/components/fields/file-upload/file-upload.tsx
@@ -1,9 +1,8 @@
-import { FileUpload as DSFileUpload, FileItemProps } from "@lifesg/react-design-system/file-upload";
+import { FileItemProps, FileUpload as DSFileUpload } from "@lifesg/react-design-system/file-upload";
 import xor from "lodash/xor";
 import { Suspense, lazy, useCallback, useContext, useEffect, useRef, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import * as Yup from "yup";
-import { IGenericFieldProps } from "..";
 import { FileHelper } from "../../../utils";
 import { useFieldEvent, useValidationConfig } from "../../../utils/hooks";
 import { IYupValidationRule } from "../../frontend-engine";
@@ -18,6 +17,7 @@ import {
 	IFileUploadValue,
 	TFileUploadErrorObject,
 } from "./types";
+import { IGenericFieldProps } from "../types";
 
 // lazy load to fix next.js SSR errors
 const FileUploadManager = lazy(() => import("./file-upload-manager"));
@@ -40,6 +40,7 @@ export const FileUploadInner = (props: IGenericFieldProps<IFileUploadSchema>) =>
 			uploadOnAddingFile,
 			validation,
 			warning: schemaWarning,
+			customLabels,
 			...otherSchema
 		},
 		warning,
@@ -338,6 +339,7 @@ export const FileUploadInner = (props: IGenericFieldProps<IFileUploadSchema>) =>
 				onDelete={handleDelete}
 				title={renderHtmlText(label)}
 				warning={renderHtmlText(warning || schemaWarning)}
+				customLabels={customLabels}
 			/>
 		</>
 	);

--- a/src/components/fields/file-upload/types.ts
+++ b/src/components/fields/file-upload/types.ts
@@ -24,6 +24,7 @@ export interface IFileUploadSchema<V = undefined>
 	className?: string | undefined;
 	description?: string | undefined;
 	label: string;
+	customLabels?: TFileUploadCustomLabels | undefined;
 	hideThumbnail?: boolean | undefined;
 	uploadOnAddingFile: {
 		type: TUploadType;
@@ -85,6 +86,9 @@ export type TUploadErrorDetail = {
 	fileId: string;
 	errorData: unknown;
 };
+
+// Custom labels type for FileUpload
+export type TFileUploadCustomLabels = FileUploadProps extends { customLabels?: infer T } ? T : never;
 
 // =============================================================================
 // EVENTS (fired from FEE)

--- a/src/stories/3-fields/file-upload/file-upload.stories.tsx
+++ b/src/stories/3-fields/file-upload/file-upload.stories.tsx
@@ -40,6 +40,14 @@ const meta: Meta = {
 				},
 			},
 		},
+		customLabels: {
+			description: "Specify custom label text for some elements",
+			table: {
+				type: {
+					summary: "{ uploadButtonLabel?: string }",
+				},
+			},
+		},
 		capture: {
 			description:
 				"Whether to allow image to be taken by device and which camera to do so. Based on HTML capture attribute, for more info, see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#capture",


### PR DESCRIPTION
**Changes**
- Expose `customLabels` prop for `uploadButtonLabel`
- Update dependencies to latest DS version to use `customLabels` from FileUpload

-   delete branch
