### PR TITLE
[MISC][GZ] add fixture factory for story

### DIFF
--- a/e2e/nextjs-app/app/components/frontend-engine/example/with-name.e2e.tsx
+++ b/e2e/nextjs-app/app/components/frontend-engine/example/with-name.e2e.tsx
@@ -2,7 +2,7 @@
 
 import { FrontendEngine, IFrontendEngineData } from "@lifesg/web-frontend-engine";
 
-const EXAMPLE_SCHEMA: IFrontendEngineData = {
+const EXAMPLE_WITH_NAME_SCHEMA: IFrontendEngineData = {
 	sections: {
 		section: {
 			uiType: "section",
@@ -12,16 +12,21 @@ const EXAMPLE_SCHEMA: IFrontendEngineData = {
 					label: "Email",
 					placeholder: "Enter your email",
 				},
+				name: {
+					uiType: "text-field",
+					label: "Name",
+					placeholder: "Enter your name",
+				},
 			},
 		},
 	},
 };
 
-export default function FrontendEngineExamplePage() {
+export default function FrontendEngineExampleWithNamePage() {
 	return (
 		<div className="panel" data-testid="frontend-engine-example-page">
 			<h2>Frontend Engine Example</h2>
-			<FrontendEngine data={EXAMPLE_SCHEMA} />
+			<FrontendEngine data={EXAMPLE_WITH_NAME_SCHEMA} />
 		</div>
 	);
 }

--- a/e2e/tests/frontend-engine/example/example.e2e.spec.ts
+++ b/e2e/tests/frontend-engine/example/example.e2e.spec.ts
@@ -1,33 +1,34 @@
-import { type Locator, type Page } from "@playwright/test";
-import { test as base, expect } from "../../utils/fixtures";
-import { StoryPage } from "../../utils/story-page";
+import { createStoryTest, expect } from "../../utils/fixtures";
 
-class FrontendEngineExamplePage extends StoryPage {
-	public readonly locators: {
-		examplePage: Locator;
-		form: Locator;
-	};
-
-	public constructor(page: Page) {
-		super(page, { component: "frontend-engine/example", story: "default" });
-		this.locators = {
+const createExampleTest = (story: string) =>
+	createStoryTest({
+		component: "frontend-engine/example",
+		story,
+		createLocators: (page) => ({
 			examplePage: page.getByTestId("frontend-engine-example-page"),
 			form: page.locator("form"),
-		};
-	}
-}
+		}),
+	});
 
-const test = base.extend<{ story: FrontendEngineExamplePage }>({
-	story: async ({ page }, use) => {
-		const story = new FrontendEngineExamplePage(page);
-		await use(story);
-	},
+const defaultTest = createExampleTest("default");
+const withNameTest = createExampleTest("with-name");
+
+defaultTest.describe("default", () => {
+	defaultTest("renders email field", async ({ story }) => {
+		await story.goto();
+		await expect(story.locators.examplePage).toBeVisible();
+		await expect(story.locators.form).toBeVisible();
+		await expect(story.locators.form.getByLabel("Email")).toBeVisible();
+		await expect(story.locators.form.getByPlaceholder("Enter your email")).toBeVisible();
+	});
 });
 
-test("frontend-engine example story renders basic form", async ({ story }) => {
-	await story.goto();
-	await expect(story.locators.examplePage).toBeVisible();
-	await expect(story.locators.form).toBeVisible();
-	await expect(story.locators.form.getByLabel("Email")).toBeVisible();
-	await expect(story.locators.form.getByPlaceholder("Enter your email")).toBeVisible();
+withNameTest.describe("with-name", () => {
+	withNameTest("renders email and name fields", async ({ story }) => {
+		await story.goto();
+		await expect(story.locators.examplePage).toBeVisible();
+		await expect(story.locators.form).toBeVisible();
+		await expect(story.locators.form.getByLabel("Email")).toBeVisible();
+		await expect(story.locators.form.getByLabel("Name")).toBeVisible();
+	});
 });

--- a/e2e/tests/utils/fixtures.ts
+++ b/e2e/tests/utils/fixtures.ts
@@ -1,6 +1,21 @@
 import { type Page, test as base } from "@playwright/test";
 import { StoryPage, type TStoryPageOptions } from "./story-page";
 
+// =============================================================================
+// TYPES
+// =============================================================================
+export type TStoryLocatorsFactory<TLocators> = (page: Page) => TLocators;
+
+export type TCreateStoryTestOptions<TLocators> = {
+	component: string;
+	story: string;
+	scope?: TStoryPageOptions["scope"];
+	createLocators: TStoryLocatorsFactory<TLocators>;
+};
+
+// =============================================================================
+// FIXTURES
+// =============================================================================
 export const forComponent = StoryPage.forComponent;
 
 export const test = base.extend<{
@@ -15,19 +30,6 @@ export const test = base.extend<{
 		await use(story);
 	},
 });
-
-export type TStoryLocatorsFactory<TLocators> = (page: Page) => TLocators;
-
-export type TCreateStoryTestOptions<TLocators> = {
-	component: string;
-	story: string;
-	scope?: TStoryPageOptions["scope"];
-	createLocators: TStoryLocatorsFactory<TLocators>;
-};
-
-export type TStoryPageWithLocators<TLocators> = StoryPage & {
-	locators: TLocators;
-};
 
 export const createStoryTest = <TLocators>(options: TCreateStoryTestOptions<TLocators>) => {
 	class StoryPageWithLocators extends StoryPage {

--- a/e2e/tests/utils/fixtures.ts
+++ b/e2e/tests/utils/fixtures.ts
@@ -1,4 +1,4 @@
-import { test as base } from "@playwright/test";
+import { type Page, test as base } from "@playwright/test";
 import { StoryPage, type TStoryPageOptions } from "./story-page";
 
 export const forComponent = StoryPage.forComponent;
@@ -15,5 +15,40 @@ export const test = base.extend<{
 		await use(story);
 	},
 });
+
+export type TStoryLocatorsFactory<TLocators> = (page: Page) => TLocators;
+
+export type TCreateStoryTestOptions<TLocators> = {
+	component: string;
+	story: string;
+	scope?: TStoryPageOptions["scope"];
+	createLocators: TStoryLocatorsFactory<TLocators>;
+};
+
+export type TStoryPageWithLocators<TLocators> = StoryPage & {
+	locators: TLocators;
+};
+
+export const createStoryTest = <TLocators>(options: TCreateStoryTestOptions<TLocators>) => {
+	class StoryPageWithLocators extends StoryPage {
+		public readonly locators: TLocators;
+
+		public constructor(page: Page) {
+			super(page, {
+				scope: options.scope,
+				component: options.component,
+				story: options.story,
+			});
+			this.locators = options.createLocators(page);
+		}
+	}
+
+	return test.extend<{ story: StoryPageWithLocators }>({
+		story: async ({ page }, runStory) => {
+			const story = new StoryPageWithLocators(page);
+			await runStory(story);
+		},
+	});
+};
 
 export { expect } from "@playwright/test";


### PR DESCRIPTION
## Background 
The test would need to repeat the same `base.extend(...)` boilerplate for every story block. This would clutter the file with duplicated lines for the test setup.

## Changes
- Updated the e2e fixture to have a factory to have a cleaner way to implement the test for multiple stories.
- Update e2e example to showcase test for multiple stories
