### PR TITLE
Update deprecated vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,6 @@
 	"[typescript]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	},
-	"typescript.preferences.importModuleSpecifier": "relative"
+    "js/ts.preferences.importModuleSpecifier": "relative",
+	"js/ts.tsdk.path": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
**Changes**
Description of changes...

-   [delete] branch
-  resolve ts errors that recently showed up due to using mismatched versions of Typescript (installed is v5, vscode uses v6)
- will look into upgrading TS6 another time
