### PR TITLE
[MISC][GZ] shared dirty state test suite and render helper

### DIFF
--- a/src/__tests__/common/data.ts
+++ b/src/__tests__/common/data.ts
@@ -1,5 +1,6 @@
 import { ISubmitButtonSchema } from "../../components/fields";
 
+export const CUSTOM_BUTTON_LABEL = "Custom Button";
 export const SUBMIT_BUTTON_ID = "submit";
 export const SUBMIT_BUTTON_LABEL = "Submit";
 export const RESET_BUTTON_ID = "reset";

--- a/src/__tests__/common/helper.tsx
+++ b/src/__tests__/common/helper.tsx
@@ -7,7 +7,14 @@ import {
 	TFrontendEngineFieldSchema,
 	TFrontendEngineValues,
 } from "../../components/frontend-engine";
-import { ERROR_MESSAGE, RESET_BUTTON_ID, RESET_BUTTON_LABEL, SUBMIT_BUTTON_ID, SUBMIT_BUTTON_LABEL } from "./data";
+import {
+	CUSTOM_BUTTON_LABEL,
+	ERROR_MESSAGE,
+	RESET_BUTTON_ID,
+	RESET_BUTTON_LABEL,
+	SUBMIT_BUTTON_ID,
+	SUBMIT_BUTTON_LABEL,
+} from "./data";
 import { useEffect, useRef } from "react";
 
 type TAriaRoles =
@@ -21,6 +28,10 @@ type TAriaRoles =
 	| "option"
 	| "treeitem"
 	| "combobox";
+
+export const getCustomButton = (): HTMLElement => {
+	return screen.getByRole("button", { name: CUSTOM_BUTTON_LABEL });
+};
 
 export const getSubmitButton = (): HTMLElement => {
 	return screen.getByRole("button", { name: SUBMIT_BUTTON_LABEL });
@@ -90,7 +101,7 @@ export const FrontendEngineWithCustomButton = (props: {
 		<>
 			<FrontendEngine {...overrideProps} data={data} ref={ref} onSubmit={onSubmit} />
 			<button type="button" onClick={() => onClick(ref)}>
-				Custom Button
+				{CUSTOM_BUTTON_LABEL}
 			</button>
 		</>
 	);

--- a/src/__tests__/common/index.ts
+++ b/src/__tests__/common/index.ts
@@ -1,3 +1,4 @@
 export * from "./data";
 export * from "./helper";
+export * from "./render-helper";
 export * from "./types";

--- a/src/__tests__/common/render-helper.tsx
+++ b/src/__tests__/common/render-helper.tsx
@@ -1,0 +1,47 @@
+import { RenderResult, render } from "@testing-library/react";
+import { FrontendEngine } from "../../components";
+import { IFrontendEngineData, IFrontendEngineProps, TFrontendEngineFieldSchema } from "../../components/types";
+import { FRONTEND_ENGINE_ID } from "./data";
+import { getResetButtonProps, getSubmitButtonProps } from "./helper";
+import { TOverrideField, TOverrideSchema } from "./types";
+
+interface ICreateRenderComponentOptions {
+	componentId: string;
+	baseSchema: Record<string, unknown>;
+	submitFn?: jest.Mock;
+	includeReset?: boolean;
+	engineProps?: Partial<Omit<IFrontendEngineProps, "data" | "onSubmit">>;
+}
+
+export function createRenderComponent<TFieldSchema>(options: ICreateRenderComponentOptions) {
+	const { componentId, baseSchema, submitFn = jest.fn(), includeReset = true, engineProps } = options;
+
+	const baseJsonSchema: IFrontendEngineData = {
+		id: FRONTEND_ENGINE_ID,
+		sections: {
+			section: {
+				uiType: "section",
+				children: {
+					[componentId]: baseSchema as TFrontendEngineFieldSchema,
+					...getSubmitButtonProps(),
+					...(includeReset ? getResetButtonProps() : {}),
+				},
+			},
+		},
+	};
+
+	const renderFn = (overrideField?: TOverrideField<TFieldSchema>, overrideSchema?: TOverrideSchema): RenderResult => {
+		const json: IFrontendEngineData = JSON.parse(JSON.stringify(baseJsonSchema));
+		if (overrideSchema) {
+			Object.assign(json, { ...overrideSchema, sections: json.sections });
+		}
+		if (overrideField) {
+			Object.assign(json.sections.section.children[componentId] as object, overrideField);
+		}
+		return render(<FrontendEngine {...engineProps} data={json} onSubmit={submitFn} />);
+	};
+
+	renderFn.schema = baseJsonSchema;
+
+	return renderFn;
+}

--- a/src/__tests__/common/render-helper.tsx
+++ b/src/__tests__/common/render-helper.tsx
@@ -1,9 +1,9 @@
-import { RenderResult, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { FrontendEngine } from "../../components";
 import { IFrontendEngineData, IFrontendEngineProps, TFrontendEngineFieldSchema } from "../../components/types";
 import { FRONTEND_ENGINE_ID } from "./data";
 import { getResetButtonProps, getSubmitButtonProps } from "./helper";
-import { TOverrideField, TOverrideSchema } from "./types";
+import { TRenderComponent } from "./types";
 
 interface ICreateRenderComponentOptions {
 	componentId: string;
@@ -30,7 +30,10 @@ export function createRenderComponent<TFieldSchema>(options: ICreateRenderCompon
 		},
 	};
 
-	const renderFn = (overrideField?: TOverrideField<TFieldSchema>, overrideSchema?: TOverrideSchema): RenderResult => {
+	const renderFn: TRenderComponent<TFieldSchema> & { schema: IFrontendEngineData } = (
+		overrideField?,
+		overrideSchema?
+	) => {
 		const json: IFrontendEngineData = JSON.parse(JSON.stringify(baseJsonSchema));
 		if (overrideSchema) {
 			Object.assign(json, { ...overrideSchema, sections: json.sections });

--- a/src/__tests__/common/render-helper.tsx
+++ b/src/__tests__/common/render-helper.tsx
@@ -16,7 +16,7 @@ interface ICreateRenderComponentOptions {
 export function createRenderComponent<TFieldSchema>(options: ICreateRenderComponentOptions) {
 	const { componentId, baseSchema, submitFn = jest.fn(), includeReset = true, engineProps } = options;
 
-	const baseJsonSchema: IFrontendEngineData = {
+	const schema: IFrontendEngineData = {
 		id: FRONTEND_ENGINE_ID,
 		sections: {
 			section: {
@@ -30,11 +30,8 @@ export function createRenderComponent<TFieldSchema>(options: ICreateRenderCompon
 		},
 	};
 
-	const renderFn: TRenderComponent<TFieldSchema> & { schema: IFrontendEngineData } = (
-		overrideField?,
-		overrideSchema?
-	) => {
-		const json: IFrontendEngineData = JSON.parse(JSON.stringify(baseJsonSchema));
+	const renderComponent: TRenderComponent<TFieldSchema> = (overrideField?, overrideSchema?) => {
+		const json: IFrontendEngineData = JSON.parse(JSON.stringify(schema));
 		if (overrideSchema) {
 			Object.assign(json, { ...overrideSchema, sections: json.sections });
 		}
@@ -44,7 +41,5 @@ export function createRenderComponent<TFieldSchema>(options: ICreateRenderCompon
 		return render(<FrontendEngine {...engineProps} data={json} onSubmit={submitFn} />);
 	};
 
-	renderFn.schema = baseJsonSchema;
-
-	return renderFn;
+	return { renderComponent, schema };
 }

--- a/src/__tests__/common/tests/dirty-state.tsx
+++ b/src/__tests__/common/tests/dirty-state.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { IFrontendEngineData, IFrontendEngineRef } from "../../../components/types";
+import { FrontendEngineWithCustomButton, getResetButton } from "../helper";
+
+interface IDirtyStateTestSuiteOptions {
+	schema: IFrontendEngineData;
+	componentId: string;
+	defaultValue: unknown;
+	modifyField: () => unknown;
+}
+
+export const dirtyStateTestSuite = (options: IDirtyStateTestSuiteOptions) =>
+	describe("dirty state", () => {
+		const { schema, componentId, defaultValue, modifyField } = options;
+		let formIsDirty: boolean | undefined;
+		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
+			formIsDirty = ref.current.isDirty;
+		};
+
+		beforeEach(() => {
+			formIsDirty = undefined;
+		});
+
+		it("should mount without setting field state as dirty", () => {
+			render(<FrontendEngineWithCustomButton data={schema} onClick={handleClick} />);
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(false);
+		});
+
+		it("should set form state as dirty if user modifies the field", async () => {
+			render(<FrontendEngineWithCustomButton data={schema} onClick={handleClick} />);
+			await modifyField();
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(true);
+		});
+
+		it("should support default value without setting form state as dirty", () => {
+			render(
+				<FrontendEngineWithCustomButton
+					data={{ ...schema, defaultValues: { [componentId]: defaultValue } }}
+					onClick={handleClick}
+				/>
+			);
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(false);
+		});
+
+		it("should reset and revert form dirty state to false", async () => {
+			render(<FrontendEngineWithCustomButton data={schema} onClick={handleClick} />);
+			await modifyField();
+			fireEvent.click(getResetButton());
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(false);
+		});
+
+		it("should reset to default value without setting form state as dirty", async () => {
+			render(
+				<FrontendEngineWithCustomButton
+					data={{ ...schema, defaultValues: { [componentId]: defaultValue } }}
+					onClick={handleClick}
+				/>
+			);
+			await modifyField();
+			fireEvent.click(getResetButton());
+			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+
+			expect(formIsDirty).toBe(false);
+		});
+	});

--- a/src/__tests__/common/tests/dirty-state.tsx
+++ b/src/__tests__/common/tests/dirty-state.tsx
@@ -1,29 +1,40 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render } from "@testing-library/react";
 import { IFrontendEngineData, IFrontendEngineRef } from "../../../components/types";
-import { FrontendEngineWithCustomButton, getResetButton } from "../helper";
+import { FrontendEngineWithCustomButton, getCustomButton, getResetButton } from "../helper";
 
 interface IDirtyStateTestSuiteOptions {
 	schema: IFrontendEngineData;
 	componentId: string;
 	defaultValue: unknown;
 	modifyField: () => unknown;
+	modifyAndRemoveField?: () => unknown;
+	beforeEach?: () => void;
 }
 
+/**
+ * The test suites for dirty state. It will test the following scenarios:
+ * 1. Should mount without setting field state as dirty
+ * 2. Should set form state as dirty if user modifies the field
+ * 3. Should support default value without setting form state as dirty
+ * 4. Should reset and revert form dirty state to false
+ * 5. Should reset to default value without setting form state as dirty
+ */
 export const dirtyStateTestSuite = (options: IDirtyStateTestSuiteOptions) =>
 	describe("dirty state", () => {
-		const { schema, componentId, defaultValue, modifyField } = options;
+		const { schema, componentId, defaultValue, modifyField, beforeEach: setup, modifyAndRemoveField } = options;
 		let formIsDirty: boolean | undefined;
 		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
 			formIsDirty = ref.current.isDirty;
 		};
 
-		beforeEach(() => {
+		beforeEach(async () => {
 			formIsDirty = undefined;
+			setup?.();
 		});
 
 		it("should mount without setting field state as dirty", () => {
 			render(<FrontendEngineWithCustomButton data={schema} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+			fireEvent.click(getCustomButton());
 
 			expect(formIsDirty).toBe(false);
 		});
@@ -31,19 +42,19 @@ export const dirtyStateTestSuite = (options: IDirtyStateTestSuiteOptions) =>
 		it("should set form state as dirty if user modifies the field", async () => {
 			render(<FrontendEngineWithCustomButton data={schema} onClick={handleClick} />);
 			await modifyField();
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+			fireEvent.click(getCustomButton());
 
 			expect(formIsDirty).toBe(true);
 		});
 
-		it("should support default value without setting form state as dirty", () => {
+		it("should support default value without setting form state as dirty", async () => {
 			render(
 				<FrontendEngineWithCustomButton
 					data={{ ...schema, defaultValues: { [componentId]: defaultValue } }}
 					onClick={handleClick}
 				/>
 			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+			fireEvent.click(getCustomButton());
 
 			expect(formIsDirty).toBe(false);
 		});
@@ -52,7 +63,7 @@ export const dirtyStateTestSuite = (options: IDirtyStateTestSuiteOptions) =>
 			render(<FrontendEngineWithCustomButton data={schema} onClick={handleClick} />);
 			await modifyField();
 			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+			fireEvent.click(getCustomButton());
 
 			expect(formIsDirty).toBe(false);
 		});
@@ -66,8 +77,23 @@ export const dirtyStateTestSuite = (options: IDirtyStateTestSuiteOptions) =>
 			);
 			await modifyField();
 			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
+			fireEvent.click(getCustomButton());
 
 			expect(formIsDirty).toBe(false);
 		});
+
+		if (modifyAndRemoveField) {
+			it("should set form state as dirty if user modifies and then removes the field", async () => {
+				render(
+					<FrontendEngineWithCustomButton
+						data={{ ...schema, defaultValues: { [componentId]: defaultValue } }}
+						onClick={handleClick}
+					/>
+				);
+				await modifyAndRemoveField?.();
+				fireEvent.click(getCustomButton());
+
+				expect(formIsDirty).toBe(true);
+			});
+		}
 	});

--- a/src/__tests__/common/tests/index.ts
+++ b/src/__tests__/common/tests/index.ts
@@ -1,1 +1,2 @@
+export * from "./dirty-state";
 export * from "./labels";

--- a/src/__tests__/common/tests/index.ts
+++ b/src/__tests__/common/tests/index.ts
@@ -1,2 +1,3 @@
 export * from "./dirty-state";
 export * from "./labels";
+export * from "./warnings";

--- a/src/__tests__/common/tests/labels.ts
+++ b/src/__tests__/common/tests/labels.ts
@@ -1,6 +1,7 @@
 import { fireEvent, screen } from "@testing-library/react";
 
-export const labelTestSuite = (renderComponent: (overrideField: unknown) => void) =>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const labelTestSuite = (renderComponent: (overrideField?: any) => void) =>
 	describe("labels", () => {
 		const getComputedStyle = window.getComputedStyle.bind(window);
 

--- a/src/__tests__/common/tests/labels.ts
+++ b/src/__tests__/common/tests/labels.ts
@@ -1,7 +1,7 @@
 import { fireEvent, screen } from "@testing-library/react";
+import { TRenderComponent } from "../types";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const labelTestSuite = (renderComponent: (overrideField?: any) => void) =>
+export const labelTestSuite = (renderComponent: TRenderComponent) =>
 	describe("labels", () => {
 		const getComputedStyle = window.getComputedStyle.bind(window);
 

--- a/src/__tests__/common/types.ts
+++ b/src/__tests__/common/types.ts
@@ -1,4 +1,9 @@
+import { RenderResult } from "@testing-library/react";
 import { IFrontendEngineData } from "../../components/frontend-engine";
 
 export type TOverrideField<T> = Partial<Omit<T, "uiType">> | undefined;
 export type TOverrideSchema = Partial<Omit<IFrontendEngineData, "sections">> | undefined;
+export type TRenderComponent<T = unknown> = (
+	overrideField?: TOverrideField<T>,
+	overrideSchema?: TOverrideSchema
+) => RenderResult;

--- a/src/__tests__/components/custom/array-field/array-field.spec.tsx
+++ b/src/__tests__/components/custom/array-field/array-field.spec.tsx
@@ -17,8 +17,7 @@ import {
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
-import { warningTestSuite } from "../../../common/tests/warnings";
-import { dirtyStateTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const VALUE_CHANGE_FN = jest.fn();

--- a/src/__tests__/components/custom/array-field/array-field.spec.tsx
+++ b/src/__tests__/components/custom/array-field/array-field.spec.tsx
@@ -18,6 +18,7 @@ import {
 	getSubmitButtonProps,
 } from "../../../common";
 import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const VALUE_CHANGE_FN = jest.fn();
@@ -30,6 +31,7 @@ const NESTED_ARRAY_FIELD_ID = "nested-array-field";
 const NESTED_TEXT_FIELD_ID = "nestedInput";
 const NESTED_TEXT_FIELD_LABEL = "NestedTextField";
 const UNIQUE_ITEM_ERROR = "Use a different value from the other entries";
+const REMOVE_CONFIRMATION_MODAL_TITLE = "Remove entry?";
 
 const JSON_SCHEMA: IFrontendEngineData = {
 	id: FRONTEND_ENGINE_ID,
@@ -195,12 +197,12 @@ describe(UI_TYPE, () => {
 			fireEvent.click(getRemoveButton(0));
 
 			await waitFor(() => {
-				expect(screen.queryByText("Remove entry?")).toBeVisible();
+				expect(screen.queryByText(REMOVE_CONFIRMATION_MODAL_TITLE)).toBeVisible();
 			});
 
 			fireEvent.click(screen.queryByTestId("field-remove-prompt__btn-remove"));
 
-			expect(screen.queryByText("Remove entry?")).not.toBeVisible();
+			expect(screen.queryByText(REMOVE_CONFIRMATION_MODAL_TITLE)).not.toBeVisible();
 
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
@@ -213,12 +215,12 @@ describe(UI_TYPE, () => {
 			fireEvent.click(getRemoveButton(0));
 
 			await waitFor(() => {
-				expect(screen.queryByText("Remove entry?")).toBeVisible();
+				expect(screen.queryByText(REMOVE_CONFIRMATION_MODAL_TITLE)).toBeVisible();
 			});
 
 			fireEvent.click(screen.queryByTestId("field-remove-prompt__btn-back"));
 
-			expect(screen.queryByText("Remove entry?")).not.toBeVisible();
+			expect(screen.queryByText(REMOVE_CONFIRMATION_MODAL_TITLE)).not.toBeVisible();
 
 			await waitFor(() => fireEvent.click(getSubmitButton()));
 
@@ -297,7 +299,7 @@ describe(UI_TYPE, () => {
 			fireEvent.click(getRemoveButton(0));
 
 			await waitFor(() => {
-				expect(screen.queryByText("Remove entry?")).toBeVisible();
+				expect(screen.queryByText(REMOVE_CONFIRMATION_MODAL_TITLE)).toBeVisible();
 			});
 		});
 
@@ -308,7 +310,7 @@ describe(UI_TYPE, () => {
 
 			fireEvent.click(getRemoveButton(0));
 
-			expect(screen.queryByText("Remove entry?")).not.toBeInTheDocument();
+			expect(screen.queryByText(REMOVE_CONFIRMATION_MODAL_TITLE)).not.toBeInTheDocument();
 			expect(screen.queryByText("The information you’ve entered will be deleted.")).not.toBeVisible();
 
 			await waitFor(() => fireEvent.click(getSubmitButton()));
@@ -582,77 +584,6 @@ describe(UI_TYPE, () => {
 				expect.objectContaining({ [COMPONENT_ID]: [{ [TEXT_FIELD_ID]: "Hello" }] })
 			);
 			expect(screen.queryAllByText("Section title")).toHaveLength(1);
-		});
-	});
-
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-
-			await waitFor(() => fireEvent.change(getTextField(0), { target: { value: "Hello" } }));
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{
-						...JSON_SCHEMA,
-						defaultValues: { [COMPONENT_ID]: [{ [TEXT_FIELD_ID]: "Hello" }] },
-					}}
-					onClick={handleClick}
-				/>
-			);
-
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-
-			await waitFor(() => fireEvent.change(getTextField(0), { target: { value: "Hello" } }));
-			fireEvent.click(getResetButton());
-			await waitFor(() => fireEvent.click(screen.getByRole("button", { name: "Custom Button" })));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{
-						...JSON_SCHEMA,
-						defaultValues: { [COMPONENT_ID]: [{ [TEXT_FIELD_ID]: "Hello" }] },
-					}}
-					onClick={handleClick}
-				/>
-			);
-
-			await waitFor(() => fireEvent.change(getTextField(0), { target: { value: "Hello" } }));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
 		});
 	});
 
@@ -964,6 +895,15 @@ describe(UI_TYPE, () => {
 				expect(screen.queryByText(ERROR_MESSAGES.ARRAY_FIELD.UNIQUE)).toBeInTheDocument();
 			});
 		});
+	});
+
+	dirtyStateTestSuite({
+		schema: JSON_SCHEMA,
+		componentId: COMPONENT_ID,
+		defaultValue: [{ [TEXT_FIELD_ID]: "Hello" }],
+		modifyField: async () => {
+			await waitFor(() => fireEvent.change(getTextField(0), { target: { value: "Hello" } }));
+		},
 	});
 
 	warningTestSuite<IArrayFieldSchema>({

--- a/src/__tests__/components/custom/iframe/iframe.spec.tsx
+++ b/src/__tests__/components/custom/iframe/iframe.spec.tsx
@@ -2,18 +2,19 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import cloneDeep from "lodash/cloneDeep";
 import merge from "lodash/merge";
 import { EPostMessageEvent, IIframeSchema } from "../../../../components/custom";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/types";
+import { IFrontendEngineData } from "../../../../components/types";
 import {
 	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
 	FrontendEngineWithEventListener,
 	TOverrideField,
 	TOverrideSchema,
+	createRenderComponent,
 	getResetButton,
 	getResetButtonProps,
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
+import { dirtyStateTestSuite } from "../../../common/tests";
 
 const CHANGE_FN = jest.fn();
 const SUBMIT_FN = jest.fn();
@@ -46,7 +47,16 @@ interface IRenderOptions {
 	eventListener?: ((this: Element, ev: Event) => any) | undefined;
 }
 
-const renderComponent = (
+const renderComponent = createRenderComponent<IIframeSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		referenceKey: UI_TYPE,
+		src: IFRAME_SRC,
+	},
+	submitFn: SUBMIT_FN,
+});
+
+const renderWithEventListener = (
 	overrideField?: TOverrideField<IIframeSchema> | undefined,
 	overrideSchema?: TOverrideSchema | undefined,
 	options?: IRenderOptions | undefined
@@ -124,7 +134,7 @@ describe("iframe", () => {
 		it("should fire a loading event when iframe starts loading", () => {
 			const testFn = jest.fn();
 
-			renderComponent(undefined, undefined, { eventType: "loading", eventListener: testFn });
+			renderWithEventListener(undefined, undefined, { eventType: "loading", eventListener: testFn });
 
 			expect(testFn).toHaveBeenCalled();
 		});
@@ -132,7 +142,7 @@ describe("iframe", () => {
 		it("should fire a loaded event on receiving a loaded postMessage", () => {
 			const testFn = jest.fn();
 
-			renderComponent(undefined, undefined, { eventType: "loaded", eventListener: testFn });
+			renderWithEventListener(undefined, undefined, { eventType: "loaded", eventListener: testFn });
 			sendPostMessage(EPostMessageEvent.LOADED);
 
 			expect(testFn).toHaveBeenCalled();
@@ -185,7 +195,7 @@ describe("iframe", () => {
 		it("should fail validation if validation exceeds validationTimeout", async () => {
 			jest.useFakeTimers();
 
-			renderComponent({ validationTimeout: 1000 });
+			renderWithEventListener({ validationTimeout: 1000 });
 			await waitFor(() => sendPostMessage(EPostMessageEvent.SET_VALUE, "hello world"));
 
 			jest.advanceTimersByTime(100);
@@ -254,64 +264,10 @@ describe("iframe", () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			sendPostMessage(EPostMessageEvent.SET_VALUE, "hello world");
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			sendPostMessage(EPostMessageEvent.SET_VALUE, "hello world");
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			sendPostMessage(EPostMessageEvent.SET_VALUE, "hello world");
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: "hello",
+		modifyField: () => sendPostMessage(EPostMessageEvent.SET_VALUE, "hello world"),
 	});
 });

--- a/src/__tests__/components/custom/iframe/iframe.spec.tsx
+++ b/src/__tests__/components/custom/iframe/iframe.spec.tsx
@@ -47,7 +47,7 @@ interface IRenderOptions {
 	eventListener?: ((this: Element, ev: Event) => any) | undefined;
 }
 
-const renderComponent = createRenderComponent<IIframeSchema>({
+const { renderComponent, schema } = createRenderComponent<IIframeSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		referenceKey: UI_TYPE,
@@ -265,7 +265,7 @@ describe("iframe", () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: "hello",
 		modifyField: () => sendPostMessage(EPostMessageEvent.SET_VALUE, "hello world"),

--- a/src/__tests__/components/elements/tab/tab.spec.tsx
+++ b/src/__tests__/components/elements/tab/tab.spec.tsx
@@ -3,11 +3,11 @@ import { ITabItemSchema, ITabSchema } from "../../../../components/elements";
 import { IFrontendEngineData } from "../../../../components/frontend-engine";
 import {
 	FRONTEND_ENGINE_ID,
+	FrontendEngineWithEventListener,
 	TOverrideField,
 	getField,
 	getSubmitButton,
 	getSubmitButtonProps,
-	FrontendEngineWithEventListener,
 } from "../../../common";
 
 const SUBMIT_FN = jest.fn();

--- a/src/__tests__/components/fields/checkbox-group/checkbox-group.spec.tsx
+++ b/src/__tests__/components/fields/checkbox-group/checkbox-group.spec.tsx
@@ -4,66 +4,39 @@ import cloneDeep from "lodash/cloneDeep";
 import merge from "lodash/merge";
 import { useState } from "react";
 import { TCheckboxGroupSchema } from "../../../../components/fields";
-import { FrontendEngine, IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
+import { FrontendEngine, IFrontendEngineData } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "checkbox";
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Checkbox",
-					uiType: UI_TYPE,
-					options: [
-						{ label: "A", value: "Apple" },
-						{ label: "B", value: "Berry" },
-						{ label: "C", value: "Cherry" },
-						{ label: "D", value: "Durian" },
-					],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
+const renderComponent = createRenderComponent<TCheckboxGroupSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Checkbox",
+		uiType: UI_TYPE,
+		options: [
+			{ label: "A", value: "Apple" },
+			{ label: "B", value: "Berry" },
+			{ label: "C", value: "Cherry" },
+			{ label: "D", value: "Durian" },
+		],
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<TCheckboxGroupSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -356,68 +329,14 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: async () => {
 			const checkboxes = getCheckboxes();
 			await waitFor(() => fireEvent.click(checkboxes[0]));
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			const checkboxes = getCheckboxes();
-			await waitFor(() => fireEvent.click(checkboxes[0]));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			const checkboxes = getCheckboxes();
-			await waitFor(() => fireEvent.click(checkboxes[1]));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+		},
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/checkbox-group/checkbox-group.spec.tsx
+++ b/src/__tests__/components/fields/checkbox-group/checkbox-group.spec.tsx
@@ -12,8 +12,7 @@ import {
 	getResetButton,
 	getSubmitButton,
 } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/checkbox-group/checkbox-group.spec.tsx
+++ b/src/__tests__/components/fields/checkbox-group/checkbox-group.spec.tsx
@@ -18,7 +18,7 @@ const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "checkbox";
 
-const renderComponent = createRenderComponent<TCheckboxGroupSchema>({
+const { renderComponent, schema } = createRenderComponent<TCheckboxGroupSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		label: "Checkbox",
@@ -35,11 +35,11 @@ const renderComponent = createRenderComponent<TCheckboxGroupSchema>({
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
+	const [data, setData] = useState<IFrontendEngineData>(schema);
 	return (
 		<>
-			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
-			<Button.Default onClick={() => setSchema(onClick)}>Update options</Button.Default>
+			<FrontendEngine data={data} onSubmit={SUBMIT_FN} />
+			<Button.Default onClick={() => setData(onClick)}>Update options</Button.Default>
 		</>
 	);
 };
@@ -329,7 +329,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: ["Apple"],
 		modifyField: async () => {

--- a/src/__tests__/components/fields/checkbox-group/checkbox-toggle-group.spec.tsx
+++ b/src/__tests__/components/fields/checkbox-group/checkbox-toggle-group.spec.tsx
@@ -4,69 +4,42 @@ import cloneDeep from "lodash/cloneDeep";
 import merge from "lodash/merge";
 import { useState } from "react";
 import { TCheckboxGroupSchema } from "../../../../components/fields";
-import { FrontendEngine, IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
+import { FrontendEngine, IFrontendEngineData } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const NESTED_FIELD_ID = "nested-field";
 const UI_TYPE = "checkbox";
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Toggle",
-					uiType: UI_TYPE,
-					customOptions: {
-						styleType: "toggle",
-					},
-					options: [
-						{ label: "A", value: "Apple" },
-						{ label: "B", value: "Berry" },
-						{ label: "C", value: "Cherry" },
-						{ label: "D", value: "Durian" },
-					],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
+const renderComponent = createRenderComponent<TCheckboxGroupSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Toggle",
+		uiType: UI_TYPE,
+		customOptions: {
+			styleType: "toggle",
 		},
+		options: [
+			{ label: "A", value: "Apple" },
+			{ label: "B", value: "Berry" },
+			{ label: "C", value: "Cherry" },
+			{ label: "D", value: "Durian" },
+		],
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<TCheckboxGroupSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -447,68 +420,14 @@ describe("checkbox toggle group", () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: async () => {
 			const toggles = getToggles();
 			await waitFor(() => fireEvent.click(toggles[0]));
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			const toggles = getToggles();
-			await waitFor(() => fireEvent.click(toggles[0]));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			const toggles = getToggles();
-			await waitFor(() => fireEvent.click(toggles[1]));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+		},
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/checkbox-group/checkbox-toggle-group.spec.tsx
+++ b/src/__tests__/components/fields/checkbox-group/checkbox-toggle-group.spec.tsx
@@ -19,7 +19,7 @@ const COMPONENT_ID = "field";
 const NESTED_FIELD_ID = "nested-field";
 const UI_TYPE = "checkbox";
 
-const renderComponent = createRenderComponent<TCheckboxGroupSchema>({
+const { renderComponent, schema } = createRenderComponent<TCheckboxGroupSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		label: "Toggle",
@@ -39,11 +39,11 @@ const renderComponent = createRenderComponent<TCheckboxGroupSchema>({
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
+	const [data, setData] = useState<IFrontendEngineData>(schema);
 	return (
 		<>
-			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
-			<Button.Default onClick={() => setSchema(onClick)}>Update options</Button.Default>
+			<FrontendEngine data={data} onSubmit={SUBMIT_FN} />
+			<Button.Default onClick={() => setData(onClick)}>Update options</Button.Default>
 		</>
 	);
 };
@@ -421,7 +421,7 @@ describe("checkbox toggle group", () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: ["Apple"],
 		modifyField: async () => {

--- a/src/__tests__/components/fields/chips/chips.spec.tsx
+++ b/src/__tests__/components/fields/chips/chips.spec.tsx
@@ -4,67 +4,40 @@ import cloneDeep from "lodash/cloneDeep";
 import merge from "lodash/merge";
 import { useState } from "react";
 import { IChipsSchema } from "../../../../components/fields";
-import { FrontendEngine, IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
+import { FrontendEngine, IFrontendEngineData } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "chips";
 const TEXT_AREA_LABEL = "E";
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Chips",
-					uiType: UI_TYPE,
-					options: [
-						{ label: "A", value: "Apple" },
-						{ label: "B", value: "Berry" },
-						{ label: "C", value: "Cherry" },
-						{ label: "D", value: "Durian" },
-					],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
+const renderComponent = createRenderComponent<IChipsSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Chips",
+		uiType: UI_TYPE,
+		options: [
+			{ label: "A", value: "Apple" },
+			{ label: "B", value: "Berry" },
+			{ label: "C", value: "Cherry" },
+			{ label: "D", value: "Durian" },
+		],
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<IChipsSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -412,65 +385,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getChipA());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getChipA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(getChipB());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: () => fireEvent.click(getChipA()),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/chips/chips.spec.tsx
+++ b/src/__tests__/components/fields/chips/chips.spec.tsx
@@ -20,7 +20,7 @@ const COMPONENT_ID = "field";
 const UI_TYPE = "chips";
 const TEXT_AREA_LABEL = "E";
 
-const renderComponent = createRenderComponent<IChipsSchema>({
+const { renderComponent, schema } = createRenderComponent<IChipsSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		label: "Chips",
@@ -37,11 +37,11 @@ const renderComponent = createRenderComponent<IChipsSchema>({
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
+	const [data, setData] = useState<IFrontendEngineData>(schema);
 	return (
 		<>
-			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
-			<Button.Default onClick={() => setSchema(onClick)}>Update options</Button.Default>
+			<FrontendEngine data={data} onSubmit={SUBMIT_FN} />
+			<Button.Default onClick={() => setData(onClick)}>Update options</Button.Default>
 		</>
 	);
 };
@@ -386,7 +386,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: ["Apple"],
 		modifyField: () => fireEvent.click(getChipA()),

--- a/src/__tests__/components/fields/contact-field/contact-field.spec.tsx
+++ b/src/__tests__/components/fields/contact-field/contact-field.spec.tsx
@@ -12,6 +12,7 @@ import {
 	FrontendEngineWithCustomButton,
 	TOverrideField,
 	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
@@ -19,45 +20,21 @@ import {
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "contact-field";
 const COMPONENT_LABEL = "Contact Number";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: COMPONENT_LABEL,
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
-	},
-};
 
 jest.setTimeout(20000);
 
-const renderComponent = (overrideField?: TOverrideField<IContactFieldSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+const renderComponent = createRenderComponent<IContactFieldSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: { label: COMPONENT_LABEL, uiType: UI_TYPE },
+	submitFn: SUBMIT_FN,
+});
 
 const getContactField = (): HTMLElement => {
 	return screen.getByTestId("input");
@@ -392,71 +369,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getContactFieldWithPlaceholder(), {
-				target: { value: "+65 91234567" },
-			});
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "91234567" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getContactFieldWithPlaceholder(), {
-				target: { value: "+65 91234567" },
-			});
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "91234567" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.change(getContactFieldWithPlaceholder(), {
-				target: { value: "+65 91234567" },
-			});
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: "91234567",
+		modifyField: () => fireEvent.change(getContactFieldWithPlaceholder(), { target: { value: "+65 91234567" } }),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/contact-field/contact-field.spec.tsx
+++ b/src/__tests__/components/fields/contact-field/contact-field.spec.tsx
@@ -29,7 +29,7 @@ const COMPONENT_LABEL = "Contact Number";
 
 jest.setTimeout(20000);
 
-const renderComponent = createRenderComponent<IContactFieldSchema>({
+const { renderComponent, schema } = createRenderComponent<IContactFieldSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: { label: COMPONENT_LABEL, uiType: UI_TYPE },
 	submitFn: SUBMIT_FN,
@@ -369,7 +369,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: "91234567",
 		modifyField: () => fireEvent.change(getContactFieldWithPlaceholder(), { target: { value: "+65 91234567" } }),

--- a/src/__tests__/components/fields/contact-field/contact-field.spec.tsx
+++ b/src/__tests__/components/fields/contact-field/contact-field.spec.tsx
@@ -20,8 +20,7 @@ import {
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/date-field/date-field.spec.tsx
+++ b/src/__tests__/components/fields/date-field/date-field.spec.tsx
@@ -1,61 +1,28 @@
 import { LocalDate } from "@js-joda/core";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { IDateFieldSchema } from "../../../../components/fields";
 import { ERROR_MESSAGES } from "../../../../components/shared";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/types";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "date-field";
 const COMPONENT_LABEL = "Date";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: COMPONENT_LABEL,
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
-	},
-};
 
-const renderComponent = (overrideField?: TOverrideField<IDateFieldSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+const renderComponent = createRenderComponent<IDateFieldSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: { label: COMPONENT_LABEL, uiType: UI_TYPE },
+	submitFn: SUBMIT_FN,
+});
 
 const getDayInput = (): HTMLElement => {
 	return getField("textbox", "Date");
@@ -324,66 +291,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting form state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			await changeDate("25", "01", "2022");
-
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "2022-02-25" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			await changeDate("25", "01", "2022");
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "2022-02-25" } }}
-					onClick={handleClick}
-				/>
-			);
-			await changeDate("25", "01", "2022");
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: "2022-02-25",
+		modifyField: () => changeDate("25", "01", "2022"),
 	});
 	labelTestSuite(renderComponent);
 	warningTestSuite<IDateFieldSchema>({ label: COMPONENT_LABEL, uiType: UI_TYPE });

--- a/src/__tests__/components/fields/date-field/date-field.spec.tsx
+++ b/src/__tests__/components/fields/date-field/date-field.spec.tsx
@@ -17,7 +17,7 @@ const COMPONENT_ID = "field";
 const UI_TYPE = "date-field";
 const COMPONENT_LABEL = "Date";
 
-const renderComponent = createRenderComponent<IDateFieldSchema>({
+const { renderComponent, schema } = createRenderComponent<IDateFieldSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: { label: COMPONENT_LABEL, uiType: UI_TYPE },
 	submitFn: SUBMIT_FN,
@@ -291,7 +291,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: "2022-02-25",
 		modifyField: () => changeDate("25", "01", "2022"),

--- a/src/__tests__/components/fields/date-field/date-field.spec.tsx
+++ b/src/__tests__/components/fields/date-field/date-field.spec.tsx
@@ -10,8 +10,7 @@ import {
 	getResetButton,
 	getSubmitButton,
 } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/date-range-field/date-range-field.spec.tsx
+++ b/src/__tests__/components/fields/date-range-field/date-range-field.spec.tsx
@@ -16,8 +16,7 @@ import {
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { labelTestSuite, warningTestSuite } from "../../../common/tests";
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const label = "Date";

--- a/src/__tests__/components/fields/e-signature-field/e-signature-field.spec.tsx
+++ b/src/__tests__/components/fields/e-signature-field/e-signature-field.spec.tsx
@@ -17,8 +17,7 @@ import {
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/file-upload/file-upload.spec.tsx
+++ b/src/__tests__/components/fields/file-upload/file-upload.spec.tsx
@@ -20,6 +20,7 @@ import {
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
+import { dirtyStateTestSuite } from "../../../common/tests";
 
 const JPG_BASE64 =
 	"data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII=";
@@ -1227,12 +1228,8 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-		const json: IFrontendEngineData = {
+	dirtyStateTestSuite({
+		schema: {
 			id: FRONTEND_ENGINE_ID,
 			sections: {
 				section: {
@@ -1251,23 +1248,19 @@ describe(UI_TYPE, () => {
 					},
 				},
 			},
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
+		},
+		componentId: COMPONENT_ID,
+		defaultValue: {
+			fileId: FILE_1.name,
+			fileName: FILE_1.name,
+			dataURL: JPG_BASE64,
+		},
+		beforeEach: () => {
 			jest.spyOn(FileHelper, "dataUrlToBlob").mockResolvedValue(FILE_1);
 			jest.spyOn(FileHelper, "getType").mockResolvedValue({ ext: "jpg", mime: "image/jpeg" });
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={json} onClick={handleClick} />);
-			fireEvent.click(getCustomButton());
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user adds a file", async () => {
-			render(<FrontendEngineWithCustomButton data={json} onClick={handleClick} />);
+			jest.spyOn(ImageHelper, "convertBlob").mockResolvedValue(JPG_BASE64);
+		},
+		modifyField: async () => {
 			await act(async () => {
 				fireEvent.change(getDragInputUploadField(), {
 					target: {
@@ -1278,42 +1271,42 @@ describe(UI_TYPE, () => {
 				await waitFor(() => expect(screen.getByTestId(/thumbnail$/)).toBeInTheDocument());
 				await flushPromise();
 			});
-			fireEvent.click(getCustomButton());
+		},
+	});
 
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{
-						...json,
-						defaultValues: {
-							[COMPONENT_ID]: [
-								{
-									fileName: FILE_1.name,
-									dataURL: JPG_BASE64,
-								},
-							],
-						},
-					}}
-					onClick={handleClick}
-				/>
-			);
-			await act(async () => {
-				await waitFor(() => expect(screen.getByTestId(/thumbnail$/)).toBeInTheDocument());
-				await flushPromise();
-			});
-			fireEvent.click(getCustomButton());
-
-			expect(formIsDirty).toBe(false);
+	describe("dirty state", () => {
+		let formIsDirty: boolean;
+		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
+			formIsDirty = ref.current.isDirty;
+		};
+		beforeEach(() => {
+			formIsDirty = undefined;
+			jest.spyOn(FileHelper, "dataUrlToBlob").mockResolvedValue(FILE_1);
+			jest.spyOn(FileHelper, "getType").mockResolvedValue({ ext: "jpg", mime: "image/jpeg" });
 		});
 
 		it("should set form state as dirty if user removes an image", async () => {
 			render(
 				<FrontendEngineWithCustomButton
 					data={{
-						...json,
+						id: FRONTEND_ENGINE_ID,
+						sections: {
+							section: {
+								uiType: "section",
+								children: {
+									[COMPONENT_ID]: {
+										label: "Upload",
+										uiType: UI_TYPE,
+										uploadOnAddingFile: {
+											type: "base64",
+											url: UPLOAD_URL,
+										},
+									},
+									...getSubmitButtonProps(),
+									...getResetButtonProps(),
+								},
+							},
+						},
 						defaultValues: {
 							[COMPONENT_ID]: [
 								{
@@ -1335,56 +1328,6 @@ describe(UI_TYPE, () => {
 			fireEvent.click(getCustomButton());
 
 			expect(formIsDirty).toBe(true);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={json} onClick={handleClick} />);
-			await act(async () => {
-				fireEvent.change(getDragInputUploadField(), {
-					target: {
-						files: [FILE_1],
-					},
-				});
-				await waitFor(() => expect(screen.getByTestId(/image$/)).toBeInTheDocument());
-				await flushPromise();
-				await waitFor(() => fireEvent.click(getResetButton()));
-			});
-			fireEvent.click(getCustomButton());
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{
-						...json,
-						defaultValues: {
-							[COMPONENT_ID]: [
-								{
-									fileName: FILE_1.name,
-									dataURL: JPG_BASE64,
-								},
-							],
-						},
-					}}
-					onClick={handleClick}
-				/>
-			);
-			await act(async () => {
-				fireEvent.change(getDragInputUploadField(), {
-					target: {
-						files: [FILE_2],
-					},
-				});
-				await waitFor(() => expect(screen.getAllByTestId(/image$/).length).toBe(2));
-				await flushPromise(200);
-				await waitFor(() => fireEvent.click(getResetButton()));
-				await flushPromise();
-			});
-			fireEvent.click(getCustomButton());
-
-			expect(formIsDirty).toBe(false);
 		});
 	});
 

--- a/src/__tests__/components/fields/histogram-slider/histogram-slider.spec.tsx
+++ b/src/__tests__/components/fields/histogram-slider/histogram-slider.spec.tsx
@@ -13,55 +13,34 @@ import {
 	FrontendEngineWithCustomButton,
 	TOverrideField,
 	TOverrideSchema,
+	createRenderComponent,
 	getResetButton,
 	getResetButtonProps,
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "histogram-slider";
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Histogram slider",
-					uiType: UI_TYPE,
-					bins: [
-						{ minValue: 10, count: 1 },
-						{ minValue: 20, count: 0 },
-						{ minValue: 30, count: 3 },
-						{ minValue: 90, count: 3 },
-					],
-					interval: 10,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
+const renderComponent = createRenderComponent<IHistogramSliderSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Histogram slider",
+		uiType: UI_TYPE,
+		bins: [
+			{ minValue: 10, count: 1 },
+			{ minValue: 20, count: 0 },
+			{ minValue: 30, count: 3 },
+			{ minValue: 90, count: 3 },
+		],
+		interval: 10,
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<IHistogramSliderSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const changeSliderValue = (
 	sliderSpy: jest.SpyInstance<JSX.Element, [FormHistogramSliderProps]>,
@@ -174,65 +153,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			changeSliderValue(sliderSpy, [20, 60]);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: { from: 10, to: 50 } } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			changeSliderValue(sliderSpy, [20, 60]);
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: { from: 10, to: 50 } } }}
-					onClick={handleClick}
-				/>
-			);
-			changeSliderValue(sliderSpy, [20, 60]);
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: { from: 10, to: 50 },
+		modifyField: () => changeSliderValue(sliderSpy, [20, 60]),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/histogram-slider/histogram-slider.spec.tsx
+++ b/src/__tests__/components/fields/histogram-slider/histogram-slider.spec.tsx
@@ -19,8 +19,7 @@ import {
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/histogram-slider/histogram-slider.spec.tsx
+++ b/src/__tests__/components/fields/histogram-slider/histogram-slider.spec.tsx
@@ -25,7 +25,7 @@ const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "histogram-slider";
 
-const renderComponent = createRenderComponent<IHistogramSliderSchema>({
+const { renderComponent, schema } = createRenderComponent<IHistogramSliderSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		label: "Histogram slider",
@@ -153,7 +153,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: { from: 10, to: 50 },
 		modifyField: () => changeSliderValue(sliderSpy, [20, 60]),

--- a/src/__tests__/components/fields/image-upload/image-upload.spec.tsx
+++ b/src/__tests__/components/fields/image-upload/image-upload.spec.tsx
@@ -21,6 +21,7 @@ import {
 	getSubmitButtonProps,
 } from "../../../common";
 import * as WindowHelper from "../../../../utils/hooks/use-window-helper";
+import { dirtyStateTestSuite } from "../../../common/tests";
 
 const METADATA = { dateTimeOriginal: "2009:10:10 04:09:20", lat: 22.316033333333333, lng: 114.17031666666666 };
 
@@ -1292,12 +1293,8 @@ describe("image-upload", () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-		const json: IFrontendEngineData = {
+	dirtyStateTestSuite({
+		schema: {
 			id: FRONTEND_ENGINE_ID,
 			sections: {
 				section: {
@@ -1313,135 +1310,34 @@ describe("image-upload", () => {
 					},
 				},
 			},
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
+		},
+		componentId: COMPONENT_ID,
+		defaultValue: [
+			{
+				fileName: FILE_1.name,
+				dataURL: JPG_BASE64,
+			},
+		],
+		modifyField: async () => {
+			await act(async () => {
+				fireEvent.change(getDragInputUploadField(), {
+					target: {
+						files: [FILE_1],
+					},
+				});
+				await new Promise((resolve) => setTimeout(resolve, 100)); //add time-out due the the behavior change in the drag-upload
+			});
+		},
+		modifyAndRemoveField: async () => {
+			await waitFor(() => fireEvent.click(screen.getByTestId(`${COMPONENT_ID}-file-item-1__btn-delete`)));
+			await flushPromise();
+		},
+		beforeEach: () => {
 			jest.spyOn(ImageHelper, "convertBlob").mockResolvedValue(JPG_BASE64);
 			jest.spyOn(ImageHelper, "getMetadata").mockResolvedValue(METADATA);
 			jest.spyOn(FileHelper, "dataUrlToBlob").mockResolvedValue(FILE_1);
 			jest.spyOn(FileHelper, "getType").mockResolvedValue({ ext: "jpg", mime: "image/jpeg" });
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={json} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user adds an image", async () => {
-			render(<FrontendEngineWithCustomButton data={json} onClick={handleClick} />);
-			await act(async () => {
-				fireEvent.change(getDragInputUploadField(), {
-					target: {
-						files: [FILE_1],
-					},
-				});
-				await new Promise((resolve) => setTimeout(resolve, 100)); //add time-out due the the behavior change in the drag-upload
-			});
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{
-						...json,
-						defaultValues: {
-							[COMPONENT_ID]: [
-								{
-									fileName: FILE_1.name,
-									dataURL: JPG_BASE64,
-								},
-							],
-						},
-					}}
-					onClick={handleClick}
-				/>
-			);
-			await act(async () => {
-				await flushPromise();
-			});
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user removes an image", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{
-						...json,
-						defaultValues: {
-							[COMPONENT_ID]: [
-								{
-									fileName: FILE_1.name,
-									dataURL: JPG_BASE64,
-								},
-							],
-						},
-					}}
-					onClick={handleClick}
-				/>
-			);
-			await waitFor(() => fireEvent.click(screen.getByTestId(`${COMPONENT_ID}-file-item-1__btn-delete`)));
-			await flushPromise();
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={json} onClick={handleClick} />);
-			await act(async () => {
-				fireEvent.change(getDragInputUploadField(), {
-					target: {
-						files: [FILE_1],
-					},
-				});
-				await new Promise((resolve) => setTimeout(resolve, 100)); //add time-out due the the behavior change in the drag-upload
-				await flushPromise(100);
-				await waitFor(() => fireEvent.click(getResetButton()));
-			});
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{
-						...json,
-						defaultValues: {
-							[COMPONENT_ID]: [
-								{
-									fileName: FILE_1.name,
-									dataURL: JPG_BASE64,
-								},
-							],
-						},
-					}}
-					onClick={handleClick}
-				/>
-			);
-			await act(async () => {
-				fireEvent.change(getDragInputUploadField(), {
-					target: {
-						files: [FILE_2],
-					},
-				});
-				await new Promise((resolve) => setTimeout(resolve, 100)); //add time-out due the the behavior change in the drag-upload
-				await flushPromise(100);
-				await waitFor(() => fireEvent.click(getResetButton()));
-			});
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+		},
 	});
 
 	describe("when capture value is specified", () => {

--- a/src/__tests__/components/fields/location-field/location-field.spec.tsx
+++ b/src/__tests__/components/fields/location-field/location-field.spec.tsx
@@ -23,7 +23,7 @@ import {
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite, warningTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 import {
 	fetchSingleLocationByLatLngSingleReponse,
 	mock1PageFetchAddressResponse,
@@ -1919,12 +1919,8 @@ describe("location-input-group", () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-		const json: IFrontendEngineData = {
+	dirtyStateTestSuite({
+		schema: {
 			id: FRONTEND_ENGINE_ID,
 			sections: {
 				section: {
@@ -1939,120 +1935,33 @@ describe("location-input-group", () => {
 					},
 				},
 			},
-		};
-
-		beforeEach(() => {
+		},
+		componentId: COMPONENT_ID,
+		defaultValue: {
+			address: "Fusionopolis View",
+		},
+		modifyField: async () => {
+			await waitFor(() => window.dispatchEvent(new Event("online")));
+			getLocationInput().focus();
+			await waitFor(() => {
+				expect(getCurrentLocationErrorModal(true)).toBeInTheDocument();
+			});
+			within(getCurrentLocationErrorModal(true)).getByRole("button").click();
+			fireEvent.change(getLocationSearchInput(), { target: { value: "found something" } });
+			await waitFor(() => {
+				expect(getLocationSearchResults(true)).not.toBeEmptyDOMElement();
+			});
+			const resultContainer = getLocationSearchResults();
+			const selectedResult = resultContainer.getElementsByTagName("div")[0];
+			fireEvent.click(selectedResult);
+			fireEvent.click(getLocationModalControlButtons("Confirm"));
+		},
+		beforeEach: () => {
 			getCurrentLocationSpy.mockRejectedValue({ code: 1 });
 			fetchAddressSpy.mockImplementation((queryString, pageNumber, onSuccess) => {
 				onSuccess(mock1PageFetchAddressResponse);
 			});
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={json} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={json} onClick={handleClick} />);
-			await waitFor(() => window.dispatchEvent(new Event("online")));
-			getLocationInput().focus();
-			await waitFor(() => {
-				expect(getCurrentLocationErrorModal(true)).toBeInTheDocument();
-			});
-			within(getCurrentLocationErrorModal(true)).getByRole("button").click();
-			fireEvent.change(getLocationSearchInput(), { target: { value: "found something" } });
-			await waitFor(() => {
-				expect(getLocationSearchResults(true)).not.toBeEmptyDOMElement();
-			});
-			const resultContainer = getLocationSearchResults();
-			const selectedResult = resultContainer.getElementsByTagName("div")[0];
-			fireEvent.click(selectedResult);
-			fireEvent.click(getLocationModalControlButtons("Confirm"));
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{
-						...json,
-						defaultValues: {
-							[COMPONENT_ID]: {
-								address: "Fusionopolis View",
-							},
-						},
-					}}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={json} onClick={handleClick} />);
-			await waitFor(() => window.dispatchEvent(new Event("online")));
-			getLocationInput().focus();
-			await waitFor(() => {
-				expect(getCurrentLocationErrorModal(true)).toBeInTheDocument();
-			});
-			within(getCurrentLocationErrorModal(true)).getByRole("button").click();
-			fireEvent.change(getLocationSearchInput(), { target: { value: "found something" } });
-			await waitFor(() => {
-				expect(getLocationSearchResults(true)).not.toBeEmptyDOMElement();
-			});
-			const resultContainer = getLocationSearchResults();
-			const selectedResult = resultContainer.getElementsByTagName("div")[0];
-			fireEvent.click(selectedResult);
-			fireEvent.click(getLocationModalControlButtons("Confirm"));
-
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{
-						...json,
-						defaultValues: {
-							[COMPONENT_ID]: {
-								address: "Fusionopolis View",
-							},
-						},
-					}}
-					onClick={handleClick}
-				/>
-			);
-			await waitFor(() => window.dispatchEvent(new Event("online")));
-			getLocationInput().focus();
-			await waitFor(() => {
-				expect(getCurrentLocationErrorModal(true)).toBeInTheDocument();
-			});
-			within(getCurrentLocationErrorModal(true)).getByRole("button").click();
-			fireEvent.change(getLocationSearchInput(), { target: { value: "found something" } });
-			await waitFor(() => {
-				expect(getLocationSearchResults(true)).not.toBeEmptyDOMElement();
-			});
-			const resultContainer = getLocationSearchResults();
-			const selectedResult = resultContainer.getElementsByTagName("div")[0];
-			fireEvent.click(selectedResult);
-			fireEvent.click(getLocationModalControlButtons("Confirm"));
-
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+		},
 	});
 
 	describe("search results list title", () => {

--- a/src/__tests__/components/fields/location-field/location-field.spec.tsx
+++ b/src/__tests__/components/fields/location-field/location-field.spec.tsx
@@ -1001,9 +1001,7 @@ describe("location-input-group", () => {
 				expect(screen.getByLabelText(LABEL)).toBeInTheDocument();
 			});
 
-			labelTestSuite((overrideField: TOverrideField<ILocationFieldSchema>) => {
-				renderComponent({ overrideField });
-			});
+			labelTestSuite((overrideField: TOverrideField<ILocationFieldSchema>) => renderComponent({ overrideField }));
 			warningTestSuite<ILocationFieldSchema>({ label: LABEL, uiType: UI_TYPE });
 
 			// test functionality

--- a/src/__tests__/components/fields/location-field/location-field.spec.tsx
+++ b/src/__tests__/components/fields/location-field/location-field.spec.tsx
@@ -23,8 +23,7 @@ import {
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { labelTestSuite, warningTestSuite } from "../../../common/tests";
 import {
 	fetchSingleLocationByLatLngSingleReponse,
 	mock1PageFetchAddressResponse,

--- a/src/__tests__/components/fields/masked-field/masked-field.spec.tsx
+++ b/src/__tests__/components/fields/masked-field/masked-field.spec.tsx
@@ -1,59 +1,30 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { IMaskedFieldSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/types";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const COMPONENT_LABEL = "Masked field";
 const UI_TYPE = "masked-field";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: COMPONENT_LABEL,
-					uiType: UI_TYPE,
-					maskRange: [0, 100],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
-	},
-};
 
-const renderComponent = (overrideField?: Partial<IMaskedFieldSchema> | undefined, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+const renderComponent = createRenderComponent<IMaskedFieldSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: COMPONENT_LABEL,
+		uiType: UI_TYPE,
+		maskRange: [0, 100],
+	},
+	submitFn: SUBMIT_FN,
+});
 
 const getMaskedField = (): HTMLElement => {
 	return getField("textbox", COMPONENT_LABEL);
@@ -165,65 +136,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getMaskedField(), { target: { value: "world" } });
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getMaskedField(), { target: { value: "world" } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.change(getMaskedField(), { target: { value: "world" } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: "hello",
+		modifyField: () => fireEvent.change(getMaskedField(), { target: { value: "world" } }),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/masked-field/masked-field.spec.tsx
+++ b/src/__tests__/components/fields/masked-field/masked-field.spec.tsx
@@ -15,7 +15,7 @@ const COMPONENT_ID = "field";
 const COMPONENT_LABEL = "Masked field";
 const UI_TYPE = "masked-field";
 
-const renderComponent = createRenderComponent<IMaskedFieldSchema>({
+const { renderComponent, schema } = createRenderComponent<IMaskedFieldSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		label: COMPONENT_LABEL,
@@ -136,7 +136,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: "hello",
 		modifyField: () => fireEvent.change(getMaskedField(), { target: { value: "world" } }),

--- a/src/__tests__/components/fields/masked-field/masked-field.spec.tsx
+++ b/src/__tests__/components/fields/masked-field/masked-field.spec.tsx
@@ -8,8 +8,7 @@ import {
 	getResetButton,
 	getSubmitButton,
 } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/multi-select/multi-select.spec.tsx
+++ b/src/__tests__/components/fields/multi-select/multi-select.spec.tsx
@@ -6,68 +6,40 @@ import merge from "lodash/merge";
 import { useState } from "react";
 import { FrontendEngine } from "../../../../components";
 import { IMultiSelectSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
+import { IFrontendEngineData } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
-const FIELD_LABEL = "Multiselect";
 const UI_TYPE = "multi-select";
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Multiselect",
-					uiType: UI_TYPE,
-					options: [
-						{ label: "A", value: "Apple" },
-						{ label: "B", value: "Berry" },
-						{ label: "C", value: "Cherry" },
-						{ label: "D", value: "Durian" },
-					],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
+const renderComponent = createRenderComponent<IMultiSelectSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Multiselect",
+		uiType: UI_TYPE,
+		options: [
+			{ label: "A", value: "Apple" },
+			{ label: "B", value: "Berry" },
+			{ label: "C", value: "Cherry" },
+			{ label: "D", value: "Durian" },
+		],
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<IMultiSelectSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -319,68 +291,14 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: () => {
 			fireEvent.click(getComponent());
 			fireEvent.click(getCheckboxA());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getComponent());
-			fireEvent.click(getCheckboxA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(getComponent());
-			fireEvent.click(getCheckboxA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+		},
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/multi-select/multi-select.spec.tsx
+++ b/src/__tests__/components/fields/multi-select/multi-select.spec.tsx
@@ -21,7 +21,7 @@ const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "multi-select";
 
-const renderComponent = createRenderComponent<IMultiSelectSchema>({
+const { renderComponent, schema } = createRenderComponent<IMultiSelectSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		label: "Multiselect",
@@ -38,11 +38,11 @@ const renderComponent = createRenderComponent<IMultiSelectSchema>({
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
+	const [data, setData] = useState<IFrontendEngineData>(schema);
 	return (
 		<>
-			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
-			<Button.Default onClick={() => setSchema(onClick)}>Update options</Button.Default>
+			<FrontendEngine data={data} onSubmit={SUBMIT_FN} />
+			<Button.Default onClick={() => setData(onClick)}>Update options</Button.Default>
 		</>
 	);
 };
@@ -291,7 +291,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: ["Apple"],
 		modifyField: () => {

--- a/src/__tests__/components/fields/multi-select/multi-select.spec.tsx
+++ b/src/__tests__/components/fields/multi-select/multi-select.spec.tsx
@@ -15,8 +15,7 @@ import {
 	getResetButton,
 	getSubmitButton,
 } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/nested-multi-select/nested-multi-select.spec.tsx
+++ b/src/__tests__/components/fields/nested-multi-select/nested-multi-select.spec.tsx
@@ -6,21 +6,17 @@ import merge from "lodash/merge";
 import { useState } from "react";
 import { FrontendEngine } from "../../../../components";
 import { IL1Value, INestedMultiSelectSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
+import { IFrontendEngineData } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
 	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
@@ -53,53 +49,27 @@ const NESTED_JSON_FIELDS: TOverrideField<INestedMultiSelectSchema> = {
 	],
 };
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Nestedmultiselect",
-					uiType: UI_TYPE,
-					options: [
-						{ label: "A", value: "Apple", key: "appleKey" },
-						{ label: "B", value: "Berry", key: "berryKey" },
-						{ label: "C", value: "Cherry", key: "cherryKey" },
-						{ label: "D", value: "Durian", key: "durianKey" },
-					],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
+const renderComponent = createRenderComponent<INestedMultiSelectSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Nestedmultiselect",
+		uiType: UI_TYPE,
+		options: [
+			{ label: "A", value: "Apple", key: "appleKey" },
+			{ label: "B", value: "Berry", key: "berryKey" },
+			{ label: "C", value: "Cherry", key: "cherryKey" },
+			{ label: "D", value: "Durian", key: "durianKey" },
+		],
 	},
-};
-
-const renderComponent = (
-	overrideField?: TOverrideField<INestedMultiSelectSchema>,
-	overrideSchema?: TOverrideSchema
-) => {
-	const json: IFrontendEngineData<INestedMultiSelectSchema> = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: {
 	onClick: (data: IFrontendEngineData) => IFrontendEngineData;
 	initialSchema?: IFrontendEngineData;
 }) => {
 	const { onClick, initialSchema } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(initialSchema ?? JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(initialSchema ?? renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -362,7 +332,7 @@ describe(UI_TYPE, () => {
 		`("$scenario", async ({ selected, expectedValueBeforeUpdate, expectedValueAfterUpdate }) => {
 			render(
 				<ComponentWithSetSchemaButton
-					initialSchema={merge(cloneDeep(JSON_SCHEMA), {
+					initialSchema={merge(cloneDeep(renderComponent.schema), {
 						sections: {
 							section: {
 								children: {
@@ -459,7 +429,7 @@ describe(UI_TYPE, () => {
 			async ({ selected, expectedValueBeforeUpdate, expectedValueAfterUpdate }: Record<string, string[]>) => {
 				render(
 					<ComponentWithSetSchemaButton
-						initialSchema={JSON_SCHEMA}
+						initialSchema={renderComponent.schema}
 						onClick={(data) => ({
 							...data,
 							overrides: {
@@ -503,7 +473,7 @@ describe(UI_TYPE, () => {
 			async ({ selected, expectedValueBeforeUpdate, expectedValueAfterUpdate }: Record<string, string[]>) => {
 				render(
 					<ComponentWithSetSchemaButton
-						initialSchema={merge(cloneDeep(JSON_SCHEMA), {
+						initialSchema={merge(cloneDeep(renderComponent.schema), {
 							sections: {
 								section: {
 									children: {
@@ -603,83 +573,14 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: { appleKey: "apple" },
+		modifyField: () => {
 			fireEvent.click(getComponent());
 			fireEvent.click(getCheckboxA());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{
-						...JSON_SCHEMA,
-						defaultValues: {
-							[COMPONENT_ID]: {
-								appleKey: "apple",
-							},
-						},
-					}}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getComponent());
-			fireEvent.click(getCheckboxA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{
-						...JSON_SCHEMA,
-						defaultValues: {
-							[COMPONENT_ID]: {
-								appleKey: "apple",
-								berryKey: "Berry",
-							},
-						},
-					}}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(getComponent());
-			fireEvent.click(getCheckboxA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+		},
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/nested-multi-select/nested-multi-select.spec.tsx
+++ b/src/__tests__/components/fields/nested-multi-select/nested-multi-select.spec.tsx
@@ -16,8 +16,7 @@ import {
 	getResetButton,
 	getSubmitButton,
 } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/nested-multi-select/nested-multi-select.spec.tsx
+++ b/src/__tests__/components/fields/nested-multi-select/nested-multi-select.spec.tsx
@@ -48,7 +48,7 @@ const NESTED_JSON_FIELDS: TOverrideField<INestedMultiSelectSchema> = {
 	],
 };
 
-const renderComponent = createRenderComponent<INestedMultiSelectSchema>({
+const { renderComponent, schema } = createRenderComponent<INestedMultiSelectSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		label: "Nestedmultiselect",
@@ -68,11 +68,11 @@ const ComponentWithSetSchemaButton = (props: {
 	initialSchema?: IFrontendEngineData;
 }) => {
 	const { onClick, initialSchema } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(initialSchema ?? renderComponent.schema);
+	const [data, setData] = useState<IFrontendEngineData>(initialSchema ?? schema);
 	return (
 		<>
-			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
-			<Button.Default onClick={() => setSchema(onClick)}>Update options</Button.Default>
+			<FrontendEngine data={data} onSubmit={SUBMIT_FN} />
+			<Button.Default onClick={() => setData(onClick)}>Update options</Button.Default>
 		</>
 	);
 };
@@ -331,7 +331,7 @@ describe(UI_TYPE, () => {
 		`("$scenario", async ({ selected, expectedValueBeforeUpdate, expectedValueAfterUpdate }) => {
 			render(
 				<ComponentWithSetSchemaButton
-					initialSchema={merge(cloneDeep(renderComponent.schema), {
+					initialSchema={merge(cloneDeep(schema), {
 						sections: {
 							section: {
 								children: {
@@ -428,7 +428,7 @@ describe(UI_TYPE, () => {
 			async ({ selected, expectedValueBeforeUpdate, expectedValueAfterUpdate }: Record<string, string[]>) => {
 				render(
 					<ComponentWithSetSchemaButton
-						initialSchema={renderComponent.schema}
+						initialSchema={schema}
 						onClick={(data) => ({
 							...data,
 							overrides: {
@@ -472,7 +472,7 @@ describe(UI_TYPE, () => {
 			async ({ selected, expectedValueBeforeUpdate, expectedValueAfterUpdate }: Record<string, string[]>) => {
 				render(
 					<ComponentWithSetSchemaButton
-						initialSchema={merge(cloneDeep(renderComponent.schema), {
+						initialSchema={merge(cloneDeep(schema), {
 							sections: {
 								section: {
 									children: {
@@ -573,7 +573,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: { appleKey: "apple" },
 		modifyField: () => {

--- a/src/__tests__/components/fields/otp-verification-field/otp-verification-field.spec.tsx
+++ b/src/__tests__/components/fields/otp-verification-field/otp-verification-field.spec.tsx
@@ -18,7 +18,7 @@ import {
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
@@ -286,65 +286,11 @@ describe(UI_TYPE, () => {
 			});
 		});
 
-		describe("dirty state", () => {
-			let formIsDirty: boolean;
-			const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-				formIsDirty = ref.current.isDirty;
-			};
-
-			beforeEach(() => {
-				formIsDirty = undefined;
-			});
-
-			it("should mount without setting field state as dirty", () => {
-				rtlRender(<FrontendEngineWithCustomButton data={PHONE_SCHEMA} onClick={handleClick} />);
-				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-				expect(formIsDirty).toBe(false);
-			});
-
-			it("should set form state as dirty if user modifies the phone OTP field", () => {
-				rtlRender(<FrontendEngineWithCustomButton data={PHONE_SCHEMA} onClick={handleClick} />);
-				fireEvent.change(getPhoneNoInput(), { target: { value: MOCK_VALID_PHONE_NO } });
-				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-				expect(formIsDirty).toBe(true);
-			});
-
-			it("should support default verified value without setting form state as dirty", () => {
-				rtlRender(
-					<FrontendEngineWithCustomButton
-						data={{ ...PHONE_SCHEMA, defaultValues: { [COMPONENT_ID]: VERIFIED_PHONE_DEFAULT_VALUE } }}
-						onClick={handleClick}
-					/>
-				);
-				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-				expect(formIsDirty).toBe(false);
-			});
-
-			it("should reset and revert phone OTP form dirty state to false", () => {
-				rtlRender(<FrontendEngineWithCustomButton data={PHONE_SCHEMA} onClick={handleClick} />);
-				fireEvent.change(getPhoneNoInput(), { target: { value: MOCK_VALID_PHONE_NO } });
-				fireEvent.click(getResetButton());
-				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-				expect(formIsDirty).toBe(false);
-			});
-
-			it("should reset to default verified value without setting form state as dirty", () => {
-				rtlRender(
-					<FrontendEngineWithCustomButton
-						data={{ ...PHONE_SCHEMA, defaultValues: { [COMPONENT_ID]: VERIFIED_PHONE_DEFAULT_VALUE } }}
-						onClick={handleClick}
-					/>
-				);
-				fireEvent.change(getPhoneNoInput(), { target: { value: "98765432" } });
-				fireEvent.click(getResetButton());
-				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-				expect(formIsDirty).toBe(false);
-			});
+		dirtyStateTestSuite({
+			schema: PHONE_SCHEMA,
+			componentId: COMPONENT_ID,
+			defaultValue: VERIFIED_PHONE_DEFAULT_VALUE,
+			modifyField: () => fireEvent.change(getPhoneNoInput(), { target: { value: MOCK_VALID_PHONE_NO } }),
 		});
 	});
 

--- a/src/__tests__/components/fields/otp-verification-field/otp-verification-field.spec.tsx
+++ b/src/__tests__/components/fields/otp-verification-field/otp-verification-field.spec.tsx
@@ -18,8 +18,7 @@ import {
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/otp-verification-field/otp-verification-field.spec.tsx
+++ b/src/__tests__/components/fields/otp-verification-field/otp-verification-field.spec.tsx
@@ -489,65 +489,11 @@ describe(UI_TYPE, () => {
 			});
 		});
 
-		describe("dirty state", () => {
-			let formIsDirty: boolean;
-			const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-				formIsDirty = ref.current.isDirty;
-			};
-
-			beforeEach(() => {
-				formIsDirty = undefined;
-			});
-
-			it("should mount without setting field state as dirty", () => {
-				rtlRender(<FrontendEngineWithCustomButton data={EMAIL_SCHEMA} onClick={handleClick} />);
-				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-				expect(formIsDirty).toBe(false);
-			});
-
-			it("should set form state as dirty if user modifies the email OTP field", () => {
-				rtlRender(<FrontendEngineWithCustomButton data={EMAIL_SCHEMA} onClick={handleClick} />);
-				fireEvent.change(getEmailInput(), { target: { value: MOCK_VALID_EMAIL } });
-				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-				expect(formIsDirty).toBe(true);
-			});
-
-			it("should support default verified value without setting form state as dirty", () => {
-				rtlRender(
-					<FrontendEngineWithCustomButton
-						data={{ ...EMAIL_SCHEMA, defaultValues: { [COMPONENT_ID]: VERIFIED_EMAIL_DEFAULT_VALUE } }}
-						onClick={handleClick}
-					/>
-				);
-				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-				expect(formIsDirty).toBe(false);
-			});
-
-			it("should reset and revert email OTP form dirty state to false", () => {
-				rtlRender(<FrontendEngineWithCustomButton data={EMAIL_SCHEMA} onClick={handleClick} />);
-				fireEvent.change(getEmailInput(), { target: { value: MOCK_VALID_EMAIL } });
-				fireEvent.click(getResetButton());
-				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-				expect(formIsDirty).toBe(false);
-			});
-
-			it("should reset to default verified value without setting form state as dirty", () => {
-				rtlRender(
-					<FrontendEngineWithCustomButton
-						data={{ ...EMAIL_SCHEMA, defaultValues: { [COMPONENT_ID]: VERIFIED_EMAIL_DEFAULT_VALUE } }}
-						onClick={handleClick}
-					/>
-				);
-				fireEvent.change(getEmailInput(), { target: { value: "updated@example.com" } });
-				fireEvent.click(getResetButton());
-				fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-				expect(formIsDirty).toBe(false);
-			});
+		dirtyStateTestSuite({
+			schema: EMAIL_SCHEMA,
+			componentId: COMPONENT_ID,
+			defaultValue: VERIFIED_EMAIL_DEFAULT_VALUE,
+			modifyField: () => fireEvent.change(getEmailInput(), { target: { value: MOCK_VALID_EMAIL } }),
 		});
 	});
 

--- a/src/__tests__/components/fields/radio-button/radio-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-button.spec.tsx
@@ -5,21 +5,16 @@ import merge from "lodash/merge";
 import { useState } from "react";
 import { FrontendEngine } from "../../../../components";
 import { TRadioButtonGroupSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
+import { IFrontendEngineData } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
@@ -34,44 +29,22 @@ const getRadioButtonB = (): HTMLElement => {
 	return getField("radio", "B");
 };
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Radio",
-					uiType: UI_TYPE,
-					options: [
-						{ label: "A", value: "Apple" },
-						{ label: "B", value: "Berry" },
-					],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
+const renderComponent = createRenderComponent<TRadioButtonGroupSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Radio",
+		uiType: UI_TYPE,
+		options: [
+			{ label: "A", value: "Apple" },
+			{ label: "B", value: "Berry" },
+		],
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<TRadioButtonGroupSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -308,65 +281,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getRadioButtonA());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getRadioButtonA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(getRadioButtonA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: () => fireEvent.click(getRadioButtonA()),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/radio-button/radio-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-button.spec.tsx
@@ -28,7 +28,7 @@ const getRadioButtonB = (): HTMLElement => {
 	return getField("radio", "B");
 };
 
-const renderComponent = createRenderComponent<TRadioButtonGroupSchema>({
+const { renderComponent, schema } = createRenderComponent<TRadioButtonGroupSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		label: "Radio",
@@ -43,11 +43,11 @@ const renderComponent = createRenderComponent<TRadioButtonGroupSchema>({
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
+	const [data, setData] = useState<IFrontendEngineData>(schema);
 	return (
 		<>
-			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
-			<Button.Default onClick={() => setSchema(onClick)}>Update options</Button.Default>
+			<FrontendEngine data={data} onSubmit={SUBMIT_FN} />
+			<Button.Default onClick={() => setData(onClick)}>Update options</Button.Default>
 		</>
 	);
 };
@@ -281,7 +281,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: ["Apple"],
 		modifyField: () => fireEvent.click(getRadioButtonA()),

--- a/src/__tests__/components/fields/radio-button/radio-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-button.spec.tsx
@@ -14,8 +14,7 @@ import {
 	getResetButton,
 	getSubmitButton,
 } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/radio-button/radio-image-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-image-button.spec.tsx
@@ -5,21 +5,9 @@ import merge from "lodash/merge";
 import { useState } from "react";
 import { FrontendEngine } from "../../../../components";
 import { TRadioButtonGroupSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
-import {
-	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
-	getErrorMessage,
-	getField,
-	getResetButton,
-	getResetButtonProps,
-	getSubmitButton,
-	getSubmitButtonProps,
-} from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { IFrontendEngineData } from "../../../../components/frontend-engine";
+import { ERROR_MESSAGE, createRenderComponent, getErrorMessage, getField, getSubmitButton } from "../../../common";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
@@ -34,47 +22,25 @@ const getRadioButtonB = (): HTMLElement => {
 	return getField("button", "B");
 };
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Radio",
-					uiType: UI_TYPE,
-					customOptions: {
-						styleType: "image-button",
-					},
-					options: [
-						{ label: "A", value: "Apple" },
-						{ label: "B", value: "Berry" },
-					],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
+const renderComponent = createRenderComponent<TRadioButtonGroupSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Radio",
+		uiType: UI_TYPE,
+		customOptions: {
+			styleType: "image-button",
 		},
+		options: [
+			{ label: "A", value: "Apple" },
+			{ label: "B", value: "Berry" },
+		],
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<TRadioButtonGroupSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -234,65 +200,11 @@ describe("radio toggle button", () => {
 		);
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getRadioButtonA());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getRadioButtonA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(getRadioButtonA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: () => fireEvent.click(getRadioButtonA()),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/radio-button/radio-image-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-image-button.spec.tsx
@@ -21,7 +21,7 @@ const getRadioButtonB = (): HTMLElement => {
 	return getField("button", "B");
 };
 
-const renderComponent = createRenderComponent<TRadioButtonGroupSchema>({
+const { renderComponent, schema } = createRenderComponent<TRadioButtonGroupSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		label: "Radio",
@@ -39,11 +39,11 @@ const renderComponent = createRenderComponent<TRadioButtonGroupSchema>({
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
+	const [data, setData] = useState<IFrontendEngineData>(schema);
 	return (
 		<>
-			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
-			<Button.Default onClick={() => setSchema(onClick)}>Update options</Button.Default>
+			<FrontendEngine data={data} onSubmit={SUBMIT_FN} />
+			<Button.Default onClick={() => setData(onClick)}>Update options</Button.Default>
 		</>
 	);
 };
@@ -200,7 +200,7 @@ describe("radio toggle button", () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: ["Apple"],
 		modifyField: () => fireEvent.click(getRadioButtonA()),

--- a/src/__tests__/components/fields/radio-button/radio-image-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-image-button.spec.tsx
@@ -7,8 +7,7 @@ import { FrontendEngine } from "../../../../components";
 import { TRadioButtonGroupSchema } from "../../../../components/fields";
 import { IFrontendEngineData } from "../../../../components/frontend-engine";
 import { ERROR_MESSAGE, createRenderComponent, getErrorMessage, getField, getSubmitButton } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
@@ -18,8 +18,7 @@ import {
 	getSubmitButton,
 	getSubmitButtonProps,
 } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
@@ -16,6 +16,7 @@ import {
 	getField,
 	getResetButton,
 	getSubmitButton,
+	getSubmitButtonProps,
 } from "../../../common";
 import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
@@ -671,7 +672,7 @@ describe("radio toggle button", () => {
 		});
 	});
 
-	labelTestSuite(renderComponent as (overrideField: unknown) => void);
+	labelTestSuite(renderComponent);
 	warningTestSuite<TRadioButtonGroupSchema>({
 		label: "Radio",
 		uiType: UI_TYPE,

--- a/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
@@ -6,20 +6,18 @@ import { useState } from "react";
 import { FrontendEngine } from "../../../../components";
 import { TRadioButtonGroupSchema } from "../../../../components/fields";
 import { IRadioButtonToggleSchema } from "../../../../components/fields/radio-button/types";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
+import { IFrontendEngineData } from "../../../../components/frontend-engine";
+
 import {
 	ERROR_MESSAGE,
 	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
@@ -39,50 +37,25 @@ const getNestedField = (): HTMLElement => {
 	return screen.queryByRole("textbox");
 };
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Radio",
-					uiType: UI_TYPE,
-					customOptions: {
-						styleType: "toggle",
-					},
-					options: [
-						{ label: "A", value: "Apple" },
-						{ label: "B", value: "Berry" },
-					],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
+const renderComponent = createRenderComponent<IRadioButtonToggleSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Radio",
+		uiType: UI_TYPE,
+		customOptions: {
+			styleType: "toggle",
 		},
+		options: [
+			{ label: "A", value: "Apple" },
+			{ label: "B", value: "Berry" },
+		],
 	},
-};
-
-const renderComponent = (
-	overrideField?: Partial<Omit<IRadioButtonToggleSchema, "uiType">>,
-	overrideSchema?: TOverrideSchema
-) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -418,65 +391,11 @@ describe("radio toggle button", () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getRadioButtonA());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getRadioButtonA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(getRadioButtonA());
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: () => fireEvent.click(getRadioButtonA()),
 	});
 
 	describe("allowDeselection feature", () => {

--- a/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
@@ -37,7 +37,7 @@ const getNestedField = (): HTMLElement => {
 	return screen.queryByRole("textbox");
 };
 
-const renderComponent = createRenderComponent<IRadioButtonToggleSchema>({
+const { renderComponent, schema } = createRenderComponent<IRadioButtonToggleSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		label: "Radio",
@@ -55,11 +55,11 @@ const renderComponent = createRenderComponent<IRadioButtonToggleSchema>({
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
+	const [data, setData] = useState<IFrontendEngineData>(schema);
 	return (
 		<>
-			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
-			<Button.Default onClick={() => setSchema(onClick)}>Update options</Button.Default>
+			<FrontendEngine data={data} onSubmit={SUBMIT_FN} />
+			<Button.Default onClick={() => setData(onClick)}>Update options</Button.Default>
 		</>
 	);
 };
@@ -392,7 +392,7 @@ describe("radio toggle button", () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: ["Apple"],
 		modifyField: () => fireEvent.click(getRadioButtonA()),

--- a/src/__tests__/components/fields/range-select/range-select.spec.tsx
+++ b/src/__tests__/components/fields/range-select/range-select.spec.tsx
@@ -6,72 +6,43 @@ import merge from "lodash/merge";
 import { useState } from "react";
 import { FrontendEngine } from "../../../../components";
 import { IRangeSelectSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
+import { IFrontendEngineData } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
-	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "range-select";
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "RangeSelect",
-					uiType: UI_TYPE,
-					options: {
-						from: [
-							{ label: "A", value: "Apple" },
-							{ label: "B", value: "Berry" },
-						],
-						to: [
-							{ label: "C", value: "Cherry" },
-							{ label: "D", value: "Date" },
-						],
-					},
-					// listStyleWidth: "40rem",
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
+const renderComponent = createRenderComponent<IRangeSelectSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "RangeSelect",
+		uiType: UI_TYPE,
+		options: {
+			from: [
+				{ label: "A", value: "Apple" },
+				{ label: "B", value: "Berry" },
+			],
+			to: [
+				{ label: "C", value: "Cherry" },
+				{ label: "D", value: "Date" },
+			],
 		},
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<IRangeSelectSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -375,71 +346,15 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: async () => {
 			await waitFor(() => fireEvent.click(getComponent()));
 			await waitFor(() => fireEvent.click(getOptionA()));
 			await waitFor(() => fireEvent.click(getOptionC()));
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			await waitFor(() => fireEvent.click(getComponent()));
-			await waitFor(() => fireEvent.click(getOptionA()));
-			await waitFor(() => fireEvent.click(getOptionC()));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			await waitFor(() => fireEvent.click(getComponent()));
-			await waitFor(() => fireEvent.click(getOptionA()));
-			await waitFor(() => fireEvent.click(getOptionC()));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+		},
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/range-select/range-select.spec.tsx
+++ b/src/__tests__/components/fields/range-select/range-select.spec.tsx
@@ -20,7 +20,7 @@ const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "range-select";
 
-const renderComponent = createRenderComponent<IRangeSelectSchema>({
+const { renderComponent, schema } = createRenderComponent<IRangeSelectSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		label: "RangeSelect",
@@ -41,11 +41,11 @@ const renderComponent = createRenderComponent<IRangeSelectSchema>({
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
+	const [data, setData] = useState<IFrontendEngineData>(schema);
 	return (
 		<>
-			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
-			<Button.Default onClick={() => setSchema(onClick)}>Update options</Button.Default>
+			<FrontendEngine data={data} onSubmit={SUBMIT_FN} />
+			<Button.Default onClick={() => setData(onClick)}>Update options</Button.Default>
 		</>
 	);
 };
@@ -346,7 +346,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: ["Apple"],
 		modifyField: async () => {

--- a/src/__tests__/components/fields/range-select/range-select.spec.tsx
+++ b/src/__tests__/components/fields/range-select/range-select.spec.tsx
@@ -14,8 +14,7 @@ import {
 	getResetButton,
 	getSubmitButton,
 } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/select-histogram/select-histogram.spec.tsx
+++ b/src/__tests__/components/fields/select-histogram/select-histogram.spec.tsx
@@ -1,70 +1,32 @@
-import { Form } from "@lifesg/react-design-system/form";
-import { FormSelectHistogramProps } from "@lifesg/react-design-system/form";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
+import { Form, FormSelectHistogramProps } from "@lifesg/react-design-system/form";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import { ISelectHistogramSchema } from "../../../../components/fields/select-histogram/types";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
 import { ERROR_MESSAGES } from "../../../../components/shared";
-import {
-	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
-	getResetButton,
-	getResetButtonProps,
-	getSubmitButton,
-	getSubmitButtonProps,
-} from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { ERROR_MESSAGE, createRenderComponent, getResetButton, getSubmitButton } from "../../../common";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "select-histogram";
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Select Histogram",
-					uiType: UI_TYPE,
-					histogramSlider: {
-						bins: [
-							{ minValue: 10, count: 1 },
-							{ minValue: 20, count: 0 },
-							{ minValue: 30, count: 3 },
-							{ minValue: 90, count: 3 },
-						],
-						interval: 10,
-					},
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
+const renderComponent = createRenderComponent<ISelectHistogramSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Select Histogram",
+		uiType: UI_TYPE,
+		histogramSlider: {
+			bins: [
+				{ minValue: 10, count: 1 },
+				{ minValue: 20, count: 0 },
+				{ minValue: 30, count: 3 },
+				{ minValue: 90, count: 3 },
+			],
+			interval: 10,
 		},
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<ISelectHistogramSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const getSelector = (): HTMLElement => {
 	return screen.getByTestId("selector");
@@ -184,65 +146,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			changeSliderValue(sliderSpy, [20, 60]);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: { from: 10, to: 50 } } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			changeSliderValue(sliderSpy, [20, 60]);
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: { from: 10, to: 50 } } }}
-					onClick={handleClick}
-				/>
-			);
-			changeSliderValue(sliderSpy, [20, 60]);
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: { from: 10, to: 50 },
+		modifyField: () => changeSliderValue(sliderSpy, [20, 60]),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/select-histogram/select-histogram.spec.tsx
+++ b/src/__tests__/components/fields/select-histogram/select-histogram.spec.tsx
@@ -3,8 +3,7 @@ import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import { ISelectHistogramSchema } from "../../../../components/fields/select-histogram/types";
 import { ERROR_MESSAGES } from "../../../../components/shared";
 import { ERROR_MESSAGE, createRenderComponent, getResetButton, getSubmitButton } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/select-histogram/select-histogram.spec.tsx
+++ b/src/__tests__/components/fields/select-histogram/select-histogram.spec.tsx
@@ -9,7 +9,7 @@ const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "select-histogram";
 
-const renderComponent = createRenderComponent<ISelectHistogramSchema>({
+const { renderComponent, schema } = createRenderComponent<ISelectHistogramSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		label: "Select Histogram",
@@ -146,7 +146,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: { from: 10, to: 50 },
 		modifyField: () => changeSliderValue(sliderSpy, [20, 60]),

--- a/src/__tests__/components/fields/select/select.spec.tsx
+++ b/src/__tests__/components/fields/select/select.spec.tsx
@@ -3,68 +3,40 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { setupJestCanvasMock } from "jest-canvas-mock";
 import cloneDeep from "lodash/cloneDeep";
 import merge from "lodash/merge";
-import React, { useState } from "react";
-import { FrontendEngine } from "../../../../components";
+import { useState } from "react";
 import { ISelectSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
+import { FrontendEngine, IFrontendEngineData } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "select";
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Select",
-					uiType: UI_TYPE,
-					options: [
-						{ label: "A", value: "Apple" },
-						{ label: "B", value: "Berry" },
-					],
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
+const renderComponent = createRenderComponent<ISelectSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Select",
+		uiType: UI_TYPE,
+		options: [
+			{ label: "A", value: "Apple" },
+			{ label: "B", value: "Berry" },
+		],
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<ISelectSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(JSON_SCHEMA);
+	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
 	return (
 		<>
 			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
@@ -252,68 +224,14 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: () => {
 			fireEvent.click(getSelectToggle());
 			fireEvent.click(screen.getByRole("option", { name: "A" }));
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getSelectToggle());
-			fireEvent.click(screen.getByRole("option", { name: "A" }));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(getSelectToggle());
-			fireEvent.click(screen.getByRole("option", { name: "A" }));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+		},
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/select/select.spec.tsx
+++ b/src/__tests__/components/fields/select/select.spec.tsx
@@ -20,7 +20,7 @@ const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "select";
 
-const renderComponent = createRenderComponent<ISelectSchema>({
+const { renderComponent, schema } = createRenderComponent<ISelectSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		label: "Select",
@@ -35,11 +35,11 @@ const renderComponent = createRenderComponent<ISelectSchema>({
 
 const ComponentWithSetSchemaButton = (props: { onClick: (data: IFrontendEngineData) => IFrontendEngineData }) => {
 	const { onClick } = props;
-	const [schema, setSchema] = useState<IFrontendEngineData>(renderComponent.schema);
+	const [data, setData] = useState<IFrontendEngineData>(schema);
 	return (
 		<>
-			<FrontendEngine data={schema} onSubmit={SUBMIT_FN} />
-			<Button.Default onClick={() => setSchema(onClick)}>Update options</Button.Default>
+			<FrontendEngine data={data} onSubmit={SUBMIT_FN} />
+			<Button.Default onClick={() => setData(onClick)}>Update options</Button.Default>
 		</>
 	);
 };
@@ -224,7 +224,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: ["Apple"],
 		modifyField: () => {

--- a/src/__tests__/components/fields/select/select.spec.tsx
+++ b/src/__tests__/components/fields/select/select.spec.tsx
@@ -14,8 +14,7 @@ import {
 	getResetButton,
 	getSubmitButton,
 } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/slider/slider.spec.tsx
+++ b/src/__tests__/components/fields/slider/slider.spec.tsx
@@ -1,61 +1,29 @@
-import { Form } from "@lifesg/react-design-system/form";
-import { FormSliderProps } from "@lifesg/react-design-system/form";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
+import { Form, FormSliderProps } from "@lifesg/react-design-system/form";
+import { act, fireEvent, waitFor } from "@testing-library/react";
 import { ISliderSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "slider";
 
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Slider",
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
+const renderComponent = createRenderComponent<ISliderSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Slider",
+		uiType: UI_TYPE,
 	},
-};
-
-const renderComponent = (overrideField?: TOverrideField<ISliderSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+	submitFn: SUBMIT_FN,
+});
 
 const getSlider = (): HTMLElement => {
 	return getField("slider");
@@ -150,65 +118,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			changeSliderValue(sliderSpy, 15);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: 50 } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			changeSliderValue(sliderSpy, 15);
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: 50 } }}
-					onClick={handleClick}
-				/>
-			);
-			changeSliderValue(sliderSpy, 15);
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: 50,
+		modifyField: () => changeSliderValue(sliderSpy, 15),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/slider/slider.spec.tsx
+++ b/src/__tests__/components/fields/slider/slider.spec.tsx
@@ -15,7 +15,7 @@ const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "slider";
 
-const renderComponent = createRenderComponent<ISliderSchema>({
+const { renderComponent, schema } = createRenderComponent<ISliderSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		label: "Slider",
@@ -118,7 +118,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: 50,
 		modifyField: () => changeSliderValue(sliderSpy, 15),

--- a/src/__tests__/components/fields/slider/slider.spec.tsx
+++ b/src/__tests__/components/fields/slider/slider.spec.tsx
@@ -9,8 +9,7 @@ import {
 	getResetButton,
 	getSubmitButton,
 } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/switch/switch.spec.tsx
+++ b/src/__tests__/components/fields/switch/switch.spec.tsx
@@ -1,61 +1,31 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
+import { fireEvent, waitFor } from "@testing-library/react";
 import { ISwitchSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "switch";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: "Switch",
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
+
+const renderComponent = createRenderComponent<ISwitchSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: "Switch",
+		uiType: UI_TYPE,
 	},
-};
+	submitFn: SUBMIT_FN,
+});
 
 const getSwitchButton = (type: "Yes" | "No"): HTMLElement => {
 	return getField("radio", type);
-};
-
-const renderComponent = (overrideField?: TOverrideField<ISwitchSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
 };
 
 describe(UI_TYPE, () => {
@@ -138,65 +108,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getSwitchButton("Yes"));
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(getSwitchButton("Yes"));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: ["Apple"] } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(getSwitchButton("Yes"));
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: ["Apple"],
+		modifyField: () => fireEvent.click(getSwitchButton("Yes")),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/switch/switch.spec.tsx
+++ b/src/__tests__/components/fields/switch/switch.spec.tsx
@@ -14,7 +14,7 @@ const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "switch";
 
-const renderComponent = createRenderComponent<ISwitchSchema>({
+const { renderComponent, schema } = createRenderComponent<ISwitchSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		label: "Switch",
@@ -108,7 +108,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: ["Apple"],
 		modifyField: () => fireEvent.click(getSwitchButton("Yes")),

--- a/src/__tests__/components/fields/switch/switch.spec.tsx
+++ b/src/__tests__/components/fields/switch/switch.spec.tsx
@@ -8,8 +8,7 @@ import {
 	getResetButton,
 	getSubmitButton,
 } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/text-field/email-field.spec.tsx
+++ b/src/__tests__/components/fields/text-field/email-field.spec.tsx
@@ -1,25 +1,16 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
 import { IEmailFieldSchema } from "../../../../components/fields";
 import { ERROR_MESSAGES } from "../../../../components/shared";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/types";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
@@ -27,36 +18,15 @@ const COMPONENT_ID = "field";
 const COMPONENT_LABEL = "Email";
 const UI_TYPE = "email-field";
 const EXPECTED_VALUE = "aa@aa.com";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: COMPONENT_LABEL,
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
-	},
-};
 
-const renderComponent = (overrideField?: TOverrideField<IEmailFieldSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+const renderComponent = createRenderComponent<IEmailFieldSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: COMPONENT_LABEL,
+		uiType: UI_TYPE,
+	},
+	submitFn: SUBMIT_FN,
+});
 
 const getEmailField = (): HTMLElement => {
 	return getField("textbox", COMPONENT_LABEL);
@@ -240,65 +210,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getEmailField(), { target: { value: "world" } });
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "john@doe.tld" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getEmailField(), { target: { value: "world" } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "john@doe.tld" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.change(getEmailField(), { target: { value: "world" } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: "john@doe.tld",
+		modifyField: () => fireEvent.change(getEmailField(), { target: { value: "world" } }),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/text-field/email-field.spec.tsx
+++ b/src/__tests__/components/fields/text-field/email-field.spec.tsx
@@ -10,8 +10,7 @@ import {
 	getResetButton,
 	getSubmitButton,
 } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/text-field/email-field.spec.tsx
+++ b/src/__tests__/components/fields/text-field/email-field.spec.tsx
@@ -18,7 +18,7 @@ const COMPONENT_LABEL = "Email";
 const UI_TYPE = "email-field";
 const EXPECTED_VALUE = "aa@aa.com";
 
-const renderComponent = createRenderComponent<IEmailFieldSchema>({
+const { renderComponent, schema } = createRenderComponent<IEmailFieldSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		label: COMPONENT_LABEL,
@@ -210,7 +210,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: "john@doe.tld",
 		modifyField: () => fireEvent.change(getEmailField(), { target: { value: "world" } }),

--- a/src/__tests__/components/fields/text-field/numeric-field.spec.tsx
+++ b/src/__tests__/components/fields/text-field/numeric-field.spec.tsx
@@ -1,60 +1,30 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
 import { INumericFieldSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/types";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const COMPONENT_LABEL = "Numeric field";
 const UI_TYPE = "numeric-field";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: COMPONENT_LABEL,
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
-	},
-};
 
-const renderComponent = (overrideField?: TOverrideField<INumericFieldSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+const renderComponent = createRenderComponent<INumericFieldSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: COMPONENT_LABEL,
+		uiType: UI_TYPE,
+	},
+	submitFn: SUBMIT_FN,
+});
 
 const getNumericField = (): HTMLElement => {
 	return getField("spinbutton", COMPONENT_LABEL);
@@ -328,65 +298,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getNumericField(), { target: { value: 1 } });
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: 2 } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getNumericField(), { target: { value: 1 } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: 2 } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.change(getNumericField(), { target: { value: 1 } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: 2,
+		modifyField: () => fireEvent.change(getNumericField(), { target: { value: 1 } }),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/text-field/numeric-field.spec.tsx
+++ b/src/__tests__/components/fields/text-field/numeric-field.spec.tsx
@@ -16,7 +16,7 @@ const COMPONENT_ID = "field";
 const COMPONENT_LABEL = "Numeric field";
 const UI_TYPE = "numeric-field";
 
-const renderComponent = createRenderComponent<INumericFieldSchema>({
+const { renderComponent, schema } = createRenderComponent<INumericFieldSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		label: COMPONENT_LABEL,
@@ -298,7 +298,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: 2,
 		modifyField: () => fireEvent.change(getNumericField(), { target: { value: 1 } }),

--- a/src/__tests__/components/fields/text-field/numeric-field.spec.tsx
+++ b/src/__tests__/components/fields/text-field/numeric-field.spec.tsx
@@ -9,8 +9,7 @@ import {
 	getResetButton,
 	getSubmitButton,
 } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/text-field/text-field.spec.tsx
+++ b/src/__tests__/components/fields/text-field/text-field.spec.tsx
@@ -1,59 +1,27 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
 import { ITextFieldSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/types";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const COMPONENT_LABEL = "Textfield";
 const UI_TYPE = "text-field";
 const EXPECTED_TEXT = "test this has been pasted";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: COMPONENT_LABEL,
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
-	},
-};
 
-const renderComponent = (overrideField?: Partial<ITextFieldSchema> | undefined, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+const renderComponent = createRenderComponent<ITextFieldSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: { label: COMPONENT_LABEL, uiType: UI_TYPE },
+	submitFn: SUBMIT_FN,
+});
 
 const getTextfield = (): HTMLElement => {
 	return getField("textbox", COMPONENT_LABEL);
@@ -240,65 +208,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getTextfield(), { target: { value: "world" } });
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getTextfield(), { target: { value: "world" } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.change(getTextfield(), { target: { value: "world" } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: "hello",
+		modifyField: () => fireEvent.change(getTextfield(), { target: { value: "world" } }),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/text-field/text-field.spec.tsx
+++ b/src/__tests__/components/fields/text-field/text-field.spec.tsx
@@ -17,7 +17,7 @@ const COMPONENT_LABEL = "Textfield";
 const UI_TYPE = "text-field";
 const EXPECTED_TEXT = "test this has been pasted";
 
-const renderComponent = createRenderComponent<ITextFieldSchema>({
+const { renderComponent, schema } = createRenderComponent<ITextFieldSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: { label: COMPONENT_LABEL, uiType: UI_TYPE },
 	submitFn: SUBMIT_FN,
@@ -209,7 +209,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: "hello",
 		modifyField: () => fireEvent.change(getTextfield(), { target: { value: "world" } }),

--- a/src/__tests__/components/fields/textarea/textarea.spec.tsx
+++ b/src/__tests__/components/fields/textarea/textarea.spec.tsx
@@ -1,59 +1,26 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { ITextareaSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/types";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const UI_TYPE = "textarea";
 const COMPONENT_LABEL = "Textarea";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: COMPONENT_LABEL,
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
-	},
-};
 
-const renderComponent = (overrideField?: TOverrideField<ITextareaSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+const renderComponent = createRenderComponent<ITextareaSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: { label: COMPONENT_LABEL, uiType: UI_TYPE },
+	submitFn: SUBMIT_FN,
+});
 
 const getTextarea = (): HTMLElement => {
 	return getField("textbox", COMPONENT_LABEL);
@@ -73,9 +40,9 @@ describe(UI_TYPE, () => {
 	it("should support validation schema", async () => {
 		renderComponent({ validation: [{ required: true, errorMessage: ERROR_MESSAGE }] });
 
-		await waitFor(() => fireEvent.click(getSubmitButton()));
+		fireEvent.click(getSubmitButton());
 
-		expect(getErrorMessage()).toBeInTheDocument();
+		await waitFor(() => expect(getErrorMessage()).toBeInTheDocument());
 	});
 
 	it("should support default value", async () => {
@@ -84,8 +51,10 @@ describe(UI_TYPE, () => {
 
 		expect(screen.getByText(defaultValue)).toBeInTheDocument();
 
-		await waitFor(() => fireEvent.click(getSubmitButton()));
-		expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
+		fireEvent.click(getSubmitButton());
+		await waitFor(() =>
+			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }))
+		);
 	});
 
 	it("should apply maxLength attribute if max validation is specified", () => {
@@ -145,9 +114,9 @@ describe(UI_TYPE, () => {
 
 			fireEvent.change(getTextarea(), { target: { value: "hello" } });
 			fireEvent.click(getResetButton());
-			await waitFor(() => fireEvent.click(getSubmitButton()));
+			fireEvent.click(getSubmitButton());
 
-			expect(getTextarea()).toHaveValue("");
+			await waitFor(() => expect(getTextarea()).toHaveValue(""));
 			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: undefined }));
 		});
 
@@ -157,72 +126,18 @@ describe(UI_TYPE, () => {
 
 			fireEvent.change(getTextarea(), { target: { value: "world" } });
 			fireEvent.click(getResetButton());
-			await waitFor(() => fireEvent.click(getSubmitButton()));
+			fireEvent.click(getSubmitButton());
 
-			expect(getTextarea()).toHaveValue(defaultValue);
+			await waitFor(() => expect(getTextarea()).toHaveValue(defaultValue));
 			expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: defaultValue }));
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getTextarea(), { target: { value: "world" } });
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.change(getTextarea(), { target: { value: "world" } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.change(getTextarea(), { target: { value: "world" } });
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: "hello",
+		modifyField: () => fireEvent.change(getTextarea(), { target: { value: "world" } }),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/textarea/textarea.spec.tsx
+++ b/src/__tests__/components/fields/textarea/textarea.spec.tsx
@@ -15,7 +15,7 @@ const COMPONENT_ID = "field";
 const UI_TYPE = "textarea";
 const COMPONENT_LABEL = "Textarea";
 
-const renderComponent = createRenderComponent<ITextareaSchema>({
+const { renderComponent, schema } = createRenderComponent<ITextareaSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: { label: COMPONENT_LABEL, uiType: UI_TYPE },
 	submitFn: SUBMIT_FN,
@@ -133,7 +133,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: "hello",
 		modifyField: () => fireEvent.change(getTextarea(), { target: { value: "world" } }),

--- a/src/__tests__/components/fields/textarea/textarea.spec.tsx
+++ b/src/__tests__/components/fields/textarea/textarea.spec.tsx
@@ -8,8 +8,7 @@ import {
 	getResetButton,
 	getSubmitButton,
 } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/time-field/time-field.spec.tsx
+++ b/src/__tests__/components/fields/time-field/time-field.spec.tsx
@@ -1,60 +1,30 @@
 import { LocalTime } from "@js-joda/core";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
+import { fireEvent, waitFor } from "@testing-library/react";
 import { ITimeFieldSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
+	createRenderComponent,
 	getErrorMessage,
 	getField,
 	getResetButton,
-	getResetButtonProps,
 	getSubmitButton,
-	getSubmitButtonProps,
 } from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const COMPONENT_LABEL = "Time";
 const UI_TYPE = "time-field";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: COMPONENT_LABEL,
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
-	},
-};
 
-const renderComponent = (overrideField?: TOverrideField<ITimeFieldSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+const renderComponent = createRenderComponent<ITimeFieldSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: COMPONENT_LABEL,
+		uiType: UI_TYPE,
+	},
+	submitFn: SUBMIT_FN,
+});
 
 const getTimePicker = (): HTMLElement => {
 	return getField("combobox");
@@ -179,65 +149,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			await pickValidTime();
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", async () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			await pickValidTime();
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", async () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "hello" } }}
-					onClick={handleClick}
-				/>
-			);
-			await pickValidTime();
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: "hello",
+		modifyField: () => pickValidTime(),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/time-field/time-field.spec.tsx
+++ b/src/__tests__/components/fields/time-field/time-field.spec.tsx
@@ -16,7 +16,7 @@ const COMPONENT_ID = "field";
 const COMPONENT_LABEL = "Time";
 const UI_TYPE = "time-field";
 
-const renderComponent = createRenderComponent<ITimeFieldSchema>({
+const { renderComponent, schema } = createRenderComponent<ITimeFieldSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		label: COMPONENT_LABEL,
@@ -149,7 +149,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: "hello",
 		modifyField: () => pickValidTime(),

--- a/src/__tests__/components/fields/time-field/time-field.spec.tsx
+++ b/src/__tests__/components/fields/time-field/time-field.spec.tsx
@@ -9,8 +9,7 @@ import {
 	getResetButton,
 	getSubmitButton,
 } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/unit-number-field/unit-number.spec.tsx
+++ b/src/__tests__/components/fields/unit-number-field/unit-number.spec.tsx
@@ -1,58 +1,23 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import cloneDeep from "lodash/cloneDeep";
-import merge from "lodash/merge";
-import { FrontendEngine } from "../../../../components";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { IUnitNumberFieldSchema } from "../../../../components/fields";
-import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
 import { ERROR_MESSAGES } from "../../../../components/shared";
-import {
-	FRONTEND_ENGINE_ID,
-	FrontendEngineWithCustomButton,
-	TOverrideField,
-	TOverrideSchema,
-	getField,
-	getResetButton,
-	getResetButtonProps,
-	getSubmitButton,
-	getSubmitButtonProps,
-} from "../../../common";
-import { labelTestSuite } from "../../../common/tests";
+import { createRenderComponent, getResetButton, getSubmitButton } from "../../../common";
+import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
 import { warningTestSuite } from "../../../common/tests/warnings";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";
 const COMPONENT_LABEL = "Unit Number";
 const UI_TYPE = "unit-number-field";
-const JSON_SCHEMA: IFrontendEngineData = {
-	id: FRONTEND_ENGINE_ID,
-	sections: {
-		section: {
-			uiType: "section",
-			children: {
-				[COMPONENT_ID]: {
-					label: COMPONENT_LABEL,
-					uiType: UI_TYPE,
-				},
-				...getSubmitButtonProps(),
-				...getResetButtonProps(),
-			},
-		},
-	},
-};
 
-const renderComponent = (overrideField?: TOverrideField<IUnitNumberFieldSchema>, overrideSchema?: TOverrideSchema) => {
-	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
-	merge(json, {
-		sections: {
-			section: {
-				children: {
-					[COMPONENT_ID]: overrideField,
-				},
-			},
-		},
-	});
-	return render(<FrontendEngine data={json} onSubmit={SUBMIT_FN} />);
-};
+const renderComponent = createRenderComponent<IUnitNumberFieldSchema>({
+	componentId: COMPONENT_ID,
+	baseSchema: {
+		label: COMPONENT_LABEL,
+		uiType: UI_TYPE,
+	},
+	submitFn: SUBMIT_FN,
+});
 
 const getFloorInputField = (): HTMLElement => {
 	return screen.getByTestId("floor-input");
@@ -175,65 +140,11 @@ describe(UI_TYPE, () => {
 		});
 	});
 
-	describe("dirty state", () => {
-		let formIsDirty: boolean;
-		const handleClick = (ref: React.MutableRefObject<IFrontendEngineRef>) => {
-			formIsDirty = ref.current.isDirty;
-		};
-
-		beforeEach(() => {
-			formIsDirty = undefined;
-		});
-
-		it("should mount without setting field state as dirty", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should set form state as dirty if user modifies the field", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			setFieldValue("12", "34");
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(true);
-		});
-
-		it("should support default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "01-02" } }}
-					onClick={handleClick}
-				/>
-			);
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset and revert form dirty state to false", () => {
-			render(<FrontendEngineWithCustomButton data={JSON_SCHEMA} onClick={handleClick} />);
-			setFieldValue("12", "34");
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
-
-		it("should reset to default value without setting form state as dirty", () => {
-			render(
-				<FrontendEngineWithCustomButton
-					data={{ ...JSON_SCHEMA, defaultValues: { [COMPONENT_ID]: "01-02" } }}
-					onClick={handleClick}
-				/>
-			);
-			setFieldValue("12", "34");
-			fireEvent.click(getResetButton());
-			fireEvent.click(screen.getByRole("button", { name: "Custom Button" }));
-
-			expect(formIsDirty).toBe(false);
-		});
+	dirtyStateTestSuite({
+		schema: renderComponent.schema,
+		componentId: COMPONENT_ID,
+		defaultValue: "01-02",
+		modifyField: () => setFieldValue("12", "34"),
 	});
 
 	labelTestSuite(renderComponent);

--- a/src/__tests__/components/fields/unit-number-field/unit-number.spec.tsx
+++ b/src/__tests__/components/fields/unit-number-field/unit-number.spec.tsx
@@ -2,8 +2,7 @@ import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { IUnitNumberFieldSchema } from "../../../../components/fields";
 import { ERROR_MESSAGES } from "../../../../components/shared";
 import { createRenderComponent, getResetButton, getSubmitButton } from "../../../common";
-import { dirtyStateTestSuite, labelTestSuite } from "../../../common/tests";
-import { warningTestSuite } from "../../../common/tests/warnings";
+import { dirtyStateTestSuite, labelTestSuite, warningTestSuite } from "../../../common/tests";
 
 const SUBMIT_FN = jest.fn();
 const COMPONENT_ID = "field";

--- a/src/__tests__/components/fields/unit-number-field/unit-number.spec.tsx
+++ b/src/__tests__/components/fields/unit-number-field/unit-number.spec.tsx
@@ -9,7 +9,7 @@ const COMPONENT_ID = "field";
 const COMPONENT_LABEL = "Unit Number";
 const UI_TYPE = "unit-number-field";
 
-const renderComponent = createRenderComponent<IUnitNumberFieldSchema>({
+const { renderComponent, schema } = createRenderComponent<IUnitNumberFieldSchema>({
 	componentId: COMPONENT_ID,
 	baseSchema: {
 		label: COMPONENT_LABEL,
@@ -140,7 +140,7 @@ describe(UI_TYPE, () => {
 	});
 
 	dirtyStateTestSuite({
-		schema: renderComponent.schema,
+		schema,
 		componentId: COMPONENT_ID,
 		defaultValue: "01-02",
 		modifyField: () => setFieldValue("12", "34"),

--- a/src/stories/4-elements/tab/tab.stories.tsx
+++ b/src/stories/4-elements/tab/tab.stories.tsx
@@ -9,7 +9,7 @@ import {
 	OverrideStoryTemplate,
 	SUBMIT_BUTTON_SCHEMA,
 } from "../../common";
-import { useRef, useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { IFrontendEngineRef } from "../../../components";
 
 const meta: Meta = {


### PR DESCRIPTION
**Changes**
- Introduce `dirtyStateTestSuite` and `createRenderComponent` utils to reduce boilerplate across field integration tests
- Converts test files to utilize the utils, removing ~2000 lines of duplicated test code. Small amount of test cases are left untouched since those doesn't follow the same pattern.

**Checklist**
- [x] All test suites pass
- [x] TypeScript compilation passes