### PR TITLE
[MOL-20125][NL] Cherry-pick MOL-21025 from main to legacy/v1

### DIFF
--- a/src/__tests__/components/fields/location-field/location-field.spec.tsx
+++ b/src/__tests__/components/fields/location-field/location-field.spec.tsx
@@ -953,6 +953,37 @@ describe("location-input-group", () => {
 
 				expect(mockRefreshLocation).toHaveBeenCalled();
 			});
+
+			it("should not call geolocation when homeAddress is provided", async () => {
+				renderComponent({
+					overrideField: {
+						homeAddress: {
+							lat: 1.3001,
+							lng: 103.8002,
+						},
+					},
+					overrideSchema: {
+						defaultValues: {
+							[COMPONENT_ID]: {
+								lat: 1.29994179707526,
+								lng: 103.789404349716,
+							},
+						},
+					},
+				});
+
+				await waitFor(() => window.dispatchEvent(new Event("online")));
+
+				getLocationInput()?.focus();
+
+				const refreshCurrentLocationButton = getCurrentLocationButton();
+
+				expect(refreshCurrentLocationButton).toBeInTheDocument();
+
+				fireEvent.click(refreshCurrentLocationButton);
+
+				expect(getCurrentLocationSpy).not.toHaveBeenCalled();
+			});
 		});
 	});
 

--- a/src/__tests__/components/fields/location-field/location-field.spec.tsx
+++ b/src/__tests__/components/fields/location-field/location-field.spec.tsx
@@ -954,10 +954,10 @@ describe("location-input-group", () => {
 				expect(mockRefreshLocation).toHaveBeenCalled();
 			});
 
-			it("should not call geolocation when homeAddress is provided", async () => {
+			it("should not call geolocation when defaultAddress is provided", async () => {
 				renderComponent({
 					overrideField: {
-						homeAddress: {
+						defaultAddress: {
 							lat: 1.3001,
 							lng: 103.8002,
 						},

--- a/src/components/fields/location-field/location-field.tsx
+++ b/src/components/fields/location-field/location-field.tsx
@@ -44,7 +44,7 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 			bufferRadius,
 			pinsOnlyIndicateCurrentLocation,
 			legendItems,
-			homeAddress,
+			defaultAddress,
 		},
 		// form values can initially be undefined when passed in via props
 		value: formValue,
@@ -199,7 +199,7 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 						bufferRadius={bufferRadius}
 						pinsOnlyIndicateCurrentLocation={pinsOnlyIndicateCurrentLocation}
 						legendItems={legendItems}
-						homeAddress={homeAddress}
+						defaultAddress={defaultAddress}
 					/>
 				)}
 			</Suspense>

--- a/src/components/fields/location-field/location-field.tsx
+++ b/src/components/fields/location-field/location-field.tsx
@@ -44,6 +44,7 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 			bufferRadius,
 			pinsOnlyIndicateCurrentLocation,
 			legendItems,
+			homeAddress,
 		},
 		// form values can initially be undefined when passed in via props
 		value: formValue,
@@ -198,6 +199,7 @@ export const LocationField = (props: IGenericFieldProps<ILocationFieldSchema>) =
 						bufferRadius={bufferRadius}
 						pinsOnlyIndicateCurrentLocation={pinsOnlyIndicateCurrentLocation}
 						legendItems={legendItems}
+						homeAddress={homeAddress}
 					/>
 				)}
 			</Suspense>

--- a/src/components/fields/location-field/location-modal/location-modal.tsx
+++ b/src/components/fields/location-field/location-modal/location-modal.tsx
@@ -51,7 +51,7 @@ const LocationModal = ({
 	bufferRadius,
 	pinsOnlyIndicateCurrentLocation,
 	legendItems,
-	homeAddress,
+	defaultAddress,
 }: ILocationModalProps) => {
 	// =============================================================================
 	// CONST, STATE, REFS
@@ -509,7 +509,7 @@ const LocationModal = ({
 									pinsOnlyIndicateCurrentLocation && locationSelectionMode === "pins-only"
 								}
 								currentLocation={currentLocation}
-								homeAddress={homeAddress}
+								defaultAddress={defaultAddress}
 							/>
 						</>
 					) : (

--- a/src/components/fields/location-field/location-modal/location-modal.tsx
+++ b/src/components/fields/location-field/location-modal/location-modal.tsx
@@ -51,6 +51,7 @@ const LocationModal = ({
 	bufferRadius,
 	pinsOnlyIndicateCurrentLocation,
 	legendItems,
+	homeAddress,
 }: ILocationModalProps) => {
 	// =============================================================================
 	// CONST, STATE, REFS
@@ -508,6 +509,7 @@ const LocationModal = ({
 									pinsOnlyIndicateCurrentLocation && locationSelectionMode === "pins-only"
 								}
 								currentLocation={currentLocation}
+								homeAddress={homeAddress}
 							/>
 						</>
 					) : (

--- a/src/components/fields/location-field/location-modal/location-picker/location-picker.tsx
+++ b/src/components/fields/location-field/location-modal/location-picker/location-picker.tsx
@@ -134,6 +134,11 @@ export const LocationPicker = ({
 	 */
 	useEffect(() => {
 		if (!selectedLocationCoord?.lat || !selectedLocationCoord?.lng) {
+			// If there is no selected location, zoom to default address if available, else reset to default view
+			if (defaultAddress?.lat && defaultAddress?.lng) {
+				zoomWithMarkers([defaultAddress], false);
+				return;
+			}
 			resetView();
 			return;
 		}

--- a/src/components/fields/location-field/location-modal/location-picker/location-picker.tsx
+++ b/src/components/fields/location-field/location-modal/location-picker/location-picker.tsx
@@ -50,6 +50,7 @@ export const LocationPicker = ({
 	pinsOnlyIndicateCurrentLocation,
 	currentLocation,
 	legendItems,
+	homeAddress,
 }: ILocationPickerProps) => {
 	// =============================================================================
 	// CONST, STATE, REFS
@@ -246,6 +247,10 @@ export const LocationPicker = ({
 					if (locationAvailable) {
 						const shouldPreventDefault = !dispatchFieldEvent("click-refresh-current-location", id);
 						if (!shouldPreventDefault) {
+							if (homeAddress?.lat && homeAddress?.lng) {
+								zoomWithMarkers([homeAddress], false);
+								return;
+							}
 							getCurrentLocation();
 						}
 					}

--- a/src/components/fields/location-field/location-modal/location-picker/location-picker.tsx
+++ b/src/components/fields/location-field/location-modal/location-picker/location-picker.tsx
@@ -50,7 +50,7 @@ export const LocationPicker = ({
 	pinsOnlyIndicateCurrentLocation,
 	currentLocation,
 	legendItems,
-	homeAddress,
+	defaultAddress,
 }: ILocationPickerProps) => {
 	// =============================================================================
 	// CONST, STATE, REFS
@@ -247,8 +247,8 @@ export const LocationPicker = ({
 					if (locationAvailable) {
 						const shouldPreventDefault = !dispatchFieldEvent("click-refresh-current-location", id);
 						if (!shouldPreventDefault) {
-							if (homeAddress?.lat && homeAddress?.lng) {
-								zoomWithMarkers([homeAddress], false);
+							if (defaultAddress?.lat && defaultAddress?.lng) {
+								zoomWithMarkers([defaultAddress], false);
 								return;
 							}
 							getCurrentLocation();

--- a/src/components/fields/location-field/location-modal/location-picker/types.ts
+++ b/src/components/fields/location-field/location-modal/location-picker/types.ts
@@ -34,4 +34,5 @@ export interface ILocationPickerProps extends React.InputHTMLAttributes<HTMLDivE
 	pinsOnlyIndicateCurrentLocation?: boolean | undefined;
 	currentLocation?: ILocationCoord | undefined;
 	legendItems?: ILegendItem[] | undefined;
+	homeAddress?: ILocationCoord | undefined;
 }

--- a/src/components/fields/location-field/location-modal/location-picker/types.ts
+++ b/src/components/fields/location-field/location-modal/location-picker/types.ts
@@ -34,5 +34,5 @@ export interface ILocationPickerProps extends React.InputHTMLAttributes<HTMLDivE
 	pinsOnlyIndicateCurrentLocation?: boolean | undefined;
 	currentLocation?: ILocationCoord | undefined;
 	legendItems?: ILegendItem[] | undefined;
-	homeAddress?: ILocationCoord | undefined;
+	defaultAddress?: ILocationCoord | undefined;
 }

--- a/src/components/fields/location-field/location-modal/types.ts
+++ b/src/components/fields/location-field/location-modal/types.ts
@@ -1,4 +1,4 @@
-import { ILocationFieldValues } from "../types";
+import { ILocationCoord, ILocationFieldValues } from "../types";
 import { ILocationPickerProps } from "./location-picker/types";
 import { ILocationSearchProps } from "./location-search/types";
 
@@ -26,4 +26,5 @@ export interface ILocationModalProps
 	mapBannerText?: string | undefined;
 	locationSelectionMode?: "default" | "pins-only" | undefined;
 	pinsOnlyIndicateCurrentLocation?: boolean | undefined;
+	homeAddress?: ILocationCoord | undefined;
 }

--- a/src/components/fields/location-field/location-modal/types.ts
+++ b/src/components/fields/location-field/location-modal/types.ts
@@ -26,5 +26,5 @@ export interface ILocationModalProps
 	mapBannerText?: string | undefined;
 	locationSelectionMode?: "default" | "pins-only" | undefined;
 	pinsOnlyIndicateCurrentLocation?: boolean | undefined;
-	homeAddress?: ILocationCoord | undefined;
+	defaultAddress?: ILocationCoord | undefined;
 }

--- a/src/components/fields/location-field/types.ts
+++ b/src/components/fields/location-field/types.ts
@@ -48,7 +48,7 @@ export interface ILocationFieldSchema<V = undefined>
 	mapBannerText?: string | undefined;
 	pinsOnlyIndicateCurrentLocation?: boolean | undefined;
 	legendItems?: ILegendItem[] | undefined;
-	homeAddress?: ILocationCoord | undefined;
+	defaultAddress?: ILocationCoord | undefined;
 }
 
 export type TSinglePanelInputMode = "search" | "map";

--- a/src/components/fields/location-field/types.ts
+++ b/src/components/fields/location-field/types.ts
@@ -48,6 +48,7 @@ export interface ILocationFieldSchema<V = undefined>
 	mapBannerText?: string | undefined;
 	pinsOnlyIndicateCurrentLocation?: boolean | undefined;
 	legendItems?: ILegendItem[] | undefined;
+	homeAddress?: ILocationCoord | undefined;
 }
 
 export type TSinglePanelInputMode = "search" | "map";

--- a/src/stories/3-fields/location-field/location-field.stories.tsx
+++ b/src/stories/3-fields/location-field/location-field.stories.tsx
@@ -515,6 +515,7 @@ export const DefaultAddressRefresh = DefaultStoryTemplate<ILocationFieldSchema>(
 DefaultAddressRefresh.args = {
 	uiType: "location-field",
 	label: "Default Address Refresh",
+	locationSelectionMode: "pins-only",
 	mapApi: defaultMapApi,
 	defaultAddress: {
 		lat: 1.3521,

--- a/src/stories/3-fields/location-field/location-field.stories.tsx
+++ b/src/stories/3-fields/location-field/location-field.stories.tsx
@@ -172,6 +172,19 @@ const meta: Meta = {
 				type: "object",
 			},
 		},
+		homeAddress: {
+			description:
+				"Specifies a home address coordinate used on refresh. When refresh is clicked and not prevented, the map centers/zooms to this coordinate (if lat/lng are present) instead of using geolocation.",
+			table: {
+				type: {
+					summary: "{ lat: number; lng: number } | undefined",
+				},
+				defaultValue: { summary: undefined },
+			},
+			control: {
+				type: "object",
+			},
+		},
 	},
 };
 export default meta;
@@ -492,4 +505,19 @@ LegendComponent.args = {
 			icon: "/img/reno.png",
 		},
 	],
+};
+
+export const HomeAddressRefresh = DefaultStoryTemplate<ILocationFieldSchema>(
+	"location-field-home-address-refresh",
+	false,
+	recaptchaSiteKey
+).bind({});
+HomeAddressRefresh.args = {
+	uiType: "location-field",
+	label: "Home Address Refresh",
+	mapApi: defaultMapApi,
+	homeAddress: {
+		lat: 1.3521,
+		lng: 103.8198,
+	},
 };

--- a/src/stories/3-fields/location-field/location-field.stories.tsx
+++ b/src/stories/3-fields/location-field/location-field.stories.tsx
@@ -172,9 +172,9 @@ const meta: Meta = {
 				type: "object",
 			},
 		},
-		homeAddress: {
+		defaultAddress: {
 			description:
-				"Specifies a home address coordinate used on refresh. When refresh is clicked and not prevented, the map centers/zooms to this coordinate (if lat/lng are present) instead of using geolocation.",
+				"Specifies a default address coordinate used on refresh. When refresh is clicked and not prevented, the map centers/zooms to this coordinate (if lat/lng are present) instead of using geolocation.",
 			table: {
 				type: {
 					summary: "{ lat: number; lng: number } | undefined",
@@ -507,16 +507,16 @@ LegendComponent.args = {
 	],
 };
 
-export const HomeAddressRefresh = DefaultStoryTemplate<ILocationFieldSchema>(
-	"location-field-home-address-refresh",
+export const DefaultAddressRefresh = DefaultStoryTemplate<ILocationFieldSchema>(
+	"location-field-default-address-refresh",
 	false,
 	recaptchaSiteKey
 ).bind({});
-HomeAddressRefresh.args = {
+DefaultAddressRefresh.args = {
 	uiType: "location-field",
-	label: "Home Address Refresh",
+	label: "Default Address Refresh",
 	mapApi: defaultMapApi,
-	homeAddress: {
+	defaultAddress: {
 		lat: 1.3521,
 		lng: 103.8198,
 	},


### PR DESCRIPTION
**Changes**
Cherry-pick MOL-21025 from main to legacy/v1

-   delete branch

**Changelog entry**

-   Adds a new defaultAddress schema field. On refresh, the map centers on this coordinate instead of using geolocatio

**Additional information**

- You may refer to this [MOL-21025](https://sgtechstack.atlassian.net/browse/MOL-21025)