### PR TITLE
[CCUBE-2137][GZ] migrate shared/prompt to linaria

### DIFF
--- a/src/__tests__/components/custom/array-field/array-field.spec.tsx
+++ b/src/__tests__/components/custom/array-field/array-field.spec.tsx
@@ -195,13 +195,12 @@ describe(UI_TYPE, () => {
 
 			fireEvent.click(getRemoveButton(0));
 
-			await waitFor(() => {
-				expect(screen.queryByText(REMOVE_CONFIRMATION_MODAL_TITLE)).toBeVisible();
-			});
+			const modalText = await screen.findByText(REMOVE_CONFIRMATION_MODAL_TITLE);
+			expect(modalText).toBeVisible();
 
-			fireEvent.click(screen.queryByTestId("field-remove-prompt__btn-remove"));
+			fireEvent.click(await screen.findByTestId("field-remove-prompt__btn-remove"));
 
-			expect(screen.queryByText(REMOVE_CONFIRMATION_MODAL_TITLE)).not.toBeVisible();
+			expect(modalText).not.toBeVisible();
 
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
@@ -213,13 +212,12 @@ describe(UI_TYPE, () => {
 
 			fireEvent.click(getRemoveButton(0));
 
-			await waitFor(() => {
-				expect(screen.queryByText(REMOVE_CONFIRMATION_MODAL_TITLE)).toBeVisible();
-			});
+			const modalText = await screen.findByText(REMOVE_CONFIRMATION_MODAL_TITLE);
+			expect(modalText).toBeVisible();
 
-			fireEvent.click(screen.queryByTestId("field-remove-prompt__btn-back"));
+			fireEvent.click(await screen.findByTestId("field-remove-prompt__btn-back"));
 
-			expect(screen.queryByText(REMOVE_CONFIRMATION_MODAL_TITLE)).not.toBeVisible();
+			expect(modalText).not.toBeVisible();
 
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
@@ -310,7 +308,7 @@ describe(UI_TYPE, () => {
 			fireEvent.click(getRemoveButton(0));
 
 			expect(screen.queryByText(REMOVE_CONFIRMATION_MODAL_TITLE)).not.toBeInTheDocument();
-			expect(screen.queryByText("The information you’ve entered will be deleted.")).toBeNull();
+			expect(screen.queryByText("The information you’ve entered will be deleted.")).not.toBeInTheDocument();
 
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 

--- a/src/__tests__/components/custom/array-field/array-field.spec.tsx
+++ b/src/__tests__/components/custom/array-field/array-field.spec.tsx
@@ -310,7 +310,7 @@ describe(UI_TYPE, () => {
 			fireEvent.click(getRemoveButton(0));
 
 			expect(screen.queryByText(REMOVE_CONFIRMATION_MODAL_TITLE)).not.toBeInTheDocument();
-			expect(screen.queryByText("The information you’ve entered will be deleted.")).not.toBeVisible();
+			expect(screen.queryByText("The information you’ve entered will be deleted.")).toBeNull();
 
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 

--- a/src/__tests__/components/fields/image-upload/image-upload.spec.tsx
+++ b/src/__tests__/components/fields/image-upload/image-upload.spec.tsx
@@ -722,7 +722,7 @@ describe("image-upload", () => {
 				await waitFor(() => {
 					expect(screen.getByText(REVIEW_MODAL_TEXT)).toBeVisible();
 				});
-				expect(screen.getByText(REVIEW_PROMPT_TEXT)).not.toBeVisible();
+				expect(screen.queryByText(REVIEW_PROMPT_TEXT)).toBeNull();
 			});
 		});
 	});
@@ -741,9 +741,11 @@ describe("image-upload", () => {
 				expect(uploadSpy).not.toHaveBeenCalled();
 			});
 
-			it("should show as many images", () => {
-				expect(getField("button", `thumbnail of ${FILE_1.name}`)).toBeInTheDocument();
-				expect(getField("button", `thumbnail of ${FILE_2.name}`)).toBeInTheDocument();
+			it("should show as many images", async () => {
+				await waitFor(() => {
+					expect(getField("button", `thumbnail of ${FILE_1.name}`)).toBeInTheDocument();
+					expect(getField("button", `thumbnail of ${FILE_2.name}`)).toBeInTheDocument();
+				});
 			});
 
 			it("should hide the add button", () => {
@@ -751,6 +753,9 @@ describe("image-upload", () => {
 			});
 
 			it("should upload as many images after clicking save", async () => {
+				await waitFor(() => {
+					expect(getSaveButton()).toBeEnabled();
+				});
 				await act(async () => {
 					fireEvent.click(getSaveButton());
 					await flushPromise();
@@ -778,9 +783,13 @@ describe("image-upload", () => {
 					await waitForUpload();
 				});
 
-				expect(getField("button", `error with ${FILE_1.name}`)).toBeInTheDocument();
+				await waitFor(() => {
+					expect(getField("button", `error with ${FILE_1.name}`)).toBeInTheDocument();
+				});
 				expect(screen.getByText(ERROR_MESSAGES.UPLOAD("photo").MODAL.FILE_TYPE.TITLE)).toBeInTheDocument();
-				expect(getSaveButton()).toBeDisabled();
+				await waitFor(() => {
+					expect(getSaveButton()).toBeDisabled();
+				});
 			});
 		});
 
@@ -803,7 +812,9 @@ describe("image-upload", () => {
 				});
 
 				expect(screen.getByText(ERROR_MESSAGES.UPLOAD("photo").MODAL.GENERIC_ERROR.TITLE)).toBeInTheDocument();
-				expect(getSaveButton()).toBeDisabled();
+				await waitFor(() => {
+					expect(getSaveButton()).toBeDisabled();
+				});
 			});
 		});
 
@@ -830,7 +841,9 @@ describe("image-upload", () => {
 
 			it("should show error and disable submit button if image exceeds max size", async () => {
 				expect(screen.getByText(ERROR_MESSAGES.UPLOAD("photo").MODAL.MAX_FILE_SIZE.TITLE)).toBeInTheDocument();
-				expect(getSaveButton()).toBeDisabled();
+				await waitFor(() => {
+					expect(getSaveButton()).toBeDisabled();
+				});
 			});
 
 			it("Should extract image metadata", async () => {
@@ -846,7 +859,9 @@ describe("image-upload", () => {
 					overrideField: { editImage: true },
 					reviewImage: true,
 				});
-				fireEvent.click(getField("button", "Draw"));
+				await waitFor(() => {
+					fireEvent.click(getField("button", "Draw"));
+				});
 			});
 
 			it("should hide the thumbnails and show the drawing toolbar", () => {
@@ -892,6 +907,11 @@ describe("image-upload", () => {
 					reviewImage: true,
 				});
 
+				await waitFor(() => {
+					expect(getField("button", "Draw")).toBeInTheDocument();
+					expect(getField("button", "Save")).toBeInTheDocument();
+				});
+
 				await act(async () => {
 					fireEvent.click(getField("button", "Draw"));
 					fireEvent.click(getField("button", "Save"));
@@ -916,7 +936,9 @@ describe("image-upload", () => {
 						overrideField: { editImage: true },
 						reviewImage: true,
 					});
-					fireEvent.click(getField("button", "Delete"));
+					await waitFor(() => {
+						fireEvent.click(getField("button", "Delete"));
+					});
 					await waitFor(() => {
 						expect(screen.getByText(DELETE_PROMPT_TEXT)).toBeVisible();
 					});
@@ -931,15 +953,19 @@ describe("image-upload", () => {
 				it("should delete the image and hide the prompt on confirming delete", async () => {
 					fireEvent.click(getField("button", "Yes, delete"));
 
-					expect(screen.getAllByRole("button", { name: /^thumbnail/i })).toHaveLength(2);
 					expect(screen.getByText(DELETE_PROMPT_TEXT)).not.toBeVisible();
+					await waitFor(() => {
+						expect(screen.getAllByRole("button", { name: /^thumbnail/i })).toHaveLength(2);
+					});
 				});
 
 				it("should not delete the image but dismiss the prompt on cancelling the confirmation prompt", async () => {
 					fireEvent.click(getField("button", "Cancel"));
 
 					expect(screen.getByText(DELETE_PROMPT_TEXT)).not.toBeVisible();
-					expect(screen.getAllByRole("button", { name: /^thumbnail/i })).toHaveLength(3);
+					await waitFor(() => {
+						expect(screen.getAllByRole("button", { name: /^thumbnail/i })).toHaveLength(3);
+					});
 				});
 			});
 
@@ -950,7 +976,9 @@ describe("image-upload", () => {
 						overrideField: { editImage: true },
 						reviewImage: true,
 					});
-					fireEvent.click(getField("button", "Delete"));
+					await waitFor(() => {
+						fireEvent.click(getField("button", "Delete"));
+					});
 					await waitFor(() => expect(screen.getByText(DELETE_EXIT_PROMPT_TEXT)).toBeVisible());
 				});
 
@@ -963,17 +991,21 @@ describe("image-upload", () => {
 				it("should delete the image and close the review modal on deleting the last image", async () => {
 					fireEvent.click(getField("button", "Delete and exit"));
 
-					expect(getField("button", /^thumbnail/i, true)).not.toBeInTheDocument();
 					expect(screen.queryByText(DELETE_EXIT_PROMPT_TEXT)).not.toBeInTheDocument();
 					expect(screen.queryByText(REVIEW_MODAL_TEXT)).not.toBeInTheDocument();
+					await waitFor(() => {
+						expect(getField("button", /^thumbnail/i, true)).not.toBeInTheDocument();
+					});
 				});
 
 				it("should not delete the image and return to the review modal on cancelling the confirmation prompt", async () => {
 					fireEvent.click(getField("button", "Cancel"));
 
-					expect(getField("button", /^thumbnail/i)).toBeInTheDocument();
 					expect(screen.getByText(DELETE_EXIT_PROMPT_TEXT)).not.toBeVisible();
 					expect(screen.getByText(REVIEW_MODAL_TEXT)).toBeInTheDocument();
+					await waitFor(() => {
+						expect(getField("button", /^thumbnail/i)).toBeInTheDocument();
+					});
 				});
 			});
 		});
@@ -985,13 +1017,18 @@ describe("image-upload", () => {
 					overrideField: { editImage: true },
 					reviewImage: true,
 				});
-				await waitFor(() => expect(screen.getByText(REVIEW_MODAL_TEXT)).toBeVisible());
-				fireEvent.click(getField("button", "exit review modal"));
+				await waitFor(() => {
+					expect(screen.getByText(REVIEW_MODAL_TEXT)).toBeVisible();
+				});
+
+				await waitFor(() => {
+					fireEvent.click(getField("button", "exit review modal"));
+				});
+
 				await waitFor(() => expect(screen.getByText(REVIEW_EXIT_PROMPT_TEXT)).toBeVisible());
 			});
 
 			it("should show confirmation prompt", () => {
-				expect(screen.getByText(REVIEW_EXIT_PROMPT_TEXT)).toBeVisible();
 				expect(getField("button", "Yes, exit")).toBeVisible();
 				expect(getField("button", "Cancel")).toBeVisible();
 			});
@@ -1009,7 +1046,10 @@ describe("image-upload", () => {
 
 				expect(screen.getByText(REVIEW_EXIT_PROMPT_TEXT)).not.toBeVisible();
 				expect(screen.getByText(REVIEW_MODAL_TEXT)).toBeInTheDocument();
-				expect(getField("button", /^thumbnail/i)).toBeInTheDocument();
+
+				await waitFor(() => {
+					expect(getField("button", `thumbnail of ${FILE_1.name}`)).toBeInTheDocument();
+				});
 			});
 		});
 	});
@@ -1146,7 +1186,9 @@ describe("image-upload", () => {
 				onClick: handleClick,
 			});
 
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+			await waitFor(() => {
+				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+			});
 
 			expect(handleDismissReviewModal).toHaveBeenCalled();
 		});
@@ -1187,7 +1229,9 @@ describe("image-upload", () => {
 				onClick: handleClick,
 			});
 
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+			await waitFor(() => {
+				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+			});
 			const errMsg = screen.getAllByTestId("field-file-item-1__error-text")[0].innerHTML;
 			expect(errMsg).toBe(ERROR_MESSAGE);
 			expect(screen.getAllByTestId("field-file-item-1__error-text")[0]).toBeInTheDocument();
@@ -1505,12 +1549,14 @@ describe("image-upload", () => {
 				await waitFor(() =>
 					fireEvent.change(getReviewModalUploadField(), { target: { files: [FILE_1, FILE_2] } })
 				);
-				await act(async () => {
-					await new Promise((resolve) => setTimeout(resolve, 100)); //add time-out due the the behavior change in the drag-upload
+				// await act(async () => {
+				// 	await new Promise((resolve) => setTimeout(resolve, 300)); //add time-out due the the behavior change in the drag-upload
+				// });
+				await waitFor(() => {
+					expect(getField("button", `thumbnail of ${FILE_1.name}`)).toBeInTheDocument();
+					expect(getField("button", `thumbnail of ${FILE_2.name}`)).toBeInTheDocument();
+					expect(getField("button", `thumbnail of test (1).jpg`)).toBeInTheDocument();
 				});
-				expect(getField("button", `thumbnail of ${FILE_1.name}`)).toBeInTheDocument();
-				expect(getField("button", `thumbnail of ${FILE_2.name}`)).toBeInTheDocument();
-				expect(getField("button", `thumbnail of test (1).jpg`)).toBeInTheDocument();
 			});
 
 			it("should show exceed error when add over the max number", async () => {
@@ -1522,13 +1568,12 @@ describe("image-upload", () => {
 				await waitFor(() =>
 					fireEvent.change(getReviewModalUploadField(), { target: { files: [FILE_1, FILE_2] } })
 				);
-				await act(async () => {
-					await new Promise((resolve) => setTimeout(resolve, 100)); //add time-out due the the behavior change in the drag-upload
+				await waitFor(() => {
+					expect(getField("button", `error with ${FILE_1.name}`)).toBeInTheDocument();
+					expect(
+						screen.getByText(ERROR_MESSAGES.UPLOAD("photo").MAX_FILES_WITH_REMAINING(1))
+					).toBeInTheDocument();
 				});
-				expect(getField("button", `error with ${FILE_1.name}`)).toBeInTheDocument();
-				expect(
-					screen.getByText(ERROR_MESSAGES.UPLOAD("photo").MAX_FILES_WITH_REMAINING(1))
-				).toBeInTheDocument();
 			});
 		});
 	});

--- a/src/__tests__/components/fields/image-upload/image-upload.spec.tsx
+++ b/src/__tests__/components/fields/image-upload/image-upload.spec.tsx
@@ -722,7 +722,7 @@ describe("image-upload", () => {
 				await waitFor(() => {
 					expect(screen.getByText(REVIEW_MODAL_TEXT)).toBeVisible();
 				});
-				expect(screen.queryByText(REVIEW_PROMPT_TEXT)).toBeNull();
+				expect(screen.queryByText(REVIEW_PROMPT_TEXT)).not.toBeInTheDocument();
 			});
 		});
 	});
@@ -744,8 +744,8 @@ describe("image-upload", () => {
 			it("should show as many images", async () => {
 				await waitFor(() => {
 					expect(getField("button", `thumbnail of ${FILE_1.name}`)).toBeInTheDocument();
-					expect(getField("button", `thumbnail of ${FILE_2.name}`)).toBeInTheDocument();
 				});
+				expect(getField("button", `thumbnail of ${FILE_2.name}`)).toBeInTheDocument();
 			});
 
 			it("should hide the add button", () => {
@@ -859,9 +859,8 @@ describe("image-upload", () => {
 					overrideField: { editImage: true },
 					reviewImage: true,
 				});
-				await waitFor(() => {
-					fireEvent.click(getField("button", "Draw"));
-				});
+				const drawButton = await screen.findByRole("button", { name: "Draw" });
+				fireEvent.click(drawButton);
 			});
 
 			it("should hide the thumbnails and show the drawing toolbar", () => {
@@ -909,8 +908,8 @@ describe("image-upload", () => {
 
 				await waitFor(() => {
 					expect(getField("button", "Draw")).toBeInTheDocument();
-					expect(getField("button", "Save")).toBeInTheDocument();
 				});
+				expect(getField("button", "Save")).toBeInTheDocument();
 
 				await act(async () => {
 					fireEvent.click(getField("button", "Draw"));
@@ -1186,9 +1185,8 @@ describe("image-upload", () => {
 				onClick: handleClick,
 			});
 
-			await waitFor(() => {
-				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-			});
+			const customButton = await screen.findByRole("button", { name: "Custom Button" });
+			fireEvent.click(customButton);
 
 			expect(handleDismissReviewModal).toHaveBeenCalled();
 		});
@@ -1207,7 +1205,8 @@ describe("image-upload", () => {
 				onClick: handleClick,
 			});
 
-			await waitFor(() => fireEvent.click(screen.getByRole("button", { name: "Custom Button" })));
+			const customButton = await screen.findByRole("button", { name: "Custom Button" });
+			fireEvent.click(customButton);
 
 			expect(saveReviewImageFn).toHaveBeenCalled();
 		});
@@ -1229,9 +1228,8 @@ describe("image-upload", () => {
 				onClick: handleClick,
 			});
 
-			await waitFor(() => {
-				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-			});
+			const customButton = await screen.findByRole("button", { name: "Custom Button" });
+			fireEvent.click(customButton);
 			const errMsg = screen.getAllByTestId("field-file-item-1__error-text")[0].innerHTML;
 			expect(errMsg).toBe(ERROR_MESSAGE);
 			expect(screen.getAllByTestId("field-file-item-1__error-text")[0]).toBeInTheDocument();
@@ -1549,14 +1547,11 @@ describe("image-upload", () => {
 				await waitFor(() =>
 					fireEvent.change(getReviewModalUploadField(), { target: { files: [FILE_1, FILE_2] } })
 				);
-				// await act(async () => {
-				// 	await new Promise((resolve) => setTimeout(resolve, 300)); //add time-out due the the behavior change in the drag-upload
-				// });
 				await waitFor(() => {
 					expect(getField("button", `thumbnail of ${FILE_1.name}`)).toBeInTheDocument();
-					expect(getField("button", `thumbnail of ${FILE_2.name}`)).toBeInTheDocument();
-					expect(getField("button", `thumbnail of test (1).jpg`)).toBeInTheDocument();
 				});
+				expect(getField("button", `thumbnail of ${FILE_2.name}`)).toBeInTheDocument();
+				expect(getField("button", `thumbnail of test (1).jpg`)).toBeInTheDocument();
 			});
 
 			it("should show exceed error when add over the max number", async () => {
@@ -1570,10 +1565,10 @@ describe("image-upload", () => {
 				);
 				await waitFor(() => {
 					expect(getField("button", `error with ${FILE_1.name}`)).toBeInTheDocument();
-					expect(
-						screen.getByText(ERROR_MESSAGES.UPLOAD("photo").MAX_FILES_WITH_REMAINING(1))
-					).toBeInTheDocument();
 				});
+				expect(
+					screen.getByText(ERROR_MESSAGES.UPLOAD("photo").MAX_FILES_WITH_REMAINING(1))
+				).toBeInTheDocument();
 			});
 		});
 	});

--- a/src/__tests__/components/fields/location-field/location-field.spec.tsx
+++ b/src/__tests__/components/fields/location-field/location-field.spec.tsx
@@ -1970,9 +1970,9 @@ describe("location-input-group", () => {
 			const selectedResult = resultContainer.getElementsByTagName("div")[0];
 			fireEvent.click(selectedResult);
 			fireEvent.click(getLocationModalControlButtons("Confirm"));
-			await waitFor(() => {
-				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-			});
+
+			const customButton = await screen.findByRole("button", { name: "Custom Button" });
+			fireEvent.click(customButton);
 
 			expect(formIsDirty).toBe(true);
 		});

--- a/src/__tests__/components/fields/location-field/location-field.spec.tsx
+++ b/src/__tests__/components/fields/location-field/location-field.spec.tsx
@@ -1970,7 +1970,9 @@ describe("location-input-group", () => {
 			const selectedResult = resultContainer.getElementsByTagName("div")[0];
 			fireEvent.click(selectedResult);
 			fireEvent.click(getLocationModalControlButtons("Confirm"));
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+			await waitFor(() => {
+				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+			});
 
 			expect(formIsDirty).toBe(true);
 		});
@@ -2011,7 +2013,9 @@ describe("location-input-group", () => {
 			fireEvent.click(selectedResult);
 			fireEvent.click(getLocationModalControlButtons("Confirm"));
 
-			fireEvent.click(getResetButton());
+			await waitFor(() => {
+				fireEvent.click(getResetButton());
+			});
 			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
 
 			expect(formIsDirty).toBe(false);
@@ -2046,7 +2050,9 @@ describe("location-input-group", () => {
 			fireEvent.click(selectedResult);
 			fireEvent.click(getLocationModalControlButtons("Confirm"));
 
-			fireEvent.click(getResetButton());
+			await waitFor(() => {
+				fireEvent.click(getResetButton());
+			});
 			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
 
 			expect(formIsDirty).toBe(false);

--- a/src/components/fields/location-field/location-modal/location-modal.styles.ts
+++ b/src/components/fields/location-field/location-modal/location-modal.styles.ts
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { TPanelInputMode } from "../types";
 import { LocationPicker } from "./location-picker";
 import { MediaQuery, Spacing } from "@lifesg/react-design-system/theme";
+import { Typography } from "@lifesg/react-design-system/typography";
 
 interface ISinglePanelStyle {
 	panelInputMode: TPanelInputMode;
@@ -68,4 +69,8 @@ export const ErrorImage = styled.img`
 
 export const PrefetchImage = styled.img`
 	display: none;
+`;
+
+export const Description = styled(Typography.HeadingXS)`
+	margin-top: ${Spacing["spacing-8"]};
 `;

--- a/src/components/fields/location-field/location-modal/location-modal.tsx
+++ b/src/components/fields/location-field/location-modal/location-modal.tsx
@@ -11,7 +11,6 @@ import { OneMapError } from "../../../../services/onemap/types";
 import { GeoLocationHelper, TestHelper } from "../../../../utils";
 import { useFieldEvent } from "../../../../utils/hooks";
 import { Prompt } from "../../../shared";
-import { Description } from "../../../shared/prompt/prompt.styles";
 import {
 	GeolocationPositionErrorWrapper,
 	ILocationCoord,
@@ -23,7 +22,7 @@ import {
 	TSetCurrentLocationDetail,
 } from "../types";
 import { ERROR_SVG, OFFLINE_IMAGE, TIMEOUT_SVG } from "./location-modal.data";
-import { ErrorImage, ModalBox, PrefetchImage, StyledLocationPicker } from "./location-modal.styles";
+import { Description, ErrorImage, ModalBox, PrefetchImage, StyledLocationPicker } from "./location-modal.styles";
 import { IMapPin } from "./location-picker/types";
 import { LocationSearch } from "./location-search";
 import NoNetworkModal from "./no-network-modal/no-network-modal";

--- a/src/components/shared/prompt/prompt.styles.ts
+++ b/src/components/shared/prompt/prompt.styles.ts
@@ -1,30 +1,7 @@
 import { css } from "@linaria/core";
 import { MediaQuery, Radius, Spacing } from "@lifesg/react-design-system/theme";
 
-export const tokens = {
-	promptButton: {
-		width: "--fds-internal-prompt-promptButton-width",
-	},
-};
-
-export const scrollableModal = css`
-	height: 100%;
-	overflow-y: auto;
-`;
-
-export const growContainer = css`
-	margin: auto;
-	padding: 5rem ${Spacing["layout-md"]};
-	width: 100%;
-
-	${MediaQuery.MaxWidth.sm} {
-		padding: ${Spacing["layout-sm"]} ${Spacing["layout-md"]};
-	}
-`;
-
 export const container = css`
-	${tokens.promptButton.width}: initial;
-
 	background: white;
 	border-radius: ${Radius.md};
 	display: flex;
@@ -44,51 +21,32 @@ export const promptImage = css`
 	margin: 0 auto ${Spacing["spacing-32"]};
 `;
 
-export const promptButton = css`
-	width: var(${tokens.promptButton.width});
-	margin: 0 auto;
-
-	&:not(:first-child):last-child {
-		margin-top: ${Spacing["spacing-16"]};
-
-		${MediaQuery.MinWidth.md} {
-			margin-top: 0;
-			margin-right: ${Spacing["spacing-16"]};
-		}
-	}
-`;
-
-export const promptButtonLarge = css`
-	&:not(:first-child):last-child {
-		${MediaQuery.MinWidth.md} {
-			margin-right: ${Spacing["spacing-32"]};
-		}
-	}
-`;
-
 export const buttonContainer = css`
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
+	margin: 0;
 	padding: 0 ${Spacing["spacing-24"]} ${Spacing["spacing-64"]};
+	gap: ${Spacing["spacing-16"]};
 
 	${MediaQuery.MinWidth.md} {
-		align-items: center;
 		flex-direction: row-reverse;
 		padding: ${Spacing["spacing-40"]} ${Spacing["spacing-24"]} ${Spacing["spacing-32"]};
 	}
 `;
 
 export const buttonContainerLarge = css`
+	gap: ${Spacing["spacing-16"]};
+
 	${MediaQuery.MinWidth.md} {
+		gap: ${Spacing["spacing-32"]};
 		padding: ${Spacing["spacing-32"]} ${Spacing["spacing-64"]} ${Spacing["spacing-64"]};
 	}
 `;
 
 export const labelContainer = css`
-	display: flex;
-	flex-direction: column;
 	text-align: center;
+	margin: 0;
 	padding: ${Spacing["spacing-64"]} ${Spacing["spacing-24"]} ${Spacing["spacing-24"]};
 
 	${MediaQuery.MinWidth.md} {

--- a/src/components/shared/prompt/prompt.styles.ts
+++ b/src/components/shared/prompt/prompt.styles.ts
@@ -2,12 +2,16 @@ import { css } from "@linaria/core";
 import { MediaQuery, Spacing } from "@lifesg/react-design-system/theme";
 
 export const container = css`
-	max-width: 426px;
-	width: 100%;
+	${MediaQuery.MinWidth.lg} {
+		max-width: 426px;
+		width: 100%;
+	}
 `;
 
 export const containerLarge = css`
-	max-width: 672px;
+	${MediaQuery.MinWidth.lg} {
+		max-width: 672px;
+	}
 `;
 
 export const promptImage = css`

--- a/src/components/shared/prompt/prompt.styles.ts
+++ b/src/components/shared/prompt/prompt.styles.ts
@@ -2,12 +2,13 @@ import { MediaQuery, Radius, Spacing } from "@lifesg/react-design-system/theme";
 import { Button } from "@lifesg/react-design-system/button";
 import { Modal } from "@lifesg/react-design-system/modal";
 import { Typography } from "@lifesg/react-design-system/typography";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 
-interface SizeProps {
-	size?: "large";
-	width?: string;
-}
+export const tokens = {
+	promptButton: {
+		width: "--fds-internal-prompt-promptButton-width",
+	},
+};
 
 export const ScrollableModal = styled(Modal)`
 	height: 100%;
@@ -24,15 +25,19 @@ export const GrowContainer = styled.div`
 	}
 `;
 
-export const Container = styled.div<SizeProps>`
+export const Container = styled.div`
 	background: white;
 	border-radius: ${Radius.md};
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
 	margin: auto;
-	max-width: ${(props) => (props.size === "large" ? "672px" : "426px")};
+	max-width: 426px;
 	width: 100%;
+
+	&.containerLarge {
+		max-width: 672px;
+	}
 `;
 
 export const PromptImage = styled.img`
@@ -40,8 +45,10 @@ export const PromptImage = styled.img`
 	margin: 0 auto ${Spacing["spacing-32"]};
 `;
 
-export const PromptButton = styled(Button)<SizeProps>`
-	width: ${({ width }) => width || "100%"};
+export const PromptButton = styled(Button)`
+	${tokens.promptButton.width}: initial;
+
+	width: var(${tokens.promptButton.width});
 	margin: 0 auto;
 
 	&:not(:first-child):last-child {
@@ -49,12 +56,18 @@ export const PromptButton = styled(Button)<SizeProps>`
 
 		${MediaQuery.MinWidth.md} {
 			margin-top: 0;
-			margin-right: ${(props) => (props.size === "large" ? Spacing["spacing-32"] : Spacing["spacing-16"])};
+			margin-right: ${Spacing["spacing-16"]};
+		}
+	}
+
+	&.promptButtonLarge:not(:first-child):last-child {
+		${MediaQuery.MinWidth.md} {
+			margin-right: ${Spacing["spacing-32"]};
 		}
 	}
 `;
 
-export const ButtonContainer = styled.div<SizeProps>`
+export const ButtonContainer = styled.div`
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
@@ -63,33 +76,30 @@ export const ButtonContainer = styled.div<SizeProps>`
 	${MediaQuery.MinWidth.md} {
 		align-items: center;
 		flex-direction: row-reverse;
+		padding: ${Spacing["spacing-40"]} ${Spacing["spacing-24"]} ${Spacing["spacing-32"]};
+	}
 
-		padding: ${(props) =>
-			props.size === "large"
-				? css`
-						${Spacing["spacing-32"]} ${Spacing["spacing-64"]} ${Spacing["spacing-64"]}
-				  `
-				: css`
-						${Spacing["spacing-40"]} ${Spacing["spacing-24"]} ${Spacing["spacing-32"]}
-				  `};
+	&.buttonContainerLarge {
+		${MediaQuery.MinWidth.md} {
+			padding: ${Spacing["spacing-32"]} ${Spacing["spacing-64"]} ${Spacing["spacing-64"]};
+		}
 	}
 `;
 
-export const LabelContainer = styled.div<SizeProps>`
+export const LabelContainer = styled.div`
 	display: flex;
 	flex-direction: column;
 	text-align: center;
 	padding: ${Spacing["spacing-64"]} ${Spacing["spacing-24"]} ${Spacing["spacing-24"]};
 
 	${MediaQuery.MinWidth.md} {
-		padding: ${(props) =>
-			props.size === "large"
-				? css`
-						${Spacing["spacing-64"]} ${Spacing["spacing-64"]} 0rem ${Spacing["spacing-64"]}
-				  `
-				: css`
-						${Spacing["spacing-32"]} ${Spacing["spacing-24"]} 0
-				  `};
+		padding: ${Spacing["spacing-32"]} ${Spacing["spacing-24"]} 0;
+	}
+
+	&.labelContainerLarge {
+		${MediaQuery.MinWidth.md} {
+			padding: ${Spacing["spacing-64"]} ${Spacing["spacing-64"]} 0rem ${Spacing["spacing-64"]};
+		}
 	}
 `;
 
@@ -97,6 +107,6 @@ export const Description = styled(Typography.HeadingXS)`
 	margin-top: ${Spacing["spacing-8"]};
 `;
 
-export const Title = styled(Typography.HeadingXS)<SizeProps>`
+export const Title = styled(Typography.HeadingXS)`
 	margin-top: 0rem;
 `;

--- a/src/components/shared/prompt/prompt.styles.ts
+++ b/src/components/shared/prompt/prompt.styles.ts
@@ -1,13 +1,7 @@
 import { css } from "@linaria/core";
-import { MediaQuery, Radius, Spacing } from "@lifesg/react-design-system/theme";
+import { MediaQuery, Spacing } from "@lifesg/react-design-system/theme";
 
 export const container = css`
-	background: white;
-	border-radius: ${Radius.md};
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	margin: auto;
 	max-width: 426px;
 	width: 100%;
 `;

--- a/src/components/shared/prompt/prompt.styles.ts
+++ b/src/components/shared/prompt/prompt.styles.ts
@@ -1,8 +1,5 @@
+import { css } from "@linaria/core";
 import { MediaQuery, Radius, Spacing } from "@lifesg/react-design-system/theme";
-import { Button } from "@lifesg/react-design-system/button";
-import { Modal } from "@lifesg/react-design-system/modal";
-import { Typography } from "@lifesg/react-design-system/typography";
-import styled from "styled-components";
 
 export const tokens = {
 	promptButton: {
@@ -10,12 +7,12 @@ export const tokens = {
 	},
 };
 
-export const ScrollableModal = styled(Modal)`
+export const scrollableModal = css`
 	height: 100%;
 	overflow-y: auto;
 `;
 
-export const GrowContainer = styled.div`
+export const growContainer = css`
 	margin: auto;
 	padding: 5rem ${Spacing["layout-md"]};
 	width: 100%;
@@ -25,7 +22,9 @@ export const GrowContainer = styled.div`
 	}
 `;
 
-export const Container = styled.div`
+export const container = css`
+	${tokens.promptButton.width}: initial;
+
 	background: white;
 	border-radius: ${Radius.md};
 	display: flex;
@@ -34,20 +33,18 @@ export const Container = styled.div`
 	margin: auto;
 	max-width: 426px;
 	width: 100%;
-
-	&.containerLarge {
-		max-width: 672px;
-	}
 `;
 
-export const PromptImage = styled.img`
+export const containerLarge = css`
+	max-width: 672px;
+`;
+
+export const promptImage = css`
 	width: 11rem;
 	margin: 0 auto ${Spacing["spacing-32"]};
 `;
 
-export const PromptButton = styled(Button)`
-	${tokens.promptButton.width}: initial;
-
+export const promptButton = css`
 	width: var(${tokens.promptButton.width});
 	margin: 0 auto;
 
@@ -59,15 +56,17 @@ export const PromptButton = styled(Button)`
 			margin-right: ${Spacing["spacing-16"]};
 		}
 	}
+`;
 
-	&.promptButtonLarge:not(:first-child):last-child {
+export const promptButtonLarge = css`
+	&:not(:first-child):last-child {
 		${MediaQuery.MinWidth.md} {
 			margin-right: ${Spacing["spacing-32"]};
 		}
 	}
 `;
 
-export const ButtonContainer = styled.div`
+export const buttonContainer = css`
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
@@ -78,15 +77,15 @@ export const ButtonContainer = styled.div`
 		flex-direction: row-reverse;
 		padding: ${Spacing["spacing-40"]} ${Spacing["spacing-24"]} ${Spacing["spacing-32"]};
 	}
+`;
 
-	&.buttonContainerLarge {
-		${MediaQuery.MinWidth.md} {
-			padding: ${Spacing["spacing-32"]} ${Spacing["spacing-64"]} ${Spacing["spacing-64"]};
-		}
+export const buttonContainerLarge = css`
+	${MediaQuery.MinWidth.md} {
+		padding: ${Spacing["spacing-32"]} ${Spacing["spacing-64"]} ${Spacing["spacing-64"]};
 	}
 `;
 
-export const LabelContainer = styled.div`
+export const labelContainer = css`
 	display: flex;
 	flex-direction: column;
 	text-align: center;
@@ -95,18 +94,18 @@ export const LabelContainer = styled.div`
 	${MediaQuery.MinWidth.md} {
 		padding: ${Spacing["spacing-32"]} ${Spacing["spacing-24"]} 0;
 	}
+`;
 
-	&.labelContainerLarge {
-		${MediaQuery.MinWidth.md} {
-			padding: ${Spacing["spacing-64"]} ${Spacing["spacing-64"]} 0rem ${Spacing["spacing-64"]};
-		}
+export const labelContainerLarge = css`
+	${MediaQuery.MinWidth.md} {
+		padding: ${Spacing["spacing-64"]} ${Spacing["spacing-64"]} 0rem ${Spacing["spacing-64"]};
 	}
 `;
 
-export const Description = styled(Typography.HeadingXS)`
+export const description = css`
 	margin-top: ${Spacing["spacing-8"]};
 `;
 
-export const Title = styled(Typography.HeadingXS)`
+export const title = css`
 	margin-top: 0rem;
 `;

--- a/src/components/shared/prompt/prompt.tsx
+++ b/src/components/shared/prompt/prompt.tsx
@@ -1,31 +1,35 @@
-import { useRef } from "react";
 import clsx from "clsx";
-import { useApplyStyle } from "@lifesg/react-design-system/theme";
-import { Modal } from "@lifesg/react-design-system/modal";
+import { ModalV2 } from "@lifesg/react-design-system/modal-v2";
 import { Typography } from "@lifesg/react-design-system/typography";
 import { Button } from "@lifesg/react-design-system/button";
 import { TestHelper } from "../../../utils";
 import * as styles from "./prompt.styles";
-import { IPromptProps } from "./types";
+import { IPromptProps, TPromptButton } from "./types";
 
-export const Prompt = (props: IPromptProps) => {
-	const { id = "prompt", show, size, title, description, image, buttons } = props;
-	const containerRef = useRef<HTMLDivElement>(null);
-
-	useApplyStyle(containerRef, {
-		[styles.tokens.promptButton.width]: buttons?.length === 1 ? "16rem" : "100%",
-	});
+export const Prompt = ({ id = "prompt", show, size, title, description, image, buttons }: IPromptProps) => {
+	const renderButton = (button: TPromptButton) => (
+		<Button
+			id={TestHelper.generateId(id, button.id ? `btn-${button.id}` : `btn-1`)}
+			data-testid={TestHelper.generateId(id, button.id ? `btn-${button.id}` : `btn-1`)}
+			key={button.title}
+			onClick={button.onClick}
+			styleType={button.buttonStyle}
+		>
+			{button.title}
+		</Button>
+	);
 
 	return (
-		<Modal
+		<ModalV2
 			show={show}
 			id={TestHelper.generateId(id, undefined, show ? "show" : "hide")}
 			data-testid={TestHelper.generateId(id, undefined, show ? "show" : "hide")}
-			className={styles.scrollableModal}
 		>
-			<div className={styles.growContainer}>
-				<div className={clsx(styles.container, size === "large" && styles.containerLarge)}>
-					<div className={clsx(styles.labelContainer, size === "large" && styles.labelContainerLarge)}>
+			<ModalV2.Content>
+				<ModalV2.Card className={clsx(styles.container, size === "large" && styles.containerLarge)}>
+					<ModalV2.Content
+						className={clsx(styles.labelContainer, size === "large" && styles.labelContainerLarge)}
+					>
 						{typeof image === "string" ? (
 							<img src={image} alt={title} className={styles.promptImage} />
 						) : (
@@ -40,32 +44,22 @@ export const Prompt = (props: IPromptProps) => {
 							{title}
 						</Typography.HeadingXS>
 						{typeof description === "string" ? (
-							<Typography.HeadingXS weight="regular" className={styles.description}>
+							<Typography.HeadingXS as="p" weight="regular" className={styles.description}>
 								{description}
 							</Typography.HeadingXS>
 						) : (
 							description
 						)}
-					</div>
-					<div
-						ref={containerRef}
-						className={clsx(styles.buttonContainer, size === "large" && styles.buttonContainerLarge)}
-					>
-						{buttons?.map((button, i) => (
-							<Button
-								id={TestHelper.generateId(id, button.id ? `btn-${button.id}` : `btn-${i + 1}`)}
-								data-testid={TestHelper.generateId(id, button.id ? `btn-${button.id}` : `btn-${i + 1}`)}
-								className={clsx(styles.promptButton, size === "large" && styles.promptButtonLarge)}
-								key={button.title}
-								onClick={button.onClick}
-								styleType={button.buttonStyle}
-							>
-								{button.title}
-							</Button>
-						))}
-					</div>
-				</div>
-			</div>
-		</Modal>
+					</ModalV2.Content>
+					{!!buttons && buttons.length > 0 && (
+						<ModalV2.Footer
+							className={clsx(styles.buttonContainer, size === "large" && styles.buttonContainerLarge)}
+							primaryButton={renderButton(buttons[0])}
+							secondaryButton={buttons.length > 1 && renderButton(buttons[1])}
+						/>
+					)}
+				</ModalV2.Card>
+			</ModalV2.Content>
+		</ModalV2>
 	);
 };

--- a/src/components/shared/prompt/prompt.tsx
+++ b/src/components/shared/prompt/prompt.tsx
@@ -7,10 +7,10 @@ import * as styles from "./prompt.styles";
 import { IPromptProps, TPromptButton } from "./types";
 
 export const Prompt = ({ id = "prompt", show, size, title, description, image, buttons }: IPromptProps) => {
-	const renderButton = (button: TPromptButton) => (
+	const renderButton = (button: TPromptButton, index: number) => (
 		<Button
-			id={TestHelper.generateId(id, button.id ? `btn-${button.id}` : `btn-1`)}
-			data-testid={TestHelper.generateId(id, button.id ? `btn-${button.id}` : `btn-1`)}
+			id={TestHelper.generateId(id, button.id ? `btn-${button.id}` : `btn-${index}`)}
+			data-testid={TestHelper.generateId(id, button.id ? `btn-${button.id}` : `btn-${index}`)}
 			key={button.title}
 			onClick={button.onClick}
 			styleType={button.buttonStyle}
@@ -54,8 +54,8 @@ export const Prompt = ({ id = "prompt", show, size, title, description, image, b
 					{!!buttons && buttons.length > 0 && (
 						<ModalV2.Footer
 							className={clsx(styles.buttonContainer, size === "large" && styles.buttonContainerLarge)}
-							primaryButton={renderButton(buttons[0])}
-							secondaryButton={buttons.length > 1 && renderButton(buttons[1])}
+							primaryButton={renderButton(buttons[0], 1)}
+							secondaryButton={buttons.length > 1 && renderButton(buttons[1], 2)}
 						/>
 					)}
 				</ModalV2.Card>

--- a/src/components/shared/prompt/prompt.tsx
+++ b/src/components/shared/prompt/prompt.tsx
@@ -10,7 +10,7 @@ import { IPromptProps } from "./types";
 
 export const Prompt = (props: IPromptProps) => {
 	const { id = "prompt", show, size, title, description, image, buttons } = props;
-	const buttonContainerRef = useRef<HTMLButtonElement>(null);
+	const buttonContainerRef = useRef<HTMLDivElement>(null);
 
 	useApplyStyle(buttonContainerRef, {
 		[styles.tokens.promptButton.width]: buttons?.length === 1 ? "16rem" : "100%",
@@ -49,10 +49,12 @@ export const Prompt = (props: IPromptProps) => {
 							description
 						)}
 					</div>
-					<div className={clsx(styles.buttonContainer, size === "large" && styles.buttonContainerLarge)}>
+					<div
+						ref={buttonContainerRef}
+						className={clsx(styles.buttonContainer, size === "large" && styles.buttonContainerLarge)}
+					>
 						{buttons?.map((button, i) => (
 							<Button
-								ref={buttonContainerRef}
 								id={TestHelper.generateId(id, button.id ? `btn-${button.id}` : `btn-${i + 1}`)}
 								data-testid={TestHelper.generateId(id, button.id ? `btn-${button.id}` : `btn-${i + 1}`)}
 								className={clsx(styles.promptButton, size === "large" && styles.promptButtonLarge)}

--- a/src/components/shared/prompt/prompt.tsx
+++ b/src/components/shared/prompt/prompt.tsx
@@ -1,71 +1,71 @@
 import { useRef } from "react";
 import clsx from "clsx";
-import { TestHelper } from "../../../utils";
-import {
-	ButtonContainer,
-	Container,
-	Description,
-	GrowContainer,
-	LabelContainer,
-	PromptButton,
-	PromptImage,
-	ScrollableModal,
-	Title,
-	tokens,
-} from "./prompt.styles";
-import { IPromptProps } from "./types";
 import { useApplyStyle } from "@lifesg/react-design-system/theme";
+import { Modal } from "@lifesg/react-design-system/modal";
+import { Typography } from "@lifesg/react-design-system/typography";
+import { Button } from "@lifesg/react-design-system/button";
+import { TestHelper } from "../../../utils";
+import * as styles from "./prompt.styles";
+import { IPromptProps } from "./types";
 
 export const Prompt = (props: IPromptProps) => {
 	const { id = "prompt", show, size, title, description, image, buttons } = props;
-	const buttonContainerRef = useRef<HTMLDivElement>(null);
+	const buttonContainerRef = useRef<HTMLButtonElement>(null);
 
 	useApplyStyle(buttonContainerRef, {
-		[tokens.promptButton.width]: buttons?.length === 1 ? "16rem" : "100%",
+		[styles.tokens.promptButton.width]: buttons?.length === 1 ? "16rem" : "100%",
 	});
 
+	console.log({ tokens: styles.tokens, buttonContainerRef });
+
 	return (
-		<ScrollableModal
+		<Modal
 			show={show}
 			id={TestHelper.generateId(id, undefined, show ? "show" : "hide")}
 			data-testid={TestHelper.generateId(id, undefined, show ? "show" : "hide")}
+			className={styles.scrollableModal}
 		>
-			<GrowContainer>
-				<Container className={clsx(size === "large" && "containerLarge")}>
-					<LabelContainer className={clsx(size === "large" && "labelContainerLarge")}>
-						{typeof image === "string" ? <PromptImage src={image} alt={title} /> : image}
-						<Title
+			<div className={styles.growContainer}>
+				<div className={clsx(styles.container, size === "large" && styles.containerLarge)}>
+					<div className={clsx(styles.labelContainer, size === "large" && styles.labelContainerLarge)}>
+						{typeof image === "string" ? (
+							<img src={image} alt={title} className={styles.promptImage} />
+						) : (
+							image
+						)}
+						<Typography.HeadingXS
 							id={TestHelper.generateId(id, "title")}
 							data-testid={TestHelper.generateId(id, "title")}
 							weight="semibold"
+							className={styles.title}
 						>
 							{title}
-						</Title>
+						</Typography.HeadingXS>
 						{typeof description === "string" ? (
-							<Description weight="regular">{description}</Description>
+							<Typography.HeadingXS weight="regular" className={styles.description}>
+								{description}
+							</Typography.HeadingXS>
 						) : (
 							description
 						)}
-					</LabelContainer>
-					<ButtonContainer
-						ref={buttonContainerRef}
-						className={clsx(size === "large" && "buttonContainerLarge")}
-					>
+					</div>
+					<div className={clsx(styles.buttonContainer, size === "large" && styles.buttonContainerLarge)}>
 						{buttons?.map((button, i) => (
-							<PromptButton
+							<Button
+								ref={buttonContainerRef}
 								id={TestHelper.generateId(id, button.id ? `btn-${button.id}` : `btn-${i + 1}`)}
 								data-testid={TestHelper.generateId(id, button.id ? `btn-${button.id}` : `btn-${i + 1}`)}
-								className={clsx(size === "large" && "promptButtonLarge")}
+								className={clsx(styles.promptButton, size === "large" && styles.promptButtonLarge)}
 								key={button.title}
 								onClick={button.onClick}
 								styleType={button.buttonStyle}
 							>
 								{button.title}
-							</PromptButton>
+							</Button>
 						))}
-					</ButtonContainer>
-				</Container>
-			</GrowContainer>
-		</ScrollableModal>
+					</div>
+				</div>
+			</div>
+		</Modal>
 	);
 };

--- a/src/components/shared/prompt/prompt.tsx
+++ b/src/components/shared/prompt/prompt.tsx
@@ -1,3 +1,5 @@
+import { useRef } from "react";
+import clsx from "clsx";
 import { TestHelper } from "../../../utils";
 import {
 	ButtonContainer,
@@ -9,11 +11,18 @@ import {
 	PromptImage,
 	ScrollableModal,
 	Title,
+	tokens,
 } from "./prompt.styles";
 import { IPromptProps } from "./types";
+import { useApplyStyle } from "@lifesg/react-design-system/theme";
 
 export const Prompt = (props: IPromptProps) => {
 	const { id = "prompt", show, size, title, description, image, buttons } = props;
+	const buttonContainerRef = useRef<HTMLDivElement>(null);
+
+	useApplyStyle(buttonContainerRef, {
+		[tokens.promptButton.width]: buttons?.length === 1 ? "16rem" : "100%",
+	});
 
 	return (
 		<ScrollableModal
@@ -22,13 +31,12 @@ export const Prompt = (props: IPromptProps) => {
 			data-testid={TestHelper.generateId(id, undefined, show ? "show" : "hide")}
 		>
 			<GrowContainer>
-				<Container size={size}>
-					<LabelContainer size={size}>
+				<Container className={clsx(size === "large" && "containerLarge")}>
+					<LabelContainer className={clsx(size === "large" && "labelContainerLarge")}>
 						{typeof image === "string" ? <PromptImage src={image} alt={title} /> : image}
 						<Title
 							id={TestHelper.generateId(id, "title")}
 							data-testid={TestHelper.generateId(id, "title")}
-							size={size}
 							weight="semibold"
 						>
 							{title}
@@ -39,16 +47,18 @@ export const Prompt = (props: IPromptProps) => {
 							description
 						)}
 					</LabelContainer>
-					<ButtonContainer size={size}>
+					<ButtonContainer
+						ref={buttonContainerRef}
+						className={clsx(size === "large" && "buttonContainerLarge")}
+					>
 						{buttons?.map((button, i) => (
 							<PromptButton
 								id={TestHelper.generateId(id, button.id ? `btn-${button.id}` : `btn-${i + 1}`)}
 								data-testid={TestHelper.generateId(id, button.id ? `btn-${button.id}` : `btn-${i + 1}`)}
-								size={size}
+								className={clsx(size === "large" && "promptButtonLarge")}
 								key={button.title}
 								onClick={button.onClick}
 								styleType={button.buttonStyle}
-								width={buttons.length === 1 ? "16rem" : undefined}
 							>
 								{button.title}
 							</PromptButton>

--- a/src/components/shared/prompt/prompt.tsx
+++ b/src/components/shared/prompt/prompt.tsx
@@ -10,13 +10,11 @@ import { IPromptProps } from "./types";
 
 export const Prompt = (props: IPromptProps) => {
 	const { id = "prompt", show, size, title, description, image, buttons } = props;
-	const buttonContainerRef = useRef<HTMLDivElement>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
 
-	useApplyStyle(buttonContainerRef, {
+	useApplyStyle(containerRef, {
 		[styles.tokens.promptButton.width]: buttons?.length === 1 ? "16rem" : "100%",
 	});
-
-	console.log({ tokens: styles.tokens, buttonContainerRef });
 
 	return (
 		<Modal
@@ -50,7 +48,7 @@ export const Prompt = (props: IPromptProps) => {
 						)}
 					</div>
 					<div
-						ref={buttonContainerRef}
+						ref={containerRef}
 						className={clsx(styles.buttonContainer, size === "large" && styles.buttonContainerLarge)}
 					>
 						{buttons?.map((button, i) => (

--- a/src/components/shared/prompt/prompt.tsx
+++ b/src/components/shared/prompt/prompt.tsx
@@ -25,41 +25,35 @@ export const Prompt = ({ id = "prompt", show, size, title, description, image, b
 			id={TestHelper.generateId(id, undefined, show ? "show" : "hide")}
 			data-testid={TestHelper.generateId(id, undefined, show ? "show" : "hide")}
 		>
-			<ModalV2.Content>
-				<ModalV2.Card className={clsx(styles.container, size === "large" && styles.containerLarge)}>
-					<ModalV2.Content
-						className={clsx(styles.labelContainer, size === "large" && styles.labelContainerLarge)}
+			<ModalV2.Card className={clsx(styles.container, size === "large" && styles.containerLarge)}>
+				<ModalV2.Content
+					className={clsx(styles.labelContainer, size === "large" && styles.labelContainerLarge)}
+				>
+					{typeof image === "string" ? <img src={image} alt={title} className={styles.promptImage} /> : image}
+					<Typography.HeadingXS
+						id={TestHelper.generateId(id, "title")}
+						data-testid={TestHelper.generateId(id, "title")}
+						weight="semibold"
+						className={styles.title}
 					>
-						{typeof image === "string" ? (
-							<img src={image} alt={title} className={styles.promptImage} />
-						) : (
-							image
-						)}
-						<Typography.HeadingXS
-							id={TestHelper.generateId(id, "title")}
-							data-testid={TestHelper.generateId(id, "title")}
-							weight="semibold"
-							className={styles.title}
-						>
-							{title}
+						{title}
+					</Typography.HeadingXS>
+					{typeof description === "string" ? (
+						<Typography.HeadingXS as="p" weight="regular" className={styles.description}>
+							{description}
 						</Typography.HeadingXS>
-						{typeof description === "string" ? (
-							<Typography.HeadingXS as="p" weight="regular" className={styles.description}>
-								{description}
-							</Typography.HeadingXS>
-						) : (
-							description
-						)}
-					</ModalV2.Content>
-					{!!buttons && buttons.length > 0 && (
-						<ModalV2.Footer
-							className={clsx(styles.buttonContainer, size === "large" && styles.buttonContainerLarge)}
-							primaryButton={renderButton(buttons[0], 1)}
-							secondaryButton={buttons.length > 1 && renderButton(buttons[1], 2)}
-						/>
+					) : (
+						description
 					)}
-				</ModalV2.Card>
-			</ModalV2.Content>
+				</ModalV2.Content>
+				{!!buttons && buttons.length > 0 && (
+					<ModalV2.Footer
+						className={clsx(styles.buttonContainer, size === "large" && styles.buttonContainerLarge)}
+						primaryButton={renderButton(buttons[0], 1)}
+						secondaryButton={buttons.length > 1 && renderButton(buttons[1], 2)}
+					/>
+				)}
+			</ModalV2.Card>
 		</ModalV2>
 	);
 };

--- a/src/stories/3-fields/location-field/location-field-events.stories.tsx
+++ b/src/stories/3-fields/location-field/location-field-events.stories.tsx
@@ -11,11 +11,13 @@ import {
 	TSetCurrentLocationDetail,
 } from "../../../components/fields";
 import { ERROR_SVG, TIMEOUT_SVG } from "../../../components/fields/location-field/location-modal/location-modal.data";
-import { ErrorImage } from "../../../components/fields/location-field/location-modal/location-modal.styles";
+import {
+	Description,
+	ErrorImage,
+} from "../../../components/fields/location-field/location-modal/location-modal.styles";
 import { IMapPin } from "../../../components/fields/location-field/location-modal/location-picker/types";
 import { IFrontendEngineRef } from "../../../components/frontend-engine";
 import { Prompt } from "../../../components/shared";
-import { Description } from "../../../components/shared/prompt/prompt.styles";
 import { TestHelper } from "../../../utils";
 import { FrontendEngine, SUBMIT_BUTTON_SCHEMA } from "../../common";
 import Default from "./location-field.stories";


### PR DESCRIPTION
**Changes**
- Migrate `shared/prompt` component to linaria
- Duplicate referenced styling by `LocationModal` to the component's own styling

**Additional information**
- With the current implementation, the `useApplyStyle` is not being applied properly on `LocationModal` due to portal timing. Would need to refactor the component to utlize the `show` props instead to control the prompt visibility. 
