### PR TITLE
[DCUBESDQLR-2767][HN] Add allowDeselection, layoutColumns, minItemWidth and stretch for radio toggle button

### DIFF
--- a/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
@@ -5,12 +5,12 @@ import merge from "lodash/merge";
 import { useState } from "react";
 import { FrontendEngine } from "../../../../components";
 import { TRadioButtonGroupSchema } from "../../../../components/fields";
+import { IRadioButtonToggleSchema } from "../../../../components/fields/radio-button/types";
 import { IFrontendEngineData, IFrontendEngineRef } from "../../../../components/frontend-engine";
 import {
 	ERROR_MESSAGE,
 	FRONTEND_ENGINE_ID,
 	FrontendEngineWithCustomButton,
-	TOverrideField,
 	TOverrideSchema,
 	getErrorMessage,
 	getField,
@@ -63,7 +63,10 @@ const JSON_SCHEMA: IFrontendEngineData = {
 	},
 };
 
-const renderComponent = (overrideField?: TOverrideField<TRadioButtonGroupSchema>, overrideSchema?: TOverrideSchema) => {
+const renderComponent = (
+	overrideField?: Partial<Omit<IRadioButtonToggleSchema, "uiType">>,
+	overrideSchema?: TOverrideSchema
+) => {
 	const json: IFrontendEngineData = merge(cloneDeep(JSON_SCHEMA), overrideSchema);
 	merge(json, {
 		sections: {
@@ -479,9 +482,9 @@ describe("radio toggle button", () => {
 	describe("allowDeselection feature", () => {
 		it("should deselect when clicking selected option if allowDeselection is true", async () => {
 			renderComponent({
+				allowDeselection: true,
 				customOptions: {
 					styleType: "toggle",
-					allowDeselection: true,
 				},
 			});
 
@@ -514,9 +517,9 @@ describe("radio toggle button", () => {
 			${"undefined"} | ${undefined}
 		`("should not deselect when allowDeselection is $description", async ({ allowDeselection }) => {
 			renderComponent({
+				...(allowDeselection !== undefined && { allowDeselection }),
 				customOptions: {
 					styleType: "toggle",
-					...(allowDeselection !== undefined && { allowDeselection }),
 				},
 			});
 
@@ -536,9 +539,9 @@ describe("radio toggle button", () => {
 		it("should not deselect disabled option even with allowDeselection true", async () => {
 			renderComponent(
 				{
+					allowDeselection: true,
 					customOptions: {
 						styleType: "toggle",
-						allowDeselection: true,
 					},
 					options: [
 						{ value: "Apple", label: "A" },
@@ -568,9 +571,9 @@ describe("radio toggle button", () => {
 							[COMPONENT_ID]: {
 								label: "Radio",
 								uiType: UI_TYPE,
+								allowDeselection: true,
 								customOptions: {
 									styleType: "toggle",
-									allowDeselection: true,
 								},
 								options: [
 									{
@@ -637,9 +640,9 @@ describe("radio toggle button", () => {
 
 		it("should trigger required validation when deselecting required field", async () => {
 			renderComponent({
+				allowDeselection: true,
 				customOptions: {
 					styleType: "toggle",
-					allowDeselection: true,
 				},
 				validation: [{ required: true, errorMessage: ERROR_MESSAGE }],
 			});
@@ -749,7 +752,7 @@ describe("radio toggle button", () => {
 		});
 	});
 
-	labelTestSuite(renderComponent);
+	labelTestSuite(renderComponent as (overrideField: unknown) => void);
 	warningTestSuite<TRadioButtonGroupSchema>({
 		label: "Radio",
 		uiType: UI_TYPE,

--- a/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
@@ -476,6 +476,279 @@ describe("radio toggle button", () => {
 		});
 	});
 
+	describe("allowDeselection feature", () => {
+		it("should deselect when clicking selected option if allowDeselection is true", async () => {
+			renderComponent({
+				customOptions: {
+					styleType: "toggle",
+					allowDeselection: true,
+				},
+			});
+
+			const radioButtonA = getRadioButtonA();
+
+			// Select option A
+			fireEvent.click(radioButtonA);
+			await waitFor(() => expect(radioButtonA).toBeChecked());
+
+			// Click again to deselect
+			fireEvent.click(radioButtonA);
+			await waitFor(() => {
+				expect(radioButtonA).not.toBeChecked();
+			});
+
+			// Submit and verify value is null
+			fireEvent.click(getSubmitButton());
+			await waitFor(() => {
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({
+						[COMPONENT_ID]: null,
+					})
+				);
+			});
+		});
+
+		it.each`
+			description    | allowDeselection
+			${"false"}     | ${false}
+			${"undefined"} | ${undefined}
+		`("should not deselect when allowDeselection is $description", async ({ allowDeselection }) => {
+			renderComponent({
+				customOptions: {
+					styleType: "toggle",
+					...(allowDeselection !== undefined && { allowDeselection }),
+				},
+			});
+
+			const radioButtonA = getRadioButtonA();
+			fireEvent.click(radioButtonA);
+			await waitFor(() => expect(radioButtonA).toBeChecked());
+
+			fireEvent.click(radioButtonA);
+			await waitFor(() => expect(radioButtonA).toBeChecked());
+
+			fireEvent.click(getSubmitButton());
+			await waitFor(() =>
+				expect(SUBMIT_FN).toHaveBeenCalledWith(expect.objectContaining({ [COMPONENT_ID]: "Apple" }))
+			);
+		});
+
+		it("should not deselect disabled option even with allowDeselection true", async () => {
+			renderComponent(
+				{
+					customOptions: {
+						styleType: "toggle",
+						allowDeselection: true,
+					},
+					options: [
+						{ value: "Apple", label: "A" },
+						{ value: "Berry", label: "B", disabled: true },
+					],
+				},
+				{ defaultValues: { [COMPONENT_ID]: "Berry" } }
+			);
+
+			const radioButtonB = getRadioButtonB();
+			expect(radioButtonB).toBeChecked();
+
+			// B is selected and disabled — clicking it should NOT deselect
+			fireEvent.click(radioButtonB);
+			await waitFor(() => {
+				expect(radioButtonB).toBeChecked();
+			});
+		});
+
+		it("should clear nested children when deselecting option with children", async () => {
+			const JSON_WITH_CHILDREN: IFrontendEngineData = {
+				id: FRONTEND_ENGINE_ID,
+				sections: {
+					section: {
+						uiType: "section",
+						children: {
+							[COMPONENT_ID]: {
+								label: "Radio",
+								uiType: UI_TYPE,
+								customOptions: {
+									styleType: "toggle",
+									allowDeselection: true,
+								},
+								options: [
+									{
+										label: "A",
+										value: "Apple",
+										children: {
+											[NESTED_FIELD_ID]: {
+												label: "Nested",
+												uiType: "text-field",
+											},
+										},
+									},
+									{ label: "B", value: "Berry" },
+								],
+							},
+							...getSubmitButtonProps(),
+						},
+					},
+				},
+			};
+
+			render(<FrontendEngine data={JSON_WITH_CHILDREN} onSubmit={SUBMIT_FN} />);
+
+			const radioButtonA = getRadioButtonA();
+
+			// Select option A - nested field should appear
+			fireEvent.click(radioButtonA);
+			await waitFor(() => {
+				expect(radioButtonA).toBeChecked();
+				expect(getNestedField()).toBeInTheDocument();
+			});
+
+			// Type in nested field
+			fireEvent.change(getNestedField(), { target: { value: "test value" } });
+			await waitFor(() => {
+				expect(getNestedField()).toHaveValue("test value");
+			});
+
+			// Deselect option A
+			fireEvent.click(radioButtonA);
+			await waitFor(() => {
+				expect(radioButtonA).not.toBeChecked();
+			});
+			await waitFor(() => {
+				expect(getNestedField()).not.toBeInTheDocument();
+			});
+
+			// Submit and verify nested field value is cleared
+			fireEvent.click(getSubmitButton());
+			await waitFor(() => {
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.objectContaining({
+						[COMPONENT_ID]: null,
+					})
+				);
+				// Nested field should not be in the submission (it's removed/unmounted)
+				expect(SUBMIT_FN).toHaveBeenCalledWith(
+					expect.not.objectContaining({
+						[NESTED_FIELD_ID]: expect.anything(),
+					})
+				);
+			});
+		});
+
+		it("should trigger required validation when deselecting required field", async () => {
+			renderComponent({
+				customOptions: {
+					styleType: "toggle",
+					allowDeselection: true,
+				},
+				validation: [{ required: true, errorMessage: ERROR_MESSAGE }],
+			});
+
+			const radioButtonA = getRadioButtonA();
+
+			// Select option A
+			fireEvent.click(radioButtonA);
+			await waitFor(() => expect(radioButtonA).toBeChecked());
+
+			// Deselect option A
+			fireEvent.click(radioButtonA);
+			await waitFor(() => {
+				expect(radioButtonA).not.toBeChecked();
+			});
+
+			// Try to submit - should show validation error
+			fireEvent.click(getSubmitButton());
+			await waitFor(() => {
+				expect(SUBMIT_FN).not.toHaveBeenCalled();
+				expect(getErrorMessage()).toBeInTheDocument();
+			});
+		});
+	});
+
+	describe("layoutColumns feature", () => {
+		it.each`
+			description     | layoutColumns
+			${"number"}     | ${2}
+			${"responsive"} | ${{ mobile: 1, desktop: 2 }}
+		`("should render toggles in grid when layoutColumns is $description", ({ layoutColumns }) => {
+			renderComponent({
+				customOptions: {
+					styleType: "toggle",
+					layoutColumns,
+				},
+				options: [
+					{ label: "A", value: "a" },
+					{ label: "B", value: "b" },
+					{ label: "C", value: "c" },
+					{ label: "D", value: "d" },
+				],
+			});
+
+			expect(screen.getAllByRole("radio")).toHaveLength(4);
+		});
+
+		it("should work with layoutType and layoutColumns together", () => {
+			renderComponent({
+				customOptions: {
+					styleType: "toggle",
+					layoutColumns: 2,
+					layoutType: "horizontal",
+				},
+			});
+
+			expect(screen.getAllByRole("radio")).toHaveLength(2);
+		});
+	});
+
+	describe("minItemWidth feature", () => {
+		it("should apply fixed item width when minItemWidth is set", () => {
+			renderComponent({
+				customOptions: { styleType: "toggle", minItemWidth: 200 },
+				options: [
+					{ label: "A", value: "a" },
+					{ label: "B", value: "b" },
+				],
+			});
+			expect(screen.getAllByRole("radio")).toHaveLength(2);
+		});
+
+		it("should apply responsive minItemWidth per breakpoint", () => {
+			renderComponent({
+				customOptions: { styleType: "toggle", minItemWidth: { mobile: 100, desktop: 200 } },
+				options: [
+					{ label: "A", value: "a" },
+					{ label: "B", value: "b" },
+				],
+			});
+			expect(screen.getAllByRole("radio")).toHaveLength(2);
+		});
+	});
+
+	describe("stretch feature", () => {
+		it("should render grid with auto-fill when stretch is true", () => {
+			renderComponent({
+				customOptions: { styleType: "toggle", stretch: true },
+				options: [
+					{ label: "A", value: "a" },
+					{ label: "B", value: "b" },
+				],
+			});
+			expect(screen.getAllByRole("radio")).toHaveLength(2);
+		});
+
+		it("should use layoutColumns with stretch", () => {
+			renderComponent({
+				customOptions: { styleType: "toggle", layoutColumns: 2, stretch: true },
+				options: [
+					{ label: "A", value: "a" },
+					{ label: "B", value: "b" },
+					{ label: "C", value: "c" },
+				],
+			});
+			expect(screen.getAllByRole("radio")).toHaveLength(3);
+		});
+	});
+
 	labelTestSuite(renderComponent);
 	warningTestSuite<TRadioButtonGroupSchema>({
 		label: "Radio",

--- a/src/__tests__/setup/global-setup.js
+++ b/src/__tests__/setup/global-setup.js
@@ -8,7 +8,36 @@ window.GeolocationPositionError = {
 	TIMEOUT: 3,
 };
 
+const matchMediaFactory = (query) => ({
+	matches: false,
+	media: query,
+	onchange: null,
+	addListener: jest.fn(),
+	removeListener: jest.fn(),
+	addEventListener: jest.fn(),
+	removeEventListener: jest.fn(),
+	dispatchEvent: jest.fn(),
+});
+
+Object.defineProperty(window, "matchMedia", {
+	writable: true,
+	configurable: true,
+	value: jest.fn().mockImplementation(matchMediaFactory),
+});
+
 global.beforeEach(() => {
+	// Restore implementation on the existing jest mock (preserves cached references used by react-responsive).
+	// If window.matchMedia is not a jest mock (e.g. jsdom-testing-mocks replaced it via mockViewportForTestGroup),
+	// leave it untouched so viewport mocking works correctly.
+	if (window.matchMedia && typeof window.matchMedia.mockImplementation === "function") {
+		window.matchMedia.mockImplementation(matchMediaFactory);
+	} else if (!window.matchMedia) {
+		Object.defineProperty(window, "matchMedia", {
+			writable: true,
+			configurable: true,
+			value: jest.fn().mockImplementation(matchMediaFactory),
+		});
+	}
 	delete window.ResizeObserver;
 	window.ResizeObserver = jest.fn().mockImplementation(() => ({
 		observe: jest.fn(),

--- a/src/components/fields/radio-button/radio-button.styles.ts
+++ b/src/components/fields/radio-button/radio-button.styles.ts
@@ -12,6 +12,10 @@ interface ILabelProps {
 
 interface IToggleWrapperProps {
 	$layoutType?: TRadioToggleLayoutType;
+	$resolvedColumns?: number | undefined;
+	$resolvedMinItemWidth?: number | undefined;
+	$stretch?: boolean | undefined;
+	$hasMinItemWidth?: boolean | undefined;
 }
 
 export const Label = styled(Typography.BodyMD)<ILabelProps>`
@@ -45,9 +49,21 @@ export const FlexImageWrapper = styled.div`
 `;
 
 export const FlexToggleWrapper = styled.div<IToggleWrapperProps>`
-	display: flex;
-	flex-direction: ${(props) => (props.$layoutType === "vertical" ? "column" : "row")};
-	flex-wrap: wrap;
+	${(props) => {
+		const { $resolvedColumns, $stretch, $resolvedMinItemWidth, $layoutType, $hasMinItemWidth } = props;
+		if ($resolvedColumns) {
+			return $stretch
+				? `display: grid; grid-template-columns: repeat(${$resolvedColumns}, 1fr);`
+				: `display: grid; grid-template-columns: repeat(${$resolvedColumns}, auto); justify-content: start;`;
+		}
+		if ($stretch) {
+			return `display: grid; grid-template-columns: repeat(auto-fill, minmax(${$resolvedMinItemWidth}px, 1fr));`;
+		}
+		if ($hasMinItemWidth) {
+			return `display: flex; flex-wrap: wrap; > * { flex: 0 0 ${$resolvedMinItemWidth}px; width: ${$resolvedMinItemWidth}px; }`;
+		}
+		return `display: flex; flex-direction: ${$layoutType === "vertical" ? "column" : "row"}; flex-wrap: wrap;`;
+	}}
 	gap: ${Spacing["spacing-16"]};
 `;
 

--- a/src/components/fields/radio-button/radio-button.tsx
+++ b/src/components/fields/radio-button/radio-button.tsx
@@ -1,3 +1,5 @@
+import isEmpty from "lodash/isEmpty";
+import isObject from "lodash/isObject";
 import { Form } from "@lifesg/react-design-system/form";
 import { Breakpoint } from "@lifesg/react-design-system/theme";
 import { useContext, useEffect, useState } from "react";
@@ -58,11 +60,16 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 			? customOptions
 			: undefined;
 
+	const allowDeselection =
+		toggleOptions && "allowDeselection" in schema
+			? (schema as { allowDeselection?: boolean }).allowDeselection
+			: undefined;
+
 	const theme = useContext(ThemeContext);
-	const { setValue, trigger, clearErrors } = useFormContext();
+	const { setValue, trigger, clearErrors, unregister } = useFormContext();
 	const [stateValue, setStateValue] = useState<string>(value || "");
 	const [currentBreakpoint, setCurrentBreakpoint] = useState<TBreakpoint>("desktop");
-	const { setFieldValidationConfig } = useValidationConfig();
+	const { setFieldValidationConfig, removeFieldValidationConfig } = useValidationConfig();
 
 	// =============================================================================
 	// EFFECTS
@@ -109,18 +116,29 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 	// EVENT HANDLERS
 	// =============================================================================
 	const handleChangeOrClick = (clickedValue: string): void => {
-		if (toggleOptions?.allowDeselection && stateValue === clickedValue) {
-			onChange?.({ target: { value: null } });
-			trigger(id);
-			const selectedOption = options.find((opt) => opt.value === clickedValue);
-			if (selectedOption && "children" in selectedOption && selectedOption.children) {
-				Object.keys(selectedOption.children as Record<string, unknown>).forEach((childId) =>
-					setValue(childId, undefined)
-				);
-			}
+		if (allowDeselection && stateValue === clickedValue) {
+			handleDeselect(clickedValue);
 		} else {
 			onChange?.({ target: { value: clickedValue } });
 			clearErrors(id);
+		}
+	};
+
+	const handleDeselect = (clickedValue: string): void => {
+		onChange?.({ target: { value: null } });
+		trigger(id);
+
+		const selectedOption = options.find((opt) => opt.value === clickedValue);
+		if (
+			selectedOption &&
+			"children" in selectedOption &&
+			isObject(selectedOption.children) &&
+			!isEmpty(selectedOption.children)
+		) {
+			collectNestedChildIds(selectedOption.children as Record<string, unknown>).forEach((childId) => {
+				removeFieldValidationConfig(childId);
+				unregister(childId);
+			});
 		}
 	};
 
@@ -135,6 +153,16 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 		const unique = generateRandomId();
 		return `${id}-${unique}`;
 	};
+
+	const collectNestedChildIds = (children: Record<string, unknown>): string[] =>
+		Object.entries(children).flatMap(([childId, child]) => {
+			const nestedChildren = isObject(child) ? (child as Record<string, unknown>)["children"] : undefined;
+			const nestedIds =
+				isObject(nestedChildren) && !isEmpty(nestedChildren)
+					? collectNestedChildIds(nestedChildren as Record<string, unknown>)
+					: [];
+			return [childId, ...nestedIds];
+		});
 
 	// =============================================================================
 	// RENDER FUNCTIONS
@@ -217,10 +245,15 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 								styleType={customOptions?.border === false ? "no-border" : "default"}
 								checked={isRadioButtonChecked(option.value)}
 								onClick={() => handleChangeOrClick(option.value)}
+								onKeyDown={(e) => {
+									if (e.key === " " || e.key === "Enter") {
+										e.preventDefault();
+										handleChangeOrClick(option.value);
+									}
+								}}
 								error={!!error?.message}
 								compositeSection={
-									option.children &&
-									(!toggleOptions?.allowDeselection || isRadioButtonChecked(option.value))
+									option.children && (!allowDeselection || isRadioButtonChecked(option.value))
 										? { children: <Wrapper>{option.children}</Wrapper>, collapsible: false }
 										: undefined
 								}

--- a/src/components/fields/radio-button/radio-button.tsx
+++ b/src/components/fields/radio-button/radio-button.tsx
@@ -1,6 +1,8 @@
 import { Form } from "@lifesg/react-design-system/form";
-import { useEffect, useState } from "react";
+import { Breakpoint } from "@lifesg/react-design-system/theme";
+import { useContext, useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
+import { ThemeContext } from "styled-components";
 import useDeepCompareEffect from "use-deep-compare-effect";
 import * as Yup from "yup";
 import { IGenericFieldProps } from "..";
@@ -17,7 +19,29 @@ import {
 	StyledRadioButton,
 	StyledToggle,
 } from "./radio-button.styles";
-import { IRadioButtonOption, TRadioButtonGroupSchema } from "./types";
+import {
+	IImageButtonOption,
+	IRadioButtonOption,
+	IRadioToggleOption,
+	TBreakpoint,
+	TRadioButtonGroupSchema,
+	TResponsiveValue,
+} from "./types";
+
+const DEFAULT_MIN_ITEM_WIDTH = 164;
+
+const resolveResponsiveValue = <T,>(
+	value: TResponsiveValue<T> | undefined,
+	breakpoint: TBreakpoint,
+	defaultValue: T
+): T => {
+	if (value === undefined || value === null) return defaultValue;
+	if (typeof value !== "object") return value as T;
+	const { mobile, tablet, desktop } = value as { mobile?: T; tablet?: T; desktop?: T };
+	if (breakpoint === "mobile") return mobile ?? tablet ?? desktop ?? defaultValue;
+	if (breakpoint === "tablet") return tablet ?? desktop ?? mobile ?? defaultValue;
+	return desktop ?? tablet ?? mobile ?? defaultValue;
+};
 
 export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSchema>) => {
 	// =============================================================================
@@ -29,15 +53,22 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 		customSchema: { className, disabled, options, ...radioProps },
 	} = filterSchemaProps(schema);
 
-	const { setValue } = useFormContext();
+	const toggleOptions =
+		customOptions && "styleType" in customOptions && customOptions.styleType === "toggle"
+			? customOptions
+			: undefined;
+
+	const theme = useContext(ThemeContext);
+	const { setValue, trigger, clearErrors } = useFormContext();
 	const [stateValue, setStateValue] = useState<string>(value || "");
+	const [currentBreakpoint, setCurrentBreakpoint] = useState<TBreakpoint>("desktop");
 	const { setFieldValidationConfig } = useValidationConfig();
 
 	// =============================================================================
 	// EFFECTS
 	// =============================================================================
 	useEffect(() => {
-		setFieldValidationConfig(id, Yup.string(), validation);
+		setFieldValidationConfig(id, Yup.string().nullable(), validation);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [validation]);
 
@@ -48,14 +79,49 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 	}, [options]);
 
 	useEffect(() => {
-		setStateValue(value || "");
+		setStateValue(value ?? "");
 	}, [value]);
+
+	useEffect(() => {
+		const mobileMax = Breakpoint["sm-max"]({ theme });
+		const tabletMax = Breakpoint["lg-max"]({ theme }) - 1;
+		const mobileQuery = window.matchMedia(`(max-width: ${mobileMax}px)`);
+		const tabletQuery = window.matchMedia(`(min-width: ${mobileMax + 1}px) and (max-width: ${tabletMax}px)`);
+
+		const detectBreakpoint = (): TBreakpoint => {
+			if (mobileQuery.matches) return "mobile";
+			if (tabletQuery.matches) return "tablet";
+			return "desktop";
+		};
+
+		const onQueryChange = () => setCurrentBreakpoint(detectBreakpoint());
+		onQueryChange();
+		mobileQuery.addEventListener("change", onQueryChange);
+		tabletQuery.addEventListener("change", onQueryChange);
+		return () => {
+			mobileQuery.removeEventListener("change", onQueryChange);
+			tabletQuery.removeEventListener("change", onQueryChange);
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	// =============================================================================
 	// EVENT HANDLERS
 	// =============================================================================
-	const handleChangeOrClick = (value: string): void => {
-		onChange({ target: { value } });
+	const handleChangeOrClick = (clickedValue: string): void => {
+		if (toggleOptions?.allowDeselection && stateValue === clickedValue) {
+			onChange?.({ target: { value: null } });
+			trigger(id);
+			const selectedOption = options.find((opt) => opt.value === clickedValue);
+			if (selectedOption && "children" in selectedOption && selectedOption.children) {
+				Object.keys(selectedOption.children as Record<string, unknown>).forEach((childId) =>
+					setValue(childId, undefined)
+				);
+			}
+		} else {
+			onChange?.({ target: { value: clickedValue } });
+			clearErrors(id);
+		}
 	};
 
 	// =============================================================================
@@ -110,14 +176,30 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 	};
 
 	const renderToggles = () => {
+		const layoutType = toggleOptions?.layoutType ?? "horizontal";
+		const resolvedColumns =
+			toggleOptions?.layoutColumns !== undefined
+				? resolveResponsiveValue(toggleOptions.layoutColumns, currentBreakpoint, 0) || undefined
+				: undefined;
+		const resolvedMinItemWidth = resolveResponsiveValue(
+			toggleOptions?.minItemWidth,
+			currentBreakpoint,
+			DEFAULT_MIN_ITEM_WIDTH
+		);
+		const stretch = toggleOptions?.stretch ?? false;
+
 		return (
 			options.length > 0 &&
-			customOptions.styleType === "toggle" && (
+			customOptions?.styleType === "toggle" && (
 				<FlexToggleWrapper
 					className={className ? `${className} ${className}-radio-container` : undefined}
-					$layoutType={customOptions?.layoutType ?? "horizontal"}
+					$layoutType={layoutType}
+					$resolvedColumns={resolvedColumns}
+					$resolvedMinItemWidth={resolvedMinItemWidth}
+					$stretch={stretch}
+					$hasMinItemWidth={!!toggleOptions?.minItemWidth}
 				>
-					{options.map((option, index) => {
+					{(options as IRadioToggleOption[]).map((option, index) => {
 						const radioButtonId = formatId();
 
 						return (
@@ -134,17 +216,15 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 								indicator={customOptions?.indicator}
 								styleType={customOptions?.border === false ? "no-border" : "default"}
 								checked={isRadioButtonChecked(option.value)}
-								onChange={() => handleChangeOrClick(option.value)}
+								onClick={() => handleChangeOrClick(option.value)}
 								error={!!error?.message}
 								compositeSection={
-									option.children
-										? {
-												children: <Wrapper>{option.children}</Wrapper>,
-												collapsible: false,
-										  }
-										: null
+									option.children &&
+									(!toggleOptions?.allowDeselection || isRadioButtonChecked(option.value))
+										? { children: <Wrapper>{option.children}</Wrapper>, collapsible: false }
+										: undefined
 								}
-								subLabel={!!option.subLabel && renderLabel(option.subLabel)}
+								subLabel={option.subLabel ? renderLabel(option.subLabel) : undefined}
 							>
 								{renderLabel(option.label)}
 							</StyledToggle>
@@ -159,7 +239,7 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 		return (
 			options.length > 0 && (
 				<FlexImageWrapper className={className ? `${className} ${className}-radio-container` : undefined}>
-					{options.map((option, index) => {
+					{(options as IImageButtonOption[]).map((option, index) => {
 						const radioButtonId = formatId();
 
 						return (

--- a/src/components/fields/radio-button/types.ts
+++ b/src/components/fields/radio-button/types.ts
@@ -45,16 +45,16 @@ interface IRadioButtonDefaultSchema<V = undefined>
 		| undefined;
 }
 
-interface IRadioButtonToggleSchema<V = undefined, C = undefined>
+export interface IRadioButtonToggleSchema<V = undefined, C = undefined>
 	extends IBaseFieldSchema<"radio", V>,
 		TComponentOmitProps<RadioButtonProps> {
 	options: IRadioToggleOption<V, C>[];
+	allowDeselection?: boolean | undefined;
 	customOptions: {
 		styleType: "toggle";
 		indicator?: boolean | undefined;
 		border?: boolean | undefined;
 		layoutType?: TRadioToggleLayoutType | undefined;
-		allowDeselection?: boolean | undefined;
 		layoutColumns?: TLayoutColumns | undefined;
 		minItemWidth?: TMinItemWidth | undefined;
 		stretch?: boolean | undefined;

--- a/src/components/fields/radio-button/types.ts
+++ b/src/components/fields/radio-button/types.ts
@@ -10,16 +10,29 @@ export interface IRadioButtonOption {
 	disabled?: boolean | undefined;
 }
 
-interface IToggleOption<V = undefined, C = undefined> extends IRadioButtonOption {
+export interface IRadioToggleOption<V = undefined, C = undefined> extends IRadioButtonOption {
 	children?: Record<string, TFrontendEngineFieldSchema<V, C>> | undefined;
 	subLabel?: string | undefined;
 }
 
-interface IImageButtonOption extends IRadioButtonOption {
+export interface IImageButtonOption extends IRadioButtonOption {
 	imgSrc?: string | undefined;
 }
 
 export type TRadioToggleLayoutType = "horizontal" | "vertical";
+
+export type TBreakpoint = "mobile" | "tablet" | "desktop";
+
+export type TResponsiveValue<T> =
+	| T
+	| {
+			mobile?: T | undefined;
+			tablet?: T | undefined;
+			desktop?: T | undefined;
+	  };
+
+export type TLayoutColumns = TResponsiveValue<number>;
+export type TMinItemWidth = TResponsiveValue<number>;
 
 interface IRadioButtonDefaultSchema<V = undefined>
 	extends IBaseFieldSchema<"radio", V>,
@@ -35,12 +48,16 @@ interface IRadioButtonDefaultSchema<V = undefined>
 interface IRadioButtonToggleSchema<V = undefined, C = undefined>
 	extends IBaseFieldSchema<"radio", V>,
 		TComponentOmitProps<RadioButtonProps> {
-	options: IToggleOption<V, C>[];
+	options: IRadioToggleOption<V, C>[];
 	customOptions: {
 		styleType: "toggle";
 		indicator?: boolean | undefined;
 		border?: boolean | undefined;
 		layoutType?: TRadioToggleLayoutType | undefined;
+		allowDeselection?: boolean | undefined;
+		layoutColumns?: TLayoutColumns | undefined;
+		minItemWidth?: TMinItemWidth | undefined;
+		stretch?: boolean | undefined;
 	};
 }
 

--- a/src/stories/3-fields/radio-button/radio-toggle-button.stories.tsx
+++ b/src/stories/3-fields/radio-button/radio-toggle-button.stories.tsx
@@ -41,13 +41,23 @@ const meta: Meta = {
 		},
 		customOptions: {
 			description:
-				'<div>A custom options on which styling to use for rendering the toggle group.</div><ul><li>`styleType` prop accept either `default` or `toggle`. If set to `toggle` will render toggle button, else render default radio buttons.</li><li>`indicator` show/hide radio icon, `false` by default.</li><li>`border` show/hide border, `true` by default.</li><li>`layoutType` render radio buttons horizontally or vertically (`"horizontal"` by default).</li><li>`allowDeselection` clicking a selected option deselects it (value becomes null), `false` by default.</li><li>`layoutColumns` controls how many toggle buttons appear per row using CSS grid — accepts a number or responsive object `{ mobile?, tablet?, desktop? }`.</li><li>`minItemWidth` sets a fixed minimum item width in pixels — accepts a number or responsive object `{ mobile?, tablet?, desktop? }`.</li><li>`stretch` when true, items stretch to fill the row using CSS auto-fill grid.</li></ul>',
+				'<div>A custom options on which styling to use for rendering the toggle group.</div><ul><li>`styleType` prop accept either `default` or `toggle`. If set to `toggle` will render toggle button, else render default radio buttons.</li><li>`indicator` show/hide radio icon, `false` by default.</li><li>`border` show/hide border, `true` by default.</li><li>`layoutType` render radio buttons horizontally or vertically (`"horizontal"` by default).</li><li>`layoutColumns` controls how many toggle buttons appear per row using CSS grid — accepts a number or responsive object `{ mobile?, tablet?, desktop? }`.</li><li>`minItemWidth` sets a fixed minimum item width in pixels — accepts a number or responsive object `{ mobile?, tablet?, desktop? }`.</li><li>`stretch` when true, items stretch to fill the row using CSS auto-fill grid.</li></ul>',
 			table: {
 				type: {
-					summary: `{styleType: "toggle", indicator?: boolean, border?: boolean, layoutType?: "horizontal" | "vertical", allowDeselection?: boolean, layoutColumns?: number | { mobile?: number, tablet?: number, desktop?: number }, minItemWidth?: number | { mobile?: number, tablet?: number, desktop?: number }, stretch?: boolean}`,
+					summary: `{styleType: "toggle", indicator?: boolean, border?: boolean, layoutType?: "horizontal" | "vertical", layoutColumns?: number | { mobile?: number, tablet?: number, desktop?: number }, minItemWidth?: number | { mobile?: number, tablet?: number, desktop?: number }, stretch?: boolean}`,
 				},
 			},
 			type: { name: "object", value: {} },
+		},
+		allowDeselection: {
+			description:
+				"When `true`, clicking an already-selected toggle deselects it (field value becomes `null`). Only applies to the `toggle` styleType. Defaults to `false`.",
+			table: {
+				type: { summary: "boolean" },
+				defaultValue: { summary: "false" },
+			},
+			options: [true, false],
+			control: { type: "boolean" },
 		},
 		options: {
 			description:
@@ -364,33 +374,15 @@ export const AllowDeselection = DefaultStoryTemplate<TRadioButtonGroupSchema>("r
 AllowDeselection.args = {
 	uiType: "radio",
 	label: "Select a fruit (click again to deselect)",
+	allowDeselection: true,
 	customOptions: {
 		styleType: "toggle",
-		allowDeselection: true,
 	},
 	options: [
 		{ label: "Apple", value: "Apple" },
 		{ label: "Berry", value: "Berry" },
 		{ label: "Cherry", value: "Cherry" },
 	],
-};
-
-export const AllowDeselectionFalse = DefaultStoryTemplate<TRadioButtonGroupSchema>(
-	"radio-allow-deselection-false"
-).bind({});
-AllowDeselectionFalse.args = {
-	uiType: "radio",
-	label: "Select a fruit (clicking selected option has no effect — allowDeselection is false)",
-	customOptions: {
-		styleType: "toggle",
-		allowDeselection: false,
-	},
-	options: [
-		{ label: "Apple", value: "Apple" },
-		{ label: "Berry", value: "Berry" },
-		{ label: "Cherry", value: "Cherry" },
-	],
-	defaultValues: "Apple",
 };
 
 export const AllowDeselectionWithNestedFields = DefaultStoryTemplate<TRadioButtonGroupSchema>(
@@ -399,9 +391,9 @@ export const AllowDeselectionWithNestedFields = DefaultStoryTemplate<TRadioButto
 AllowDeselectionWithNestedFields.args = {
 	uiType: "radio",
 	label: "Select a reason (deselect to clear nested field)",
+	allowDeselection: true,
 	customOptions: {
 		styleType: "toggle",
-		allowDeselection: true,
 		indicator: true,
 	},
 	options: [
@@ -433,9 +425,9 @@ export const AllowDeselectionWithRequiredValidation = DefaultStoryTemplate<TRadi
 AllowDeselectionWithRequiredValidation.args = {
 	uiType: "radio",
 	label: "Select a fruit (required — deselecting triggers validation error)",
+	allowDeselection: true,
 	customOptions: {
 		styleType: "toggle",
-		allowDeselection: true,
 	},
 	options: [
 		{ label: "Apple", value: "Apple" },
@@ -452,9 +444,9 @@ export const AllowDeselectionWithDefault = DefaultStoryTemplate<TRadioButtonGrou
 AllowDeselectionWithDefault.args = {
 	uiType: "radio",
 	label: "Select a fruit (has default, click to deselect)",
+	allowDeselection: true,
 	customOptions: {
 		styleType: "toggle",
-		allowDeselection: true,
 	},
 	options: [
 		{ label: "Apple", value: "Apple" },
@@ -479,24 +471,6 @@ MinItemWidth.args = {
 
 export const LayoutColumns = DefaultStoryTemplate<TRadioButtonGroupSchema>("radio-layout-columns").bind({});
 LayoutColumns.args = {
-	uiType: "radio",
-	label: "Select an option (2 per row, not stretched)",
-	customOptions: {
-		styleType: "toggle",
-		layoutColumns: 2,
-	},
-	options: [
-		{ label: "Option A", value: "a" },
-		{ label: "Option B", value: "b" },
-		{ label: "Option C", value: "c" },
-		{ label: "Option D", value: "d" },
-	],
-};
-
-export const LayoutColumnsResponsive = DefaultStoryTemplate<TRadioButtonGroupSchema>(
-	"radio-layout-columns-responsive"
-).bind({});
-LayoutColumnsResponsive.args = {
 	uiType: "radio",
 	label: "Responsive columns (1 on mobile, 3 on desktop, not stretched)",
 	customOptions: {
@@ -530,22 +504,6 @@ export const LayoutColumnsWithStretch = DefaultStoryTemplate<TRadioButtonGroupSc
 	"radio-layout-columns-stretch"
 ).bind({});
 LayoutColumnsWithStretch.args = {
-	uiType: "radio",
-	label: "2 columns, stretched (resize to see)",
-	customOptions: { styleType: "toggle", layoutColumns: 2, stretch: true },
-	options: [
-		{ label: "Option A", value: "a" },
-		{ label: "Option B", value: "b" },
-		{ label: "Option C", value: "c" },
-		{ label: "Option D", value: "d" },
-		{ label: "Option E", value: "e" },
-	],
-};
-
-export const LayoutColumnsResponsiveWithStretch = DefaultStoryTemplate<TRadioButtonGroupSchema>(
-	"radio-layout-columns-responsive-stretch"
-).bind({});
-LayoutColumnsResponsiveWithStretch.args = {
 	uiType: "radio",
 	label: "Responsive columns with stretch (1 mobile, 2 tablet, 3 desktop)",
 	customOptions: {

--- a/src/stories/3-fields/radio-button/radio-toggle-button.stories.tsx
+++ b/src/stories/3-fields/radio-button/radio-toggle-button.stories.tsx
@@ -41,10 +41,10 @@ const meta: Meta = {
 		},
 		customOptions: {
 			description:
-				"<div>A custom options on which styling to use for rendering the toggle group.</div><ul><li>`styleType` prop accept either `default` or `toggle` and also can be `undefined`.If set to `toggle` will render toggle button, else render default radio buttons.</li><li>`indicator` show/hide radio icon, `false` by default.</li><li>`border` show/hide border,`true` by default.</li><li>`layoutType` render radio buttons horizontally or vertically, `horizontal` by default.</li></ul>",
+				'<div>A custom options on which styling to use for rendering the toggle group.</div><ul><li>`styleType` prop accept either `default` or `toggle`. If set to `toggle` will render toggle button, else render default radio buttons.</li><li>`indicator` show/hide radio icon, `false` by default.</li><li>`border` show/hide border, `true` by default.</li><li>`layoutType` render radio buttons horizontally or vertically (`"horizontal"` by default).</li><li>`allowDeselection` clicking a selected option deselects it (value becomes null), `false` by default.</li><li>`layoutColumns` controls how many toggle buttons appear per row using CSS grid — accepts a number or responsive object `{ mobile?, tablet?, desktop? }`.</li><li>`minItemWidth` sets a fixed minimum item width in pixels — accepts a number or responsive object `{ mobile?, tablet?, desktop? }`.</li><li>`stretch` when true, items stretch to fill the row using CSS auto-fill grid.</li></ul>',
 			table: {
 				type: {
-					summary: `{styleType: "toggle", indicator?: boolean, border?: boolean, layoutType?: "horizontal" | "vertical"}`,
+					summary: `{styleType: "toggle", indicator?: boolean, border?: boolean, layoutType?: "horizontal" | "vertical", allowDeselection?: boolean, layoutColumns?: number | { mobile?: number, tablet?: number, desktop?: number }, minItemWidth?: number | { mobile?: number, tablet?: number, desktop?: number }, stretch?: boolean}`,
 				},
 			},
 			type: { name: "object", value: {} },
@@ -359,3 +359,206 @@ Overrides.args = {
 	},
 };
 Overrides.argTypes = OVERRIDES_ARG_TYPE;
+
+export const AllowDeselection = DefaultStoryTemplate<TRadioButtonGroupSchema>("radio-allow-deselection").bind({});
+AllowDeselection.args = {
+	uiType: "radio",
+	label: "Select a fruit (click again to deselect)",
+	customOptions: {
+		styleType: "toggle",
+		allowDeselection: true,
+	},
+	options: [
+		{ label: "Apple", value: "Apple" },
+		{ label: "Berry", value: "Berry" },
+		{ label: "Cherry", value: "Cherry" },
+	],
+};
+
+export const AllowDeselectionFalse = DefaultStoryTemplate<TRadioButtonGroupSchema>(
+	"radio-allow-deselection-false"
+).bind({});
+AllowDeselectionFalse.args = {
+	uiType: "radio",
+	label: "Select a fruit (clicking selected option has no effect — allowDeselection is false)",
+	customOptions: {
+		styleType: "toggle",
+		allowDeselection: false,
+	},
+	options: [
+		{ label: "Apple", value: "Apple" },
+		{ label: "Berry", value: "Berry" },
+		{ label: "Cherry", value: "Cherry" },
+	],
+	defaultValues: "Apple",
+};
+
+export const AllowDeselectionWithNestedFields = DefaultStoryTemplate<TRadioButtonGroupSchema>(
+	"radio-allow-deselection-nested"
+).bind({});
+AllowDeselectionWithNestedFields.args = {
+	uiType: "radio",
+	label: "Select a reason (deselect to clear nested field)",
+	customOptions: {
+		styleType: "toggle",
+		allowDeselection: true,
+		indicator: true,
+	},
+	options: [
+		{
+			label: "Others",
+			value: "Others",
+			children: {
+				wrapper: {
+					uiType: "div",
+					style: { padding: "1rem" },
+					showIf: [{ "radio-allow-deselection-nested": [{ equals: "Others" }] }],
+					children: {
+						otherInput: {
+							uiType: "textarea",
+							label: "Please specify",
+							validation: [{ required: true }, { max: 100 }],
+						},
+					},
+				},
+			},
+		},
+		{ label: "Not applicable", value: "NA" },
+	],
+};
+
+export const AllowDeselectionWithRequiredValidation = DefaultStoryTemplate<TRadioButtonGroupSchema>(
+	"radio-allow-deselection-required"
+).bind({});
+AllowDeselectionWithRequiredValidation.args = {
+	uiType: "radio",
+	label: "Select a fruit (required — deselecting triggers validation error)",
+	customOptions: {
+		styleType: "toggle",
+		allowDeselection: true,
+	},
+	options: [
+		{ label: "Apple", value: "Apple" },
+		{ label: "Berry", value: "Berry" },
+		{ label: "Cherry", value: "Cherry" },
+	],
+	validation: [{ required: true, errorMessage: "Please select an option" }],
+	defaultValues: "Apple",
+};
+
+export const AllowDeselectionWithDefault = DefaultStoryTemplate<TRadioButtonGroupSchema>(
+	"radio-allow-deselection-default"
+).bind({});
+AllowDeselectionWithDefault.args = {
+	uiType: "radio",
+	label: "Select a fruit (has default, click to deselect)",
+	customOptions: {
+		styleType: "toggle",
+		allowDeselection: true,
+	},
+	options: [
+		{ label: "Apple", value: "Apple" },
+		{ label: "Berry", value: "Berry" },
+		{ label: "Cherry", value: "Cherry" },
+	],
+	defaultValues: "Apple",
+};
+
+export const MinItemWidth = DefaultStoryTemplate<TRadioButtonGroupSchema>("radio-min-item-width").bind({});
+MinItemWidth.args = {
+	uiType: "radio",
+	label: "Fixed item width (200px each)",
+	customOptions: { styleType: "toggle", minItemWidth: 200 },
+	options: [
+		{ label: "Option A", value: "a" },
+		{ label: "Option B", value: "b" },
+		{ label: "Option C", value: "c" },
+		{ label: "Option D", value: "d" },
+	],
+};
+
+export const LayoutColumns = DefaultStoryTemplate<TRadioButtonGroupSchema>("radio-layout-columns").bind({});
+LayoutColumns.args = {
+	uiType: "radio",
+	label: "Select an option (2 per row, not stretched)",
+	customOptions: {
+		styleType: "toggle",
+		layoutColumns: 2,
+	},
+	options: [
+		{ label: "Option A", value: "a" },
+		{ label: "Option B", value: "b" },
+		{ label: "Option C", value: "c" },
+		{ label: "Option D", value: "d" },
+	],
+};
+
+export const LayoutColumnsResponsive = DefaultStoryTemplate<TRadioButtonGroupSchema>(
+	"radio-layout-columns-responsive"
+).bind({});
+LayoutColumnsResponsive.args = {
+	uiType: "radio",
+	label: "Responsive columns (1 on mobile, 3 on desktop, not stretched)",
+	customOptions: {
+		styleType: "toggle",
+		layoutColumns: { mobile: 1, desktop: 3 },
+	},
+	options: [
+		{ label: "Option A", value: "a" },
+		{ label: "Option B", value: "b" },
+		{ label: "Option C", value: "c" },
+		{ label: "Option D", value: "d" },
+		{ label: "Option E", value: "e" },
+		{ label: "Option F", value: "f" },
+	],
+};
+
+export const Stretch = DefaultStoryTemplate<TRadioButtonGroupSchema>("radio-stretch").bind({});
+Stretch.args = {
+	uiType: "radio",
+	label: "Stretch to fill row (auto-fill grid)",
+	customOptions: { styleType: "toggle", stretch: true },
+	options: [
+		{ label: "Option A", value: "a" },
+		{ label: "Option B", value: "b" },
+		{ label: "Option C", value: "c" },
+		{ label: "Option D", value: "d" },
+	],
+};
+
+export const LayoutColumnsWithStretch = DefaultStoryTemplate<TRadioButtonGroupSchema>(
+	"radio-layout-columns-stretch"
+).bind({});
+LayoutColumnsWithStretch.args = {
+	uiType: "radio",
+	label: "2 columns, stretched (resize to see)",
+	customOptions: { styleType: "toggle", layoutColumns: 2, stretch: true },
+	options: [
+		{ label: "Option A", value: "a" },
+		{ label: "Option B", value: "b" },
+		{ label: "Option C", value: "c" },
+		{ label: "Option D", value: "d" },
+		{ label: "Option E", value: "e" },
+	],
+};
+
+export const LayoutColumnsResponsiveWithStretch = DefaultStoryTemplate<TRadioButtonGroupSchema>(
+	"radio-layout-columns-responsive-stretch"
+).bind({});
+LayoutColumnsResponsiveWithStretch.args = {
+	uiType: "radio",
+	label: "Responsive columns with stretch (1 mobile, 2 tablet, 3 desktop)",
+	customOptions: {
+		styleType: "toggle",
+		layoutColumns: { mobile: 1, tablet: 2, desktop: 3 },
+		stretch: true,
+	},
+	options: [
+		{ label: "Option A", value: "a" },
+		{ label: "Option B", value: "b" },
+		{ label: "Option C", value: "c" },
+		{ label: "Option D", value: "d" },
+		{ label: "Option E", value: "e" },
+		{ label: "Option F", value: "f" },
+	],
+};


### PR DESCRIPTION
Add allowDeselection, layoutColumns, minItemWidth and stretch for radio toggle button

**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)
-   [x] Documentation (change to documentation, comments or API descriptions)
-   [x] Tests (improvements to unit tests or E2E tests)
-   [ ] Other (technical improvements, refactoring, or changes that don't fall into the above categories)

**Description of changes**

-   Link to [DCUBESDQLR-2767](https://sgtechstack.atlassian.net/browse/DCUBESDQLR-2767)
-   Added `allowDeselection` to toggle variant — click selected option to deselect, setting value to `null`; clears nested children fields on deselection; triggers validation immediately
-   Added `layoutColumns` (`number` or `responsive` { `mobile`?, `tablet`?, `desktop`? }) — controls items per row via CSS grid
-   Added `minItemWidth` (`number` or `responsive` { `mobile`?, `tablet`?, `desktop`? }) — sets minimum item width in pixels
-   Added `stretch` (`boolean`) — stretches items to fill the row via CSS `auto-fill` grid
-   Added new types: `TResponsiveValue`, `TBreakpoint`, `TLayoutColumns`, `TMinItemWidth`
-   Updated Storybook stories with examples for all new options


**Checklist**

<!-- Put an `x` in items that apply -->

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md)
-   [x] Looks good on mobile and tablet
-   [x] Updated documentation
-   [x] Added/updated unit tests