### PR TITLE
[MISC][GZ] shared dirty state test suite and render helper

### DIFF
--- a/src/__tests__/common/index.ts
+++ b/src/__tests__/common/index.ts
@@ -1,3 +1,4 @@
 export * from "./data";
 export * from "./helper";
+export * from "./render-helper";
 export * from "./types";

--- a/src/__tests__/common/render-helper.tsx
+++ b/src/__tests__/common/render-helper.tsx
@@ -1,0 +1,47 @@
+import { RenderResult, render } from "@testing-library/react";
+import { FrontendEngine } from "../../components";
+import { IFrontendEngineData, IFrontendEngineProps, TFrontendEngineFieldSchema } from "../../components/types";
+import { FRONTEND_ENGINE_ID } from "./data";
+import { getResetButtonProps, getSubmitButtonProps } from "./helper";
+import { TOverrideField, TOverrideSchema } from "./types";
+
+interface ICreateRenderComponentOptions {
+	componentId: string;
+	baseSchema: Record<string, unknown>;
+	submitFn?: jest.Mock;
+	includeReset?: boolean;
+	engineProps?: Partial<Omit<IFrontendEngineProps, "data" | "onSubmit">>;
+}
+
+export function createRenderComponent<TFieldSchema>(options: ICreateRenderComponentOptions) {
+	const { componentId, baseSchema, submitFn = jest.fn(), includeReset = true, engineProps } = options;
+
+	const baseJsonSchema: IFrontendEngineData = {
+		id: FRONTEND_ENGINE_ID,
+		sections: {
+			section: {
+				uiType: "section",
+				children: {
+					[componentId]: baseSchema as TFrontendEngineFieldSchema,
+					...getSubmitButtonProps(),
+					...(includeReset ? getResetButtonProps() : {}),
+				},
+			},
+		},
+	};
+
+	const renderFn = (overrideField?: TOverrideField<TFieldSchema>, overrideSchema?: TOverrideSchema): RenderResult => {
+		const json: IFrontendEngineData = JSON.parse(JSON.stringify(baseJsonSchema));
+		if (overrideSchema) {
+			Object.assign(json, { ...overrideSchema, sections: json.sections });
+		}
+		if (overrideField) {
+			Object.assign(json.sections.section.children[componentId] as object, overrideField);
+		}
+		return render(<FrontendEngine {...engineProps} data={json} onSubmit={submitFn} />);
+	};
+
+	renderFn.schema = baseJsonSchema;
+
+	return renderFn;
+}

--- a/src/__tests__/common/tests/dirty-state.tsx
+++ b/src/__tests__/common/tests/dirty-state.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { IFrontendEngineData, IFrontendEngineRef } from "../../../components/types";
+import { FrontendEngineWithCustomButton, getResetButton } from "../helper";
+
+interface IDirtyStateTestSuiteOptions {
+	schema: IFrontendEngineData;
+	componentId: string;
+	defaultValue: unknown;
+	modifyField: () => unknown;
+}
+
+export const dirtyStateTestSuite = (options: IDirtyStateTestSuiteOptions) =>
+	describe("dirty state", () => {
+		const { schema, componentId, defaultValue, modifyField } = options;
+		let formIsDirty: boolean | undefined;
+		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
+			formIsDirty = ref.current.isDirty;
+		};
+
+		beforeEach(() => {
+			formIsDirty = undefined;
+		});
+
+		it("should mount without setting field state as dirty", () => {
+			render(<FrontendEngineWithCustomButton data={schema} onClick={handleClick} />);
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(false);
+		});
+
+		it("should set form state as dirty if user modifies the field", async () => {
+			render(<FrontendEngineWithCustomButton data={schema} onClick={handleClick} />);
+			await modifyField();
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(true);
+		});
+
+		it("should support default value without setting form state as dirty", () => {
+			render(
+				<FrontendEngineWithCustomButton
+					data={{ ...schema, defaultValues: { [componentId]: defaultValue } }}
+					onClick={handleClick}
+				/>
+			);
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(false);
+		});
+
+		it("should reset and revert form dirty state to false", async () => {
+			render(<FrontendEngineWithCustomButton data={schema} onClick={handleClick} />);
+			await modifyField();
+			fireEvent.click(getResetButton());
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(false);
+		});
+
+		it("should reset to default value without setting form state as dirty", async () => {
+			render(
+				<FrontendEngineWithCustomButton
+					data={{ ...schema, defaultValues: { [componentId]: defaultValue } }}
+					onClick={handleClick}
+				/>
+			);
+			await modifyField();
+			fireEvent.click(getResetButton());
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(false);
+		});
+	});

--- a/src/__tests__/common/tests/index.ts
+++ b/src/__tests__/common/tests/index.ts
@@ -1,1 +1,2 @@
+export * from "./dirty-state";
 export * from "./labels";

--- a/src/__tests__/common/tests/labels.ts
+++ b/src/__tests__/common/tests/labels.ts
@@ -1,6 +1,7 @@
 import { fireEvent, screen } from "@testing-library/react";
 
-export const labelTestSuite = (renderComponent: (overrideField: unknown) => void) =>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const labelTestSuite = (renderComponent: (overrideField?: any) => void) =>
 	describe("labels", () => {
 		const getComputedStyle = window.getComputedStyle.bind(window);
 

--- a/src/__tests__/components/custom/array-field/array-field.spec.tsx
+++ b/src/__tests__/components/custom/array-field/array-field.spec.tsx
@@ -18,6 +18,7 @@ import {
 	getSubmitButtonProps,
 } from "../../../common";
 import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const VALUE_CHANGE_FN = jest.fn();
@@ -586,77 +587,6 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-
-			await waitFor(() => fireEvent.change(getTextField(0), { target: { value: "Hello" } }));
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{
-						...JSON_SCHEMA,
-						defaultValues: { [COMPONENT_ID]: [{ [TEXT_FIELD_ID]: "Hello" }] },
-					}}
-					onClick={handleClick}
-				/>
-			);
-
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-
-			await waitFor(() => fireEvent.change(getTextField(0), { target: { value: "Hello" } }));
-			fireEvent.click(getResetButton());
-			await waitFor(() => fireEvent.click(screen.getByRole("button", { name: "Custom Button" })));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{
-						...JSON_SCHEMA,
-						defaultValues: { [COMPONENT_ID]: [{ [TEXT_FIELD_ID]: "Hello" }] },
-					}}
-					onClick={handleClick}
-				/>
-			);
-
-			await waitFor(() => fireEvent.change(getTextField(0), { target: { value: "Hello" } }));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-	});
-
 	describe("form config", () => {
 		it("should include form values of unregistered fields if stripUnknown is not true", async () => {
 			const mockOnSubmit = jest.fn();
@@ -965,6 +895,15 @@ describe(UI_TYPE, () => {
 				expect(screen.queryByText(ERROR_MESSAGES.ARRAY_FIELD.UNIQUE)).toBeInTheDocument();
 			});
 		});
+	});
+
+	dirtyStateTestSuite({
+		schema: JSON_SCHEMA,
+		componentId: COMPONENT_ID,
+		defaultValue: [{ [TEXT_FIELD_ID]: "Hello" }],
+		modifyField: async () => {
+			await waitFor(() => fireEvent.change(getTextField(0), { target: { value: "Hello" } }));
+		},
 	});
 
 	warningTestSuite<IArrayFieldSchema>({

--- a/src/__tests__/components/custom/iframe/iframe.spec.tsx
+++ b/src/__tests__/components/custom/iframe/iframe.spec.tsx
@@ -2,18 +2,19 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import cloneDeep from "lodash/cloneDeep";
 import merge from "lodash/merge";
 import { EPostMessageEvent, IIframeSchema } from "../../../../components/custom";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/types";
+import { IFrontendEngineData } from "../../../../components/types";
 import {
 	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
 	FrontendEngineWithEventListener,
 	TOverrideField,
 	TOverrideSchema,
+	createRenderComponent,
 	getResetButton,
 	getResetButtonProps,
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
+import { dirtyStateTestSuite } from "../../../common/tests";
 
 const CHANGE_FN = jest.fn();
 const SUBMIT_FN = jest.fn();
@@ -46,7 +47,16 @@ interface IRenderOptions {
 	eventListener?: ((this: Element, ev: Event) => any) | undefined;
 }
 
-const renderComponent = (
+const renderComponent = createRenderComponent<IIframeSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		referenceKey: UI_TYPE,
+		src: IFRAME_SRC,
+	},
+	submitFn: SUBMIT_FN,
+});
+
+const renderWithEventListener = (
 	overrideField?: TOverrideField<IIframeSchema> | undefined,
 	overrideSchema?: TOverrideSchema | undefined,
 	options?: IRenderOptions | undefined
@@ -124,7 +134,7 @@ describe("iframe", () => {
 		it("should fire a loading event when iframe starts loading", () => {
 			const testFn = jest.fn();
 
-			renderComponent(undefined, undefined, { eventType: "loading", eventListener: testFn });
+			renderWithEventListener(undefined, undefined, { eventType: "loading", eventListener: testFn });
 
 			expect(testFn).toHaveBeenCalled();
 		});
@@ -132,7 +142,7 @@ describe("iframe", () => {
 		it("should fire a loaded event on receiving a loaded postMessage", () => {
 			const testFn = jest.fn();
 
-			renderComponent(undefined, undefined, { eventType: "loaded", eventListener: testFn });
+			renderWithEventListener(undefined, undefined, { eventType: "loaded", eventListener: testFn });
 			sendPostMessage(EPostMessageEvent.LOADED);
 
 			expect(testFn).toHaveBeenCalled();
@@ -185,7 +195,7 @@ describe("iframe", () => {
 		it("should fail validation if validation exceeds validationTimeout", async () => {
 			jest.useFakeTimers();
 
-			renderComponent({ validationTimeout: 1000 });
+			renderWithEventListener({ validationTimeout: 1000 });
 			await waitFor(() => sendPostMessage(EPostMessageEvent.SET_VALUE, "hello world"));
 
 			jest.advanceTimersByTime(100);
@@ -254,64 +264,10 @@ describe("iframe", () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			sendPostMessage(EPostMessageEvent.SET_VALUE, "hello world");
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			sendPostMessage(EPostMessageEvent.SET_VALUE, "hello world");
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			sendPostMessage(EPostMessageEvent.SET_VALUE, "hello world");
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: "hello",
+		modifyField: () => sendPostMessage(EPostMessageEvent.SET_VALUE, "hello world"),
 	});
 });

--- a/src/__tests__/components/fields/checkbox-group/checkbox-group.spec.tsx
+++ b/src/__tests__/components/fields/checkbox-group/checkbox-group.spec.tsx
@@ -4,66 +4,39 @@ import cloneDeep from "lodash/cloneDeep";
 import merge from "lodash/merge";
 import { useState } from "react";
 import { TCheckboxGroupSchema } from "../../../../components/fields";
-import { FrontendEngine, IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
+import { FrontendEngine, IFrontendEngineData } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "checkbox";
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Checkbox",
-					uiType: UI_TYPE,
-					options: [
-						{ label: "A", value: "Apple" },
-						{ label: "B", value: "Berry" },
-						{ label: "C", value: "Cherry" },
-						{ label: "D", value: "Durian" },
-					],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
+const renderComponent = createRenderComponent<TCheckboxGroupSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Checkbox",
+		uiType: UI_TYPE,
+		options: [
+			{ label: "A", value: "Apple" },
+			{ label: "B", value: "Berry" },
+			{ label: "C", value: "Cherry" },
+			{ label: "D", value: "Durian" },
+		],
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<TCheckboxGroupSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -356,68 +329,14 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: async () => {
 			const checkboxes = getCheckboxes();
 			await waitFor(() => fireEvent.click(checkboxes[0]));
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			const checkboxes = getCheckboxes();
-			await waitFor(() => fireEvent.click(checkboxes[0]));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			const checkboxes = getCheckboxes();
-			await waitFor(() => fireEvent.click(checkboxes[1]));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+		},
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/checkbox-group/checkbox-toggle-group.spec.tsx
+++ b/src/__tests__/components/fields/checkbox-group/checkbox-toggle-group.spec.tsx
@@ -4,69 +4,42 @@ import cloneDeep from "lodash/cloneDeep";
 import merge from "lodash/merge";
 import { useState } from "react";
 import { TCheckboxGroupSchema } from "../../../../components/fields";
-import { FrontendEngine, IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
+import { FrontendEngine, IFrontendEngineData } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const NESTED_FIELD_ID = "nested-field";
 const UI_TYPE = "checkbox";
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Toggle",
-					uiType: UI_TYPE,
-					customOptions: {
-						styleType: "toggle",
-					},
-					options: [
-						{ label: "A", value: "Apple" },
-						{ label: "B", value: "Berry" },
-						{ label: "C", value: "Cherry" },
-						{ label: "D", value: "Durian" },
-					],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
+const renderComponent = createRenderComponent<TCheckboxGroupSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Toggle",
+		uiType: UI_TYPE,
+		customOptions: {
+			styleType: "toggle",
 		},
+		options: [
+			{ label: "A", value: "Apple" },
+			{ label: "B", value: "Berry" },
+			{ label: "C", value: "Cherry" },
+			{ label: "D", value: "Durian" },
+		],
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<TCheckboxGroupSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -447,68 +420,14 @@ describe("checkbox toggle group", () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: async () => {
 			const toggles = getToggles();
 			await waitFor(() => fireEvent.click(toggles[0]));
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			const toggles = getToggles();
-			await waitFor(() => fireEvent.click(toggles[0]));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			const toggles = getToggles();
-			await waitFor(() => fireEvent.click(toggles[1]));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+		},
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/chips/chips.spec.tsx
+++ b/src/__tests__/components/fields/chips/chips.spec.tsx
@@ -4,67 +4,40 @@ import cloneDeep from "lodash/cloneDeep";
 import merge from "lodash/merge";
 import { useState } from "react";
 import { IChipsSchema } from "../../../../components/fields";
-import { FrontendEngine, IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
+import { FrontendEngine, IFrontendEngineData } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "chips";
 const TEXT_AREA_LABEL = "E";
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Chips",
-					uiType: UI_TYPE,
-					options: [
-						{ label: "A", value: "Apple" },
-						{ label: "B", value: "Berry" },
-						{ label: "C", value: "Cherry" },
-						{ label: "D", value: "Durian" },
-					],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
+const renderComponent = createRenderComponent<IChipsSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Chips",
+		uiType: UI_TYPE,
+		options: [
+			{ label: "A", value: "Apple" },
+			{ label: "B", value: "Berry" },
+			{ label: "C", value: "Cherry" },
+			{ label: "D", value: "Durian" },
+		],
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<IChipsSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -412,65 +385,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getChipA());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getChipA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(getChipB());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: () => fireEvent.click(getChipA()),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/contact-field/contact-field.spec.tsx
+++ b/src/__tests__/components/fields/contact-field/contact-field.spec.tsx
@@ -12,6 +12,7 @@ import {
 	FrontendEngineWithCustomButton,
 	TOverrideField,
 	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
@@ -19,45 +20,21 @@ import {
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "contact-field";
 const COMPONENT_LABEL = "Contact Number";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: COMPONENT_LABEL,
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
-	},
-};
 
 jest.setTimeout(20000);
 
-const renderComponent = (overrideField?: TOverrideField<IContactFieldSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+const renderComponent = createRenderComponent<IContactFieldSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: { label: COMPONENT_LABEL, uiType: UI_TYPE },
+	submitFn: SUBMIT_FN,
+});
 
 const getContactField = (): HTMLElement => {
 	return screen.getByTestId("input");
@@ -392,71 +369,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getContactFieldWithPlaceholder(), {
-				target: { value: "+65 91234567" },
-			});
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "91234567" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getContactFieldWithPlaceholder(), {
-				target: { value: "+65 91234567" },
-			});
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "91234567" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.change(getContactFieldWithPlaceholder(), {
-				target: { value: "+65 91234567" },
-			});
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: "91234567",
+		modifyField: () => fireEvent.change(getContactFieldWithPlaceholder(), { target: { value: "+65 91234567" } }),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/date-field/date-field.spec.tsx
+++ b/src/__tests__/components/fields/date-field/date-field.spec.tsx
@@ -1,61 +1,28 @@
 import { LocalDate } from "@js-joda/core";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { IDateFieldSchema } from "../../../../components/fields";
 import { ERROR_MESSAGES } from "../../../../components/shared";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/types";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "date-field";
 const COMPONENT_LABEL = "Date";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: COMPONENT_LABEL,
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
-	},
-};
 
-const renderComponent = (overrideField?: TOverrideField<IDateFieldSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+const renderComponent = createRenderComponent<IDateFieldSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: { label: COMPONENT_LABEL, uiType: UI_TYPE },
+	submitFn: SUBMIT_FN,
+});
 
 const getDayInput = (): HTMLElement => {
 	return getField("textbox", "Date");
@@ -324,66 +291,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting form state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			await changeDate("25", "01", "2022");
-
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "2022-02-25" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			await changeDate("25", "01", "2022");
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "2022-02-25" } }}
-					onClick={handleClick}
-				/>
-			);
-			await changeDate("25", "01", "2022");
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: "2022-02-25",
+		modifyField: () => changeDate("25", "01", "2022"),
 	});
 	labelTestSuite(renderComponent);
 	warningTestSuite<IDateFieldSchema>({ label: COMPONENT_LABEL, uiType: UI_TYPE });

--- a/src/__tests__/components/fields/histogram-slider/histogram-slider.spec.tsx
+++ b/src/__tests__/components/fields/histogram-slider/histogram-slider.spec.tsx
@@ -13,55 +13,34 @@ import {
 	FrontendEngineWithCustomButton,
 	TOverrideField,
 	TOverrideSchema,
+	createRenderComponent,
 	getResetButton,
 	getResetButtonProps,
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "histogram-slider";
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Histogram slider",
-					uiType: UI_TYPE,
-					bins: [
-						{ minValue: 10, count: 1 },
-						{ minValue: 20, count: 0 },
-						{ minValue: 30, count: 3 },
-						{ minValue: 90, count: 3 },
-					],
-					interval: 10,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
+const renderComponent = createRenderComponent<IHistogramSliderSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Histogram slider",
+		uiType: UI_TYPE,
+		bins: [
+			{ minValue: 10, count: 1 },
+			{ minValue: 20, count: 0 },
+			{ minValue: 30, count: 3 },
+			{ minValue: 90, count: 3 },
+		],
+		interval: 10,
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<IHistogramSliderSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const changeSliderValue = (
 	sliderSpy: jest.SpyInstance<JSX.Element, [FormHistogramSliderProps]>,
@@ -174,65 +153,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			changeSliderValue(sliderSpy, [20, 60]);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: { from: 10, to: 50 } } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			changeSliderValue(sliderSpy, [20, 60]);
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: { from: 10, to: 50 } } }}
-					onClick={handleClick}
-				/>
-			);
-			changeSliderValue(sliderSpy, [20, 60]);
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: { from: 10, to: 50 },
+		modifyField: () => changeSliderValue(sliderSpy, [20, 60]),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/masked-field/masked-field.spec.tsx
+++ b/src/__tests__/components/fields/masked-field/masked-field.spec.tsx
@@ -9,6 +9,7 @@ import {
 	FRONTEND_ENGINE_ID,
 	FrontendEngineWithCustomButton,
 	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
@@ -16,44 +17,23 @@ import {
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const COMPONENT_LABEL = "Masked field";
 const UI_TYPE = "masked-field";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: COMPONENT_LABEL,
-					uiType: UI_TYPE,
-					maskRange: [0, 100],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
-	},
-};
 
-const renderComponent = (overrideField?: Partial<IMaskedFieldSchema> | undefined, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+const renderComponent = createRenderComponent<IMaskedFieldSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: COMPONENT_LABEL,
+		uiType: UI_TYPE,
+		maskRange: [0, 100],
+	},
+	submitFn: SUBMIT_FN,
+});
 
 const getMaskedField = (): HTMLElement => {
 	return getField("textbox", COMPONENT_LABEL);
@@ -119,7 +99,7 @@ describe(UI_TYPE, () => {
 	it("should mask based on regex", async () => {
 		const defaultValue = "hellohello";
 		renderComponent(
-			{ maskRange: null, maskRegex: "/^(hello)/g" },
+			{ maskRange: undefined, maskRegex: "/^(hello)/g" },
 			{ defaultValues: { [COMPONENT_ID]: defaultValue } }
 		);
 
@@ -165,65 +145,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getMaskedField(), { target: { value: "world" } });
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getMaskedField(), { target: { value: "world" } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.change(getMaskedField(), { target: { value: "world" } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: "hello",
+		modifyField: () => fireEvent.change(getMaskedField(), { target: { value: "world" } }),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/multi-select/multi-select.spec.tsx
+++ b/src/__tests__/components/fields/multi-select/multi-select.spec.tsx
@@ -6,68 +6,40 @@ import merge from "lodash/merge";
 import { useState } from "react";
 import { FrontendEngine } from "../../../../components";
 import { IMultiSelectSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
+import { IFrontendEngineData } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
-const FIELD_LABEL = "Multiselect";
 const UI_TYPE = "multi-select";
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Multiselect",
-					uiType: UI_TYPE,
-					options: [
-						{ label: "A", value: "Apple" },
-						{ label: "B", value: "Berry" },
-						{ label: "C", value: "Cherry" },
-						{ label: "D", value: "Durian" },
-					],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
+const renderComponent = createRenderComponent<IMultiSelectSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Multiselect",
+		uiType: UI_TYPE,
+		options: [
+			{ label: "A", value: "Apple" },
+			{ label: "B", value: "Berry" },
+			{ label: "C", value: "Cherry" },
+			{ label: "D", value: "Durian" },
+		],
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<IMultiSelectSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -319,68 +291,14 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: () => {
 			fireEvent.click(getComponent());
 			fireEvent.click(getCheckboxA());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getComponent());
-			fireEvent.click(getCheckboxA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(getComponent());
-			fireEvent.click(getCheckboxA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+		},
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/nested-multi-select/nested-multi-select.spec.tsx
+++ b/src/__tests__/components/fields/nested-multi-select/nested-multi-select.spec.tsx
@@ -6,21 +6,17 @@ import merge from "lodash/merge";
 import { useState } from "react";
 import { FrontendEngine } from "../../../../components";
 import { IL1Value, INestedMultiSelectSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
+import { IFrontendEngineData } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
 	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
@@ -53,53 +49,27 @@ const NESTED_JSON_FIELDS: TOverrideField<INestedMultiSelectSchema> = {
 	],
 };
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Nestedmultiselect",
-					uiType: UI_TYPE,
-					options: [
-						{ label: "A", value: "Apple", key: "appleKey" },
-						{ label: "B", value: "Berry", key: "berryKey" },
-						{ label: "C", value: "Cherry", key: "cherryKey" },
-						{ label: "D", value: "Durian", key: "durianKey" },
-					],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
+const renderComponent = createRenderComponent<INestedMultiSelectSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Nestedmultiselect",
+		uiType: UI_TYPE,
+		options: [
+			{ label: "A", value: "Apple", key: "appleKey" },
+			{ label: "B", value: "Berry", key: "berryKey" },
+			{ label: "C", value: "Cherry", key: "cherryKey" },
+			{ label: "D", value: "Durian", key: "durianKey" },
+		],
 	},
-};
-
-const renderComponent = (
-	overrideField?: TOverrideField<INestedMultiSelectSchema>,
-	overrideSchema?: TOverrideSchema
-) => {
-	const json: IFrontendEngineData<INestedMultiSelectSchema> = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: {
 	onClick: (data: IFrontendEngineData) => IFrontendEngineData;
 	initialSchema?: IFrontendEngineData;
 }) => {
 	const { onClick, initialSchema } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(initialSchema ?? JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(initialSchema ?? renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -362,7 +332,7 @@ describe(UI_TYPE, () => {
 		`("$scenario", async ({ selected, expectedValueBeforeUpdate, expectedValueAfterUpdate }) => {
 			render(
 				<ComponentWithSetSchemaButton
-					initialSchema={merge(cloneDeep(JSON_SCHEMA), {
+					initialSchema={merge(cloneDeep(renderComponent.schema), {
 						sections: {
 							section: {
 								children: {
@@ -459,7 +429,7 @@ describe(UI_TYPE, () => {
 			async ({ selected, expectedValueBeforeUpdate, expectedValueAfterUpdate }: Record<string, string[]>) => {
 				render(
 					<ComponentWithSetSchemaButton
-						initialSchema={JSON_SCHEMA}
+						initialSchema={renderComponent.schema}
 						onClick={(data) => ({
 							...data,
 							overrides: {
@@ -503,7 +473,7 @@ describe(UI_TYPE, () => {
 			async ({ selected, expectedValueBeforeUpdate, expectedValueAfterUpdate }: Record<string, string[]>) => {
 				render(
 					<ComponentWithSetSchemaButton
-						initialSchema={merge(cloneDeep(JSON_SCHEMA), {
+						initialSchema={merge(cloneDeep(renderComponent.schema), {
 							sections: {
 								section: {
 									children: {
@@ -603,83 +573,14 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: { appleKey: "apple" },
+		modifyField: () => {
 			fireEvent.click(getComponent());
 			fireEvent.click(getCheckboxA());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{
-						...JSON_SCHEMA,
-						defaultValues: {
-							[COMPONENT_ID]: {
-								appleKey: "apple",
-							},
-						},
-					}}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getComponent());
-			fireEvent.click(getCheckboxA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{
-						...JSON_SCHEMA,
-						defaultValues: {
-							[COMPONENT_ID]: {
-								appleKey: "apple",
-								berryKey: "Berry",
-							},
-						},
-					}}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(getComponent());
-			fireEvent.click(getCheckboxA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+		},
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/otp-verification-field/otp-verification-field.spec.tsx
+++ b/src/__tests__/components/fields/otp-verification-field/otp-verification-field.spec.tsx
@@ -18,7 +18,7 @@ import {
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
@@ -286,65 +286,11 @@ describe(UI_TYPE, () => {
 			});
 		});
 
-		describe("dirty state", () => {
-			let formIsDirty: boolean;
-			const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-				formIsDirty = ref.current.isDirty;
-			};
-
-			beforeEach(() => {
-				formIsDirty = undefined;
-			});
-
-			it("should mount without setting field state as dirty", () => {
-				rtlRender(<FrontendEngineWithCustomButton data={PHONE_SCHEMA} onClick={handleClick} />);
-				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-				expect(formIsDirty).toBe(false);
-			});
-
-			it("should set form state as dirty if user modifies the phone OTP field", () => {
-				rtlRender(<FrontendEngineWithCustomButton data={PHONE_SCHEMA} onClick={handleClick} />);
-				fireEvent.change(getPhoneNoInput(), { target: { value: MOCK_VALID_PHONE_NO } });
-				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-				expect(formIsDirty).toBe(true);
-			});
-
-			it("should support default verified value without setting form state as dirty", () => {
-				rtlRender(
-					<FrontendEngineWithCustomButton
-						data={{ ...PHONE_SCHEMA, defaultValues: { [COMPONENT_ID]: VERIFIED_PHONE_DEFAULT_VALUE } }}
-						onClick={handleClick}
-					/>
-				);
-				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-				expect(formIsDirty).toBe(false);
-			});
-
-			it("should reset and revert phone OTP form dirty state to false", () => {
-				rtlRender(<FrontendEngineWithCustomButton data={PHONE_SCHEMA} onClick={handleClick} />);
-				fireEvent.change(getPhoneNoInput(), { target: { value: MOCK_VALID_PHONE_NO } });
-				fireEvent.click(getResetButton());
-				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-				expect(formIsDirty).toBe(false);
-			});
-
-			it("should reset to default verified value without setting form state as dirty", () => {
-				rtlRender(
-					<FrontendEngineWithCustomButton
-						data={{ ...PHONE_SCHEMA, defaultValues: { [COMPONENT_ID]: VERIFIED_PHONE_DEFAULT_VALUE } }}
-						onClick={handleClick}
-					/>
-				);
-				fireEvent.change(getPhoneNoInput(), { target: { value: "98765432" } });
-				fireEvent.click(getResetButton());
-				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-				expect(formIsDirty).toBe(false);
-			});
+		dirtyStateTestSuite({
+			schema: PHONE_SCHEMA,
+			componentId: COMPONENT_ID,
+			defaultValue: VERIFIED_PHONE_DEFAULT_VALUE,
+			modifyField: () => fireEvent.change(getPhoneNoInput(), { target: { value: MOCK_VALID_PHONE_NO } }),
 		});
 	});
 

--- a/src/__tests__/components/fields/radio-button/radio-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-button.spec.tsx
@@ -5,21 +5,16 @@ import merge from "lodash/merge";
 import { useState } from "react";
 import { FrontendEngine } from "../../../../components";
 import { TRadioButtonGroupSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
+import { IFrontendEngineData } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
@@ -34,44 +29,22 @@ const getRadioButtonB = (): HTMLElement => {
 	return getField("radio", "B");
 };
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Radio",
-					uiType: UI_TYPE,
-					options: [
-						{ label: "A", value: "Apple" },
-						{ label: "B", value: "Berry" },
-					],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
+const renderComponent = createRenderComponent<TRadioButtonGroupSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Radio",
+		uiType: UI_TYPE,
+		options: [
+			{ label: "A", value: "Apple" },
+			{ label: "B", value: "Berry" },
+		],
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<TRadioButtonGroupSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -308,65 +281,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getRadioButtonA());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getRadioButtonA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(getRadioButtonA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: () => fireEvent.click(getRadioButtonA()),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/radio-button/radio-image-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-image-button.spec.tsx
@@ -5,21 +5,9 @@ import merge from "lodash/merge";
 import { useState } from "react";
 import { FrontendEngine } from "../../../../components";
 import { TRadioButtonGroupSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
-import {
-	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
-	getErrorMessage,
-	getField,
-	getResetButton,
-	getResetButtonProps,
-	getSubmitButton,
-	getSubmitButtonProps,
-} from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { IFrontendEngineData } from "../../../../components/frontend-engine";
+import { ERROR_MESSAGE, createRenderComponent, getErrorMessage, getField, getSubmitButton } from "../../../common";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
@@ -34,47 +22,25 @@ const getRadioButtonB = (): HTMLElement => {
 	return getField("button", "B");
 };
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Radio",
-					uiType: UI_TYPE,
-					customOptions: {
-						styleType: "image-button",
-					},
-					options: [
-						{ label: "A", value: "Apple" },
-						{ label: "B", value: "Berry" },
-					],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
+const renderComponent = createRenderComponent<TRadioButtonGroupSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Radio",
+		uiType: UI_TYPE,
+		customOptions: {
+			styleType: "image-button",
 		},
+		options: [
+			{ label: "A", value: "Apple" },
+			{ label: "B", value: "Berry" },
+		],
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<TRadioButtonGroupSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -234,65 +200,11 @@ describe("radio toggle button", () => {
 		);
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getRadioButtonA());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getRadioButtonA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(getRadioButtonA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: () => fireEvent.click(getRadioButtonA()),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
@@ -5,21 +5,16 @@ import merge from "lodash/merge";
 import { useState } from "react";
 import { FrontendEngine } from "../../../../components";
 import { TRadioButtonGroupSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
+import { IFrontendEngineData } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
@@ -39,47 +34,25 @@ const getNestedField = (): HTMLElement => {
 	return screen.queryByRole("textbox");
 };
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Radio",
-					uiType: UI_TYPE,
-					customOptions: {
-						styleType: "toggle",
-					},
-					options: [
-						{ label: "A", value: "Apple" },
-						{ label: "B", value: "Berry" },
-					],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
+const renderComponent = createRenderComponent<TRadioButtonGroupSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Radio",
+		uiType: UI_TYPE,
+		customOptions: {
+			styleType: "toggle",
 		},
+		options: [
+			{ label: "A", value: "Apple" },
+			{ label: "B", value: "Berry" },
+		],
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<TRadioButtonGroupSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -415,65 +388,11 @@ describe("radio toggle button", () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getRadioButtonA());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getRadioButtonA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(getRadioButtonA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: () => fireEvent.click(getRadioButtonA()),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/range-select/range-select.spec.tsx
+++ b/src/__tests__/components/fields/range-select/range-select.spec.tsx
@@ -6,72 +6,43 @@ import merge from "lodash/merge";
 import { useState } from "react";
 import { FrontendEngine } from "../../../../components";
 import { IRangeSelectSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
+import { IFrontendEngineData } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
-	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "range-select";
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "RangeSelect",
-					uiType: UI_TYPE,
-					options: {
-						from: [
-							{ label: "A", value: "Apple" },
-							{ label: "B", value: "Berry" },
-						],
-						to: [
-							{ label: "C", value: "Cherry" },
-							{ label: "D", value: "Date" },
-						],
-					},
-					// listStyleWidth: "40rem",
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
+const renderComponent = createRenderComponent<IRangeSelectSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "RangeSelect",
+		uiType: UI_TYPE,
+		options: {
+			from: [
+				{ label: "A", value: "Apple" },
+				{ label: "B", value: "Berry" },
+			],
+			to: [
+				{ label: "C", value: "Cherry" },
+				{ label: "D", value: "Date" },
+			],
 		},
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<IRangeSelectSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -375,71 +346,15 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: async () => {
 			await waitFor(() => fireEvent.click(getComponent()));
 			await waitFor(() => fireEvent.click(getOptionA()));
 			await waitFor(() => fireEvent.click(getOptionC()));
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			await waitFor(() => fireEvent.click(getComponent()));
-			await waitFor(() => fireEvent.click(getOptionA()));
-			await waitFor(() => fireEvent.click(getOptionC()));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			await waitFor(() => fireEvent.click(getComponent()));
-			await waitFor(() => fireEvent.click(getOptionA()));
-			await waitFor(() => fireEvent.click(getOptionC()));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+		},
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/select-histogram/select-histogram.spec.tsx
+++ b/src/__tests__/components/fields/select-histogram/select-histogram.spec.tsx
@@ -1,70 +1,32 @@
-import { Form } from "@lifesg/react-design-system/form";
-import { FormSelectHistogramProps } from "@lifesg/react-design-system/form";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
+import { Form, FormSelectHistogramProps } from "@lifesg/react-design-system/form";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import { ISelectHistogramSchema } from "../../../../components/fields/select-histogram/types";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
 import { ERROR_MESSAGES } from "../../../../components/shared";
-import {
-	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
-	getResetButton,
-	getResetButtonProps,
-	getSubmitButton,
-	getSubmitButtonProps,
-} from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { ERROR_MESSAGE, createRenderComponent, getResetButton, getSubmitButton } from "../../../common";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "select-histogram";
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Select Histogram",
-					uiType: UI_TYPE,
-					histogramSlider: {
-						bins: [
-							{ minValue: 10, count: 1 },
-							{ minValue: 20, count: 0 },
-							{ minValue: 30, count: 3 },
-							{ minValue: 90, count: 3 },
-						],
-						interval: 10,
-					},
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
+const renderComponent = createRenderComponent<ISelectHistogramSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Select Histogram",
+		uiType: UI_TYPE,
+		histogramSlider: {
+			bins: [
+				{ minValue: 10, count: 1 },
+				{ minValue: 20, count: 0 },
+				{ minValue: 30, count: 3 },
+				{ minValue: 90, count: 3 },
+			],
+			interval: 10,
 		},
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<ISelectHistogramSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const getSelector = (): HTMLElement => {
 	return screen.getByTestId("selector");
@@ -184,65 +146,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			changeSliderValue(sliderSpy, [20, 60]);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: { from: 10, to: 50 } } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			changeSliderValue(sliderSpy, [20, 60]);
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: { from: 10, to: 50 } } }}
-					onClick={handleClick}
-				/>
-			);
-			changeSliderValue(sliderSpy, [20, 60]);
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: { from: 10, to: 50 },
+		modifyField: () => changeSliderValue(sliderSpy, [20, 60]),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/select/select.spec.tsx
+++ b/src/__tests__/components/fields/select/select.spec.tsx
@@ -3,68 +3,40 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { setupJestCanvasMock } from "jest-canvas-mock";
 import cloneDeep from "lodash/cloneDeep";
 import merge from "lodash/merge";
-import React, { useState } from "react";
-import { FrontendEngine } from "../../../../components";
+import { useState } from "react";
 import { ISelectSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
+import { FrontendEngine, IFrontendEngineData } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "select";
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Select",
-					uiType: UI_TYPE,
-					options: [
-						{ label: "A", value: "Apple" },
-						{ label: "B", value: "Berry" },
-					],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
+const renderComponent = createRenderComponent<ISelectSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Select",
+		uiType: UI_TYPE,
+		options: [
+			{ label: "A", value: "Apple" },
+			{ label: "B", value: "Berry" },
+		],
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<ISelectSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -252,68 +224,14 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: () => {
 			fireEvent.click(getSelectToggle());
 			fireEvent.click(screen.getByRole("option", { name: "A" }));
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getSelectToggle());
-			fireEvent.click(screen.getByRole("option", { name: "A" }));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(getSelectToggle());
-			fireEvent.click(screen.getByRole("option", { name: "A" }));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+		},
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/slider/slider.spec.tsx
+++ b/src/__tests__/components/fields/slider/slider.spec.tsx
@@ -1,61 +1,29 @@
-import { Form } from "@lifesg/react-design-system/form";
-import { FormSliderProps } from "@lifesg/react-design-system/form";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
+import { Form, FormSliderProps } from "@lifesg/react-design-system/form";
+import { act, fireEvent, waitFor } from "@testing-library/react";
 import { ISliderSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "slider";
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Slider",
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
+const renderComponent = createRenderComponent<ISliderSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Slider",
+		uiType: UI_TYPE,
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<ISliderSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const getSlider = (): HTMLElement => {
 	return getField("slider");
@@ -150,65 +118,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			changeSliderValue(sliderSpy, 15);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: 50 } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			changeSliderValue(sliderSpy, 15);
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: 50 } }}
-					onClick={handleClick}
-				/>
-			);
-			changeSliderValue(sliderSpy, 15);
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: 50,
+		modifyField: () => changeSliderValue(sliderSpy, 15),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/switch/switch.spec.tsx
+++ b/src/__tests__/components/fields/switch/switch.spec.tsx
@@ -1,61 +1,31 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
+import { fireEvent, waitFor } from "@testing-library/react";
 import { ISwitchSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "switch";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Switch",
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
+
+const renderComponent = createRenderComponent<ISwitchSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Switch",
+		uiType: UI_TYPE,
 	},
-};
+	submitFn: SUBMIT_FN,
+});
 
 const getSwitchButton = (type: "Yes" | "No"): HTMLElement => {
 	return getField("radio", type);
-};
-
-const renderComponent = (overrideField?: TOverrideField<ISwitchSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
 };
 
 describe(UI_TYPE, () => {
@@ -138,65 +108,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getSwitchButton("Yes"));
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getSwitchButton("Yes"));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(getSwitchButton("Yes"));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: () => fireEvent.click(getSwitchButton("Yes")),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/text-field/email-field.spec.tsx
+++ b/src/__tests__/components/fields/text-field/email-field.spec.tsx
@@ -1,25 +1,16 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
 import { IEmailFieldSchema } from "../../../../components/fields";
 import { ERROR_MESSAGES } from "../../../../components/shared";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/types";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
@@ -27,36 +18,15 @@ const COMPONENT_ID = "field";
 const COMPONENT_LABEL = "Email";
 const UI_TYPE = "email-field";
 const EXPECTED_VALUE = "aa@aa.com";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: COMPONENT_LABEL,
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
-	},
-};
 
-const renderComponent = (overrideField?: TOverrideField<IEmailFieldSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+const renderComponent = createRenderComponent<IEmailFieldSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: COMPONENT_LABEL,
+		uiType: UI_TYPE,
+	},
+	submitFn: SUBMIT_FN,
+});
 
 const getEmailField = (): HTMLElement => {
 	return getField("textbox", COMPONENT_LABEL);
@@ -240,65 +210,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getEmailField(), { target: { value: "world" } });
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "john@doe.tld" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getEmailField(), { target: { value: "world" } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "john@doe.tld" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.change(getEmailField(), { target: { value: "world" } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: "john@doe.tld",
+		modifyField: () => fireEvent.change(getEmailField(), { target: { value: "world" } }),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/text-field/numeric-field.spec.tsx
+++ b/src/__tests__/components/fields/text-field/numeric-field.spec.tsx
@@ -1,60 +1,30 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
 import { INumericFieldSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/types";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const COMPONENT_LABEL = "Numeric field";
 const UI_TYPE = "numeric-field";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: COMPONENT_LABEL,
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
-	},
-};
 
-const renderComponent = (overrideField?: TOverrideField<INumericFieldSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+const renderComponent = createRenderComponent<INumericFieldSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: COMPONENT_LABEL,
+		uiType: UI_TYPE,
+	},
+	submitFn: SUBMIT_FN,
+});
 
 const getNumericField = (): HTMLElement => {
 	return getField("spinbutton", COMPONENT_LABEL);
@@ -328,65 +298,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getNumericField(), { target: { value: 1 } });
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: 2 } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getNumericField(), { target: { value: 1 } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: 2 } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.change(getNumericField(), { target: { value: 1 } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: 2,
+		modifyField: () => fireEvent.change(getNumericField(), { target: { value: 1 } }),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/text-field/text-field.spec.tsx
+++ b/src/__tests__/components/fields/text-field/text-field.spec.tsx
@@ -1,59 +1,27 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
 import { ITextFieldSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/types";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const COMPONENT_LABEL = "Textfield";
 const UI_TYPE = "text-field";
 const EXPECTED_TEXT = "test this has been pasted";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: COMPONENT_LABEL,
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
-	},
-};
 
-const renderComponent = (overrideField?: Partial<ITextFieldSchema> | undefined, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+const renderComponent = createRenderComponent<ITextFieldSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: { label: COMPONENT_LABEL, uiType: UI_TYPE },
+	submitFn: SUBMIT_FN,
+});
 
 const getTextfield = (): HTMLElement => {
 	return getField("textbox", COMPONENT_LABEL);
@@ -73,9 +41,9 @@ describe(UI_TYPE, () => {
 	it("should support validation schema", async () => {
 		renderComponent({ validation: [{ required: true, errorMessage: ERROR_MESSAGE }] });
 
-		await waitFor(() => fireEvent.click(getSubmitButton()));
+		fireEvent.click(getSubmitButton());
 
-		expect(getErrorMessage()).toBeInTheDocument();
+		await waitFor(() => expect(getErrorMessage()).toBeInTheDocument());
 	});
 
 	it("should apply inputMode according to its type", () => {
@@ -102,8 +70,10 @@ describe(UI_TYPE, () => {
 
 		expect(screen.getByDisplayValue(defaultValue)).toBeInTheDocument();
 
-		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		fireEvent.click(getSubmitButton());
+		await waitFor(() =>
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }))
+		);
 	});
 
 	it("should pass other props into the field", () => {
@@ -126,7 +96,7 @@ describe(UI_TYPE, () => {
 		});
 		const textField = getTextfield();
 		textField.focus();
-		await waitFor(() => userEvent.paste(EXPECTED_TEXT));
+		await userEvent.paste(EXPECTED_TEXT);
 		expect(textField).toHaveValue(EXPECTED_TEXT);
 	});
 
@@ -138,7 +108,7 @@ describe(UI_TYPE, () => {
 		});
 		const textField = getTextfield();
 		textField.focus();
-		await waitFor(() => userEvent.paste(EXPECTED_TEXT));
+		await userEvent.paste(EXPECTED_TEXT);
 		expect(textField).toHaveValue("");
 	});
 
@@ -193,8 +163,10 @@ describe(UI_TYPE, () => {
 			expect(startIcon).toBeInTheDocument();
 			expect(getTextfield()).toHaveValue("hello");
 
-			await waitFor(() => fireEvent.click(getSubmitButton()));
-			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: "hello" }));
+			fireEvent.click(getSubmitButton());
+			await waitFor(() =>
+				expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: "hello" }))
+			);
 		});
 
 		it("should be able to render the label add on", async () => {
@@ -210,8 +182,10 @@ describe(UI_TYPE, () => {
 			expect(screen.getByText("$")).toBeInTheDocument();
 			expect(textfield).toHaveValue("hello");
 
-			await waitFor(() => fireEvent.click(getSubmitButton()));
-			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: "hello" }));
+			fireEvent.click(getSubmitButton());
+			await waitFor(() =>
+				expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: "hello" }))
+			);
 		});
 	});
 
@@ -221,9 +195,9 @@ describe(UI_TYPE, () => {
 
 			fireEvent.change(getTextfield(), { target: { value: "hello" } });
 			fireEvent.click(getResetButton());
-			await waitFor(() => fireEvent.click(getSubmitButton()));
+			fireEvent.click(getSubmitButton());
 
-			expect(getTextfield()).toHaveValue("");
+			await waitFor(() => expect(getTextfield()).toHaveValue(""));
 			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
@@ -233,72 +207,18 @@ describe(UI_TYPE, () => {
 
 			fireEvent.change(getTextfield(), { target: { value: "world" } });
 			fireEvent.click(getResetButton());
-			await waitFor(() => fireEvent.click(getSubmitButton()));
+			fireEvent.click(getSubmitButton());
 
-			expect(getTextfield()).toHaveValue(defaultValue);
+			await waitFor(() => expect(getTextfield()).toHaveValue(defaultValue));
 			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getTextfield(), { target: { value: "world" } });
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getTextfield(), { target: { value: "world" } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.change(getTextfield(), { target: { value: "world" } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: "hello",
+		modifyField: () => fireEvent.change(getTextfield(), { target: { value: "world" } }),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/textarea/textarea.spec.tsx
+++ b/src/__tests__/components/fields/textarea/textarea.spec.tsx
@@ -1,59 +1,26 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { ITextareaSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/types";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "textarea";
 const COMPONENT_LABEL = "Textarea";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: COMPONENT_LABEL,
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
-	},
-};
 
-const renderComponent = (overrideField?: TOverrideField<ITextareaSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+const renderComponent = createRenderComponent<ITextareaSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: { label: COMPONENT_LABEL, uiType: UI_TYPE },
+	submitFn: SUBMIT_FN,
+});
 
 const getTextarea = (): HTMLElement => {
 	return getField("textbox", COMPONENT_LABEL);
@@ -73,9 +40,9 @@ describe(UI_TYPE, () => {
 	it("should support validation schema", async () => {
 		renderComponent({ validation: [{ required: true, errorMessage: ERROR_MESSAGE }] });
 
-		await waitFor(() => fireEvent.click(getSubmitButton()));
+		fireEvent.click(getSubmitButton());
 
-		expect(getErrorMessage()).toBeInTheDocument();
+		await waitFor(() => expect(getErrorMessage()).toBeInTheDocument());
 	});
 
 	it("should support default value", async () => {
@@ -84,8 +51,10 @@ describe(UI_TYPE, () => {
 
 		expect(screen.getByText(defaultValue)).toBeInTheDocument();
 
-		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		fireEvent.click(getSubmitButton());
+		await waitFor(() =>
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }))
+		);
 	});
 
 	it("should apply maxLength attribute if max validation is specified", () => {
@@ -145,9 +114,9 @@ describe(UI_TYPE, () => {
 
 			fireEvent.change(getTextarea(), { target: { value: "hello" } });
 			fireEvent.click(getResetButton());
-			await waitFor(() => fireEvent.click(getSubmitButton()));
+			fireEvent.click(getSubmitButton());
 
-			expect(getTextarea()).toHaveValue("");
+			await waitFor(() => expect(getTextarea()).toHaveValue(""));
 			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
@@ -157,72 +126,18 @@ describe(UI_TYPE, () => {
 
 			fireEvent.change(getTextarea(), { target: { value: "world" } });
 			fireEvent.click(getResetButton());
-			await waitFor(() => fireEvent.click(getSubmitButton()));
+			fireEvent.click(getSubmitButton());
 
-			expect(getTextarea()).toHaveValue(defaultValue);
+			await waitFor(() => expect(getTextarea()).toHaveValue(defaultValue));
 			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getTextarea(), { target: { value: "world" } });
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getTextarea(), { target: { value: "world" } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.change(getTextarea(), { target: { value: "world" } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: "hello",
+		modifyField: () => fireEvent.change(getTextarea(), { target: { value: "world" } }),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/time-field/time-field.spec.tsx
+++ b/src/__tests__/components/fields/time-field/time-field.spec.tsx
@@ -1,60 +1,30 @@
 import { LocalTime } from "@js-joda/core";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
+import { fireEvent, waitFor } from "@testing-library/react";
 import { ITimeFieldSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const COMPONENT_LABEL = "Time";
 const UI_TYPE = "time-field";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: COMPONENT_LABEL,
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
-	},
-};
 
-const renderComponent = (overrideField?: TOverrideField<ITimeFieldSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+const renderComponent = createRenderComponent<ITimeFieldSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: COMPONENT_LABEL,
+		uiType: UI_TYPE,
+	},
+	submitFn: SUBMIT_FN,
+});
 
 const getTimePicker = (): HTMLElement => {
 	return getField("combobox");
@@ -179,65 +149,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			await pickValidTime();
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			await pickValidTime();
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			await pickValidTime();
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: "hello",
+		modifyField: () => pickValidTime(),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/unit-number-field/unit-number.spec.tsx
+++ b/src/__tests__/components/fields/unit-number-field/unit-number.spec.tsx
@@ -1,58 +1,23 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { IUnitNumberFieldSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
 import { ERROR_MESSAGES } from "../../../../components/shared";
-import {
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
-	getField,
-	getResetButton,
-	getResetButtonProps,
-	getSubmitButton,
-	getSubmitButtonProps,
-} from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { createRenderComponent, getResetButton, getSubmitButton } from "../../../common";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const COMPONENT_LABEL = "Unit Number";
 const UI_TYPE = "unit-number-field";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: COMPONENT_LABEL,
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
-	},
-};
 
-const renderComponent = (overrideField?: TOverrideField<IUnitNumberFieldSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+const renderComponent = createRenderComponent<IUnitNumberFieldSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: COMPONENT_LABEL,
+		uiType: UI_TYPE,
+	},
+	submitFn: SUBMIT_FN,
+});
 
 const getFloorInputField = (): HTMLElement => {
 	return screen.getByTestId("floor-input");
@@ -175,65 +140,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			setFieldValue("12", "34");
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "01-02" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			setFieldValue("12", "34");
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "01-02" } }}
-					onClick={handleClick}
-				/>
-			);
-			setFieldValue("12", "34");
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: "01-02",
+		modifyField: () => setFieldValue("12", "34"),
 	});
 
 	labelTestSuite(renderComponent);


### PR DESCRIPTION
**Changes**
- Introduce `dirtyStateTestSuite` and `createRenderComponent` utils to reduce boilerplate across field integration tests
- Converts test files to utilize the utils, removing ~2000 lines of duplicated test code. Some tests are left untouched since those doesn't follow the same pattern.

**Checklist**
- [x] All test suites pass
- [x] TypeScript compilation passes