### PR TITLE
[MOL-20815][TIEN] Fix ERROR_CUSTOM_MUTED file item layout

### DIFF
--- a/src/components/fields/image-upload/image-input/file-item/file-item.styles.ts
+++ b/src/components/fields/image-upload/image-input/file-item/file-item.styles.ts
@@ -144,4 +144,5 @@ export const DeleteButton = styled(IconButton)`
 
 export const ErrorCustomMutedThumbnailContainer = styled.div`
 	display: flex;
+	width: 100%;
 `;


### PR DESCRIPTION
**Root cause:** 
- In the `file-item` with `ERROR_CUSTOM_MUTED` branch, the error message is rendered as a sibling of the thumbnail/name block inside a wrapping flex container, so it could remain on the same row.

**Fix:** 
- set width: 100% on ErrorCustomMutedThumbnailContainer so the thumbnail/name block always takes a full row and pushes the error message onto the next line.

**Additional Information**
- You can refer to ticket [MOL-20815](https://sgtechstack.atlassian.net/jira/software/c/projects/MOL/boards/1861?selectedIssue=MOL-20815&sprints=33071)
- You can switch to the [MOL-20815-demo](https://github.com/LifeSG/web-frontend-engine/commits/MOL-20815-demo/) branch to view the Storybook example for this case under `Image Upload / File Item.`