### PR TITLE
[DCUBESDQLR-2364][MPT] Loosen react-design-system constraint upwards to be able to use newer versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The intention of frontend engine is to take out the heavy lifting of form develo
 
 Developers are expected to have the following packages installed:
 
--   @lifesg/react-design-system v3.2.0-canary.5
+-   @lifesg/react-design-system v3.3.0-canary.7 or above
 -   @lifesg/react-icons 1.9.0
 -   react 17.0.2 or 18 or 19
 -   react-dom 17.0.2 or 18

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
 			},
 			"peerDependencies": {
 				"@floating-ui/react": ">=0.26.23 <1.0.0",
-				"@lifesg/react-design-system": "^3.3.0-canary.7",
+				"@lifesg/react-design-system": ">=3.3.0-canary.7 <4.0.0",
 				"@lifesg/react-icons": "^1.9.0",
 				"react": "^17.0.2 || ^18.0.0 || ^19.0.0",
 				"react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0",
@@ -16542,7 +16542,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 	},
 	"peerDependencies": {
 		"@floating-ui/react": ">=0.26.23 <1.0.0",
-		"@lifesg/react-design-system": "^3.3.0-canary.7",
+		"@lifesg/react-design-system": ">=3.3.0-canary.7 <4.0.0",
 		"@lifesg/react-icons": "^1.9.0",
 		"react": "^17.0.2 || ^18.0.0 || ^19.0.0",
 		"react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0",


### PR DESCRIPTION
**Changes**
Loosen the `react-design-system` constraint upwards to allow using newer versions. Needed to use `3.4.0-canary-1` for ticket https://sgtechstack.atlassian.net/browse/DCUBESDQLR-2303`.

-   delete branch

**Changelog entry**

-   Loosen the `react-design-system` constraint upwards to allow using newer versions.

**Additional information**

-   You may refer to this [ticket](https://sgtechstack.atlassian.net/browse/DCUBESDQLR-2303)
