### PR TITLE
[MOL-20560][NL] Add new event listeners-ready to location-field

### DIFF
--- a/src/__tests__/components/fields/location-field/location-field.spec.tsx
+++ b/src/__tests__/components/fields/location-field/location-field.spec.tsx
@@ -52,6 +52,7 @@ enum ELocationInputEvents {
 	"SET_CURRENT_LOCATION" = "set-current-location",
 	"GET_CURRENT_LOCATION" = "get-current-location",
 	"MOUNT" = "mount",
+	"LISTENERS_READY" = "listeners-ready",
 	"SHOW_MODAL" = "show-location-modal",
 	"HIDE_MODAL" = "hide-location-modal",
 	"CLICK_EDIT_BUTTON" = "click-edit-button",
@@ -635,6 +636,23 @@ describe("location-input-group", () => {
 		// PostalCodeError
 
 		//Modal Events
+		describe("Listeners-ready events", () => {
+			it("should fire listeners-ready after listeners are registered", async () => {
+				const handleListenersReady = jest.fn();
+				renderComponent({
+					eventType: ELocationInputEvents.LISTENERS_READY,
+					eventListener: (formRef) => () => {
+						handleListenersReady();
+						formRef.dispatchFieldEvent(UI_TYPE, ELocationInputEvents.SHOW_MODAL, COMPONENT_ID);
+					},
+				});
+				await waitFor(() => {
+					expect(handleListenersReady).toHaveBeenCalled();
+					expect(getLocationModal(true)).toBeInTheDocument();
+				});
+			});
+		});
+
 		describe("Modal events", () => {
 			it("should fire show-location-modal event on showing location modal", async () => {
 				const handleShowReviewModal = jest.fn();

--- a/src/__tests__/components/fields/location-field/location-field.spec.tsx
+++ b/src/__tests__/components/fields/location-field/location-field.spec.tsx
@@ -52,7 +52,7 @@ enum ELocationInputEvents {
 	"SET_CURRENT_LOCATION" = "set-current-location",
 	"GET_CURRENT_LOCATION" = "get-current-location",
 	"MOUNT" = "mount",
-	"LISTENERS_READY" = "listeners-ready",
+	"SHOW_LOCATION_MODAL_READY" = "show-location-modal-ready",
 	"SHOW_MODAL" = "show-location-modal",
 	"HIDE_MODAL" = "hide-location-modal",
 	"CLICK_EDIT_BUTTON" = "click-edit-button",
@@ -636,18 +636,18 @@ describe("location-input-group", () => {
 		// PostalCodeError
 
 		//Modal Events
-		describe("Listeners-ready events", () => {
-			it("should fire listeners-ready after listeners are registered", async () => {
-				const handleListenersReady = jest.fn();
+		describe("Show Location Modal Ready events", () => {
+			it("should fire show-location-modal-ready after it is registered", async () => {
+				const handleShowLocationModalReady = jest.fn();
 				renderComponent({
-					eventType: ELocationInputEvents.LISTENERS_READY,
+					eventType: ELocationInputEvents.SHOW_LOCATION_MODAL_READY,
 					eventListener: (formRef) => () => {
-						handleListenersReady();
+						handleShowLocationModalReady();
 						formRef.dispatchFieldEvent(UI_TYPE, ELocationInputEvents.SHOW_MODAL, COMPONENT_ID);
 					},
 				});
 				await waitFor(() => {
-					expect(handleListenersReady).toHaveBeenCalled();
+					expect(handleShowLocationModalReady).toHaveBeenCalled();
 					expect(getLocationModal(true)).toBeInTheDocument();
 				});
 			});

--- a/src/components/fields/location-field/location-field.tsx
+++ b/src/components/fields/location-field/location-field.tsx
@@ -59,6 +59,9 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 	useEffect(() => {
 		addFieldEventListener("show-location-modal", id, handleLocationModalShow);
 
+		// Signal that the field has registered its listeners and is ready for external triggers.
+		dispatchFieldEvent("listeners-ready", id);
+
 		return () => {
 			removeFieldEventListener("show-location-modal", id, handleLocationModalShow);
 		};

--- a/src/components/fields/location-field/location-field.tsx
+++ b/src/components/fields/location-field/location-field.tsx
@@ -60,7 +60,7 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 		addFieldEventListener("show-location-modal", id, handleLocationModalShow);
 
 		// Signal that the field has registered its listeners and is ready for external triggers.
-		dispatchFieldEvent("listeners-ready", id);
+		dispatchFieldEvent("show-location-modal-ready", id);
 
 		return () => {
 			removeFieldEventListener("show-location-modal", id, handleLocationModalShow);

--- a/src/components/fields/location-field/location-modal/location-search/location-search.tsx
+++ b/src/components/fields/location-field/location-modal/location-search/location-search.tsx
@@ -142,7 +142,7 @@ export const LocationSearch = ({
 					latitude: 1.29994179707526,
 					longitude: 103.789404349716,
 					bufferRadius: 1,
-					abortSignal: reverseGeocodeAborter.current.signal,
+					abortSignal: reverseGeocodeAborter.current?.signal,
 					otherFeatures: OneMapBoolean.YES,
 					getToken,
 					headers: mapApiHeaders,

--- a/src/components/fields/location-field/types.ts
+++ b/src/components/fields/location-field/types.ts
@@ -96,7 +96,7 @@ export type TSetCurrentLocationDetail = TLocationFieldDetail<ILocationCoord>;
 export type TLocationFieldErrorDetail = TLocationFieldDetail<TErrorType>;
 
 export type TLocationFieldEvents = {
-	"listeners-ready": CustomEvent;
+	"show-location-modal-ready": CustomEvent;
 	"get-current-location": CustomEvent;
 	"set-current-location": CustomEvent<TSetCurrentLocationDetail>;
 	error: CustomEvent<TLocationFieldErrorDetail>;
@@ -120,7 +120,7 @@ export class GeolocationPositionErrorWrapper extends Error {
 /** fired after the location field registers its internal event listeners and is ready for external triggers */
 function locationFieldEvent(
 	uiType: "location-field",
-	type: "listeners-ready",
+	type: "show-location-modal-ready",
 	id: string,
 	listener: TFieldEventListener,
 	options?: boolean | AddEventListenerOptions | undefined

--- a/src/components/fields/location-field/types.ts
+++ b/src/components/fields/location-field/types.ts
@@ -117,7 +117,7 @@ export class GeolocationPositionErrorWrapper extends Error {
 // =============================================================================
 // EVENTS (fired from FEE)
 // =============================================================================
-/** fired after the location field registers its internal event listeners and is ready for external triggers */
+/** fired after the location field registers the `show-location-modal` event listener and is ready for external triggers */
 function locationFieldEvent(
 	uiType: "location-field",
 	type: "show-location-modal-ready",

--- a/src/components/fields/location-field/types.ts
+++ b/src/components/fields/location-field/types.ts
@@ -96,6 +96,7 @@ export type TSetCurrentLocationDetail = TLocationFieldDetail<ILocationCoord>;
 export type TLocationFieldErrorDetail = TLocationFieldDetail<TErrorType>;
 
 export type TLocationFieldEvents = {
+	"listeners-ready": CustomEvent;
 	"get-current-location": CustomEvent;
 	"set-current-location": CustomEvent<TSetCurrentLocationDetail>;
 	error: CustomEvent<TLocationFieldErrorDetail>;
@@ -116,6 +117,14 @@ export class GeolocationPositionErrorWrapper extends Error {
 // =============================================================================
 // EVENTS (fired from FEE)
 // =============================================================================
+/** fired after the location field registers its internal event listeners and is ready for external triggers */
+function locationFieldEvent(
+	uiType: "location-field",
+	type: "listeners-ready",
+	id: string,
+	listener: TFieldEventListener,
+	options?: boolean | AddEventListenerOptions | undefined
+): void;
 /** fired on showing location modal */
 function locationFieldEvent(
 	uiType: "location-field",

--- a/src/stories/3-fields/location-field/location-field-events.stories.tsx
+++ b/src/stories/3-fields/location-field/location-field-events.stories.tsx
@@ -850,3 +850,10 @@ RefreshLocationAndTriggerGetCurrentLocation.args = {
 	label: "Refresh current location and trigger get current location",
 	mapApi: defaultMapApi,
 };
+
+export const ListenersReady = Template("listeners-ready").bind({});
+ListenersReady.args = {
+	uiType: "location-field",
+	label: "Listeners Ready",
+	mapApi: defaultMapApi,
+};

--- a/src/stories/3-fields/location-field/location-field-events.stories.tsx
+++ b/src/stories/3-fields/location-field/location-field-events.stories.tsx
@@ -851,9 +851,9 @@ RefreshLocationAndTriggerGetCurrentLocation.args = {
 	mapApi: defaultMapApi,
 };
 
-export const ListenersReady = Template("listeners-ready").bind({});
-ListenersReady.args = {
+export const ShowLocationModalReady = Template("show-location-modal-ready").bind({});
+ShowLocationModalReady.args = {
 	uiType: "location-field",
-	label: "Listeners Ready",
+	label: "Show Location Modal Ready",
 	mapApi: defaultMapApi,
 };


### PR DESCRIPTION
**Changes**

In the new OS 2.0 enhancement, we need to display the location map immediately on page load in the mobile app. Normally, show-location-modal is triggered when the user clicks the location field, but now it runs on mount.

To support this, the location-field must register its show-location-modal event listener before the event is dispatched. This MR introduces a location-field listener-ready signal so consumers know when it’s safe to dispatch the event.

-   [delete] branch

**Changelog entry**

- Add new event: listeners-ready to location-field

**Additional information**

-   You may refer to this [MOL-20560](https://sgtechstack.atlassian.net/browse/MOL-20560)
