### PR TITLE
[DCUBESDQLR-2364][MPT] Fix react-design-system constraint to be able to use current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The intention of frontend engine is to take out the heavy lifting of form develo
 
 Developers are expected to have the following packages installed:
 
--   @lifesg/react-design-system v3.3.0-canary.7 or above
+-   @lifesg/react-design-system v3.4.0-canary.1 or above
 -   @lifesg/react-icons 1.9.0
 -   react 17.0.2 or 18 or 19
 -   react-dom 17.0.2 or 18

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
 			},
 			"peerDependencies": {
 				"@floating-ui/react": ">=0.26.23 <1.0.0",
-				"@lifesg/react-design-system": ">=3.3.0-canary.7 <4.0.0",
+				"@lifesg/react-design-system": ">=3.4.0-canary.1 <4.0.0",
 				"@lifesg/react-icons": "^1.9.0",
 				"react": "^17.0.2 || ^18.0.0 || ^19.0.0",
 				"react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
 			},
 			"peerDependencies": {
 				"@floating-ui/react": ">=0.26.23 <1.0.0",
-				"@lifesg/react-design-system": ">=3.4.0-canary.1 <4.0.0",
+				"@lifesg/react-design-system": "^3.4.0-canary.1",
 				"@lifesg/react-icons": "^1.9.0",
 				"react": "^17.0.2 || ^18.0.0 || ^19.0.0",
 				"react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 	},
 	"peerDependencies": {
 		"@floating-ui/react": ">=0.26.23 <1.0.0",
-		"@lifesg/react-design-system": ">=3.3.0-canary.7 <4.0.0",
+		"@lifesg/react-design-system": ">=3.4.0-canary.1 <4.0.0",
 		"@lifesg/react-icons": "^1.9.0",
 		"react": "^17.0.2 || ^18.0.0 || ^19.0.0",
 		"react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 	},
 	"peerDependencies": {
 		"@floating-ui/react": ">=0.26.23 <1.0.0",
-		"@lifesg/react-design-system": ">=3.4.0-canary.1 <4.0.0",
+		"@lifesg/react-design-system": "^3.4.0-canary.1",
 		"@lifesg/react-icons": "^1.9.0",
 		"react": "^17.0.2 || ^18.0.0 || ^19.0.0",
 		"react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0",


### PR DESCRIPTION
**Changes**
Fix the `react-design-system` constraint, the one I put in https://github.com/LifeSG/web-frontend-engine/pull/586 didn't cover `3.4.0-canary-1`, needed for ticket https://sgtechstack.atlassian.net/browse/DCUBESDQLR-2303`. This one does:

```js
const semver = require('semver');

const currentRange = '>=3.3.0-canary.7 <4.0.0';
console.log('canary DL needs:', semver.satisfies( '3.4.0-canary.1', currentRange)); // false

const newRange = '^3.4.0-canary.1';
console.log('canary DL needs:', semver.satisfies( '3.4.0-canary.1', newRange)); // true
console.log('stable future version', semver.satisfies('3.4.0', newRange)); // true
console.log('stable new patch version', semver.satisfies('3.4.1', newRange)); // true
console.log('stable new minor version', semver.satisfies('3.5.0', newRange)); // true
console.log('stable new major version', semver.satisfies('4.0.0', newRange)); // true
```

-   delete branch

**Changelog entry**

-  Fix `react-design-system` constraint to allow current version.

**Additional information**

-   You may refer to this [ticket](https://sgtechstack.atlassian.net/browse/DCUBESDQLR-2364)
