### PR TITLE
[CCUBE-2185][GZ] handle circular dependency in wrapper component initialization

### DIFF
--- a/src/components/elements/wrapper/wrapper.tsx
+++ b/src/components/elements/wrapper/wrapper.tsx
@@ -21,9 +21,6 @@ import { ConditionalRenderer } from "./conditional-renderer";
 import { FieldWrapper } from "./field-wrapper";
 import { IWrapperProps, TWrapperChildSchema } from "./types";
 
-const fieldTypeKeys = Object.keys(EFieldType);
-const elementTypeKeys = Object.keys(EElementType);
-
 export const Wrapper = (props: IWrapperProps): JSX.Element | null => {
 	// =============================================================================
 	// CONST, STATE, REF
@@ -50,6 +47,8 @@ export const Wrapper = (props: IWrapperProps): JSX.Element | null => {
 	 * - otherwise show field not supported error
 	 */
 	useIsomorphicDeepLayoutEffect(() => {
+		const fieldTypeKeys = Object.keys(EFieldType);
+		const elementTypeKeys = Object.keys(EElementType);
 		const wrapperChildren = overrideSchema(schemaChildren || children, overrides);
 		if (typeof wrapperChildren === "object") {
 			const renderComponents: JSX.Element[] = [];


### PR DESCRIPTION
[FEE storybook error](https://sgtechstack.atlassian.net/browse/CCUBE-2185)

**Changes**
At module initialization time, `EFieldType` was still `undefined`, causing the Storybook build to fail. Moved it from module scope into inside of `useIsomorphicDeepLayoutEffect`, so it execute at runtime after all modules have loaded instead of during initialization.
