### PR TITLE
[MOL-21265][TIEN]  Add shouldRenderFileItem to fix 0 KB flicker while…

### DIFF
--- a/src/components/fields/image-upload/image-input/image-input.tsx
+++ b/src/components/fields/image-upload/image-input/image-input.tsx
@@ -139,6 +139,10 @@ export const ImageInput = (props: IImageInputProps) => {
 	const renderFiles = () => {
 		if (!images || !images.length) return null;
 		return images.map((fileItem: IImage, i: number) => {
+			if (!ImageUploadHelper.shouldRenderFileItem(fileItem)) {
+				return null;
+			}
+
 			return (
 				<FileItem
 					id={`${id}-file-item`}

--- a/src/components/fields/image-upload/image-upload-helper.ts
+++ b/src/components/fields/image-upload/image-upload-helper.ts
@@ -1,6 +1,15 @@
-import { IImage } from "./types";
+import { EImageStatus, IImage } from "./types";
 
 export namespace ImageUploadHelper {
+	/** Render when base64 is ready, or when FileItem should show a validation/upload error row. */
+	export const shouldRenderFileItem = (image: IImage): boolean => {
+		const { status, drawingDataURL, dataURL } = image;
+		return (
+			!!(drawingDataURL || dataURL) ||
+			(status < EImageStatus.NONE && status !== EImageStatus.INJECTED && status !== EImageStatus.TO_DELETE)
+		);
+	};
+
 	/**
 	 * picks an available slot
 	 * slot refers to the index of the file selected


### PR DESCRIPTION
**Changes**

- Fix brief 0 KB flicker on image-upload file list rows while images are still processing by add `ImageUploadHelper.shouldRenderFileItem` to decide when a list row should mount:

  - Yes when `dataURL` or `drawingDataURL` exists (processed image ready).
  - Yes when the image has a renderable error status (status < `NONE`, excluding `INJECTED` and `TO_DELETE`) so validation/upload errors still show inline via existing `FileItem` logic.
  - No while status is NONE and base64 is not ready yet (avoids rendering `FileItem` with empty base64 → 0 KB).

- Delete branch

**Additional information**

-   You may refer to this [ticket](https://sgtechstack.atlassian.net/jira/software/c/projects/MOL/boards/1861?selectedIssue=MOL-21265&sprints=35923)

