### PR TITLE
[MISC][HN] Show validation errors on radio toggle selection

### DIFF
--- a/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
@@ -121,6 +121,32 @@ describe("radio toggle button", () => {
 		expect(getErrorMessage()).toBeInTheDocument();
 	});
 
+	it("should show error immediately when selected value fails notEquals validation", async () => {
+		renderComponent({
+			validation: [{ required: true }, { notEquals: "Apple", errorMessage: ERROR_MESSAGE }],
+		});
+
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+		fireEvent.click(getRadioButtonA());
+
+		await waitFor(() => expect(getErrorMessage()).toBeInTheDocument());
+	});
+
+	it("should clear error when selected value passes notEquals validation", async () => {
+		renderComponent({
+			validation: [{ required: true }, { notEquals: "Apple", errorMessage: ERROR_MESSAGE }],
+		});
+
+		// Trigger validation by submitting with invalid value
+		fireEvent.click(getRadioButtonA());
+		await waitFor(() => fireEvent.click(getSubmitButton()));
+		await waitFor(() => expect(screen.getByText(ERROR_MESSAGE)).toBeInTheDocument());
+
+		// Select valid value — error should clear
+		fireEvent.click(getRadioButtonB());
+		await waitFor(() => expect(screen.queryByText(ERROR_MESSAGE)).not.toBeInTheDocument());
+	});
+
 	it("should be disabled if configured for options", async () => {
 		renderComponent({
 			options: [

--- a/src/components/fields/radio-button/radio-button.styles.ts
+++ b/src/components/fields/radio-button/radio-button.styles.ts
@@ -2,9 +2,9 @@ import { ImageButton } from "@lifesg/react-design-system/image-button";
 import { RadioButton } from "@lifesg/react-design-system/radio-button";
 import { Toggle } from "@lifesg/react-design-system/toggle";
 import { Typography } from "@lifesg/react-design-system/typography";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { TRadioToggleLayoutType } from "./types";
-import { Spacing } from "@lifesg/react-design-system/theme";
+import { Colour, Spacing } from "@lifesg/react-design-system/theme";
 
 interface ILabelProps {
 	disabled?: boolean | undefined;
@@ -67,9 +67,22 @@ export const FlexToggleWrapper = styled.div<IToggleWrapperProps>`
 	gap: ${Spacing["spacing-16"]};
 `;
 
-export const StyledToggle = styled(Toggle)`
+interface IToggleProps {
+	$hasError?: boolean;
+}
+
+export const StyledToggle = styled(Toggle)<IToggleProps>`
 	[data-id="toggle-composite-children"] {
 		margin: 0;
 		padding: 0;
 	}
+
+	${({ $hasError }) =>
+		$hasError &&
+		css`
+			&:has(input:checked) [data-testid="toggle-label"],
+			&:has(input:checked) [aria-hidden="true"] {
+				color: ${Colour["text-error"]} !important;
+			}
+		`}
 `;

--- a/src/components/fields/radio-button/radio-button.tsx
+++ b/src/components/fields/radio-button/radio-button.tsx
@@ -66,7 +66,7 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 			: undefined;
 
 	const theme = useContext(ThemeContext);
-	const { setValue, trigger, clearErrors, unregister } = useFormContext();
+	const { setValue, trigger, unregister } = useFormContext();
 	const [stateValue, setStateValue] = useState<string>(value || "");
 	const [currentBreakpoint, setCurrentBreakpoint] = useState<TBreakpoint>("desktop");
 	const { setFieldValidationConfig, removeFieldValidationConfig } = useValidationConfig();
@@ -120,7 +120,7 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 			handleDeselect(clickedValue);
 		} else {
 			onChange?.({ target: { value: clickedValue } });
-			clearErrors(id);
+			trigger(id);
 		}
 	};
 
@@ -251,7 +251,8 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 										handleChangeOrClick(option.value);
 									}
 								}}
-								error={!!error?.message}
+								error={!!error?.message && (!stateValue || isRadioButtonChecked(option.value))}
+								$hasError={!!error?.message && isRadioButtonChecked(option.value)}
 								compositeSection={
 									option.children && (!allowDeselection || isRadioButtonChecked(option.value))
 										? { children: <Wrapper>{option.children}</Wrapper>, collapsible: false }


### PR DESCRIPTION
**Type of changes**

<!-- Put an `x` in the items that apply -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)
-   [ ] Documentation (change to documentation, comments or API descriptions)
-   [ ] Tests (improvements to unit tests or E2E tests)
-   [ ] Other (technical improvements, refactoring, or changes that don't fall into the above categories)

**Description of changes**

-   Replace `clearErrors` with trigger on selection so validations fire immediately on click
-   Show error border only on selected item when a value is chosen; show on all items for required (no selection)
-   Override selected item indicator color to error red when invalid; keep label color consistent with selected state
-   Add `notEquals` validation example to WithValidation toggle story

**Checklist**

<!-- Put an `x` in items that apply -->

-   [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md)
-   [x] Looks good on mobile and tablet
-   [x] Updated documentation (storybook)
-   [x] Added/updated unit tests

**Screenshots**
confirmed with UX

<img width="601" height="173" alt="Screenshot 2026-07-20 at 19 21 41" src="https://github.com/user-attachments/assets/6fa24906-d2e4-4640-b56f-33da5052f231" />

<img width="617" height="170" alt="Screenshot 2026-07-20 at 19 21 36" src="https://github.com/user-attachments/assets/fddab52f-47fe-4207-be56-60d796222f96" />

<img width="587" height="148" alt="Screenshot 2026-07-20 at 19 06 58" src="https://github.com/user-attachments/assets/3b81126a-d48f-4a11-8aeb-4c30b14419db" />

<img width="581" height="156" alt="Screenshot 2026-07-20 at 19 06 46" src="https://github.com/user-attachments/assets/5cc96c7a-e9ce-4632-b3cf-13e59cc57109" />
