### PR TITLE
[DCUBESDQLR-2831][GR] support validation modes on radio deselection

### DIFF
--- a/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
+++ b/src/__tests__/components/fields/radio-button/radio-toggle-button.spec.tsx
@@ -359,6 +359,105 @@ describe("radio toggle button", () => {
 				})
 			);
 		});
+		describe("validation mode on deselection", () => {
+			it("should not show error on deselect when validationMode is onSubmit (before submit)", async () => {
+				renderComponent(
+					{
+						allowDeselection: true,
+						customOptions: { styleType: "toggle" },
+						validation: [{ required: true, errorMessage: ERROR_MESSAGE }],
+					},
+					{ validationMode: "onSubmit" }
+				);
+
+				const radioButtonA = getRadioButtonA();
+				fireEvent.click(radioButtonA);
+				await waitFor(() => expect(radioButtonA).toBeChecked());
+
+				fireEvent.click(radioButtonA);
+				await waitFor(() => expect(radioButtonA).not.toBeChecked());
+
+				// No error should show before submit
+				expect(getErrorMessage(true)).not.toBeInTheDocument();
+			});
+
+			it("should show error immediately on deselect when validationMode is onChange (before submit)", async () => {
+				renderComponent(
+					{
+						allowDeselection: true,
+						customOptions: { styleType: "toggle" },
+						validation: [{ required: true, errorMessage: ERROR_MESSAGE }],
+					},
+					{ validationMode: "onChange" }
+				);
+
+				const radioButtonA = getRadioButtonA();
+				fireEvent.click(radioButtonA);
+				await waitFor(() => expect(radioButtonA).toBeChecked());
+
+				fireEvent.click(radioButtonA);
+				await waitFor(() => {
+					expect(radioButtonA).not.toBeChecked();
+					expect(getErrorMessage()).toBeInTheDocument();
+				});
+			});
+
+			it("should show error immediately on deselect when revalidationMode is onChange (after submit)", async () => {
+				renderComponent(
+					{
+						allowDeselection: true,
+						customOptions: { styleType: "toggle" },
+						validation: [{ required: true, errorMessage: ERROR_MESSAGE }],
+					},
+					{ revalidationMode: "onChange" }
+				);
+
+				const radioButtonA = getRadioButtonA();
+				fireEvent.click(radioButtonA);
+				await waitFor(() => expect(radioButtonA).toBeChecked());
+
+				// Submit first to set isSubmitted = true
+				await waitFor(() => fireEvent.click(getSubmitButton()));
+
+				// Deselect after submit
+				fireEvent.click(radioButtonA);
+				await waitFor(() => {
+					expect(radioButtonA).not.toBeChecked();
+					expect(getErrorMessage()).toBeInTheDocument();
+				});
+			});
+
+			it("should show error only on blur when revalidationMode is onBlur (after submit)", async () => {
+				renderComponent(
+					{
+						allowDeselection: true,
+						customOptions: { styleType: "toggle" },
+						validation: [{ required: true, errorMessage: ERROR_MESSAGE }],
+					},
+					{ revalidationMode: "onBlur" }
+				);
+
+				const radioButtonA = getRadioButtonA();
+				fireEvent.click(radioButtonA);
+				await waitFor(() => expect(radioButtonA).toBeChecked());
+
+				// Submit first
+				await waitFor(() => fireEvent.click(getSubmitButton()));
+
+				// Deselect after submit
+				fireEvent.click(radioButtonA);
+				await waitFor(() => expect(radioButtonA).not.toBeChecked());
+
+				// No error yet before blur
+				expect(getErrorMessage(true)).not.toBeInTheDocument();
+
+				// Blur the radiogroup
+				fireEvent.blur(screen.getByRole("radiogroup"));
+				await waitFor(() => {
+					expect(getErrorMessage()).toBeInTheDocument();
+				});
+			});
+		});
 	});
 
 	describe("reset", () => {

--- a/src/components/fields/radio-button/radio-button.tsx
+++ b/src/components/fields/radio-button/radio-button.tsx
@@ -3,13 +3,14 @@ import isObject from "lodash/isObject";
 import { Form } from "@lifesg/react-design-system/form";
 import { Breakpoint } from "@lifesg/react-design-system/theme";
 import { useContext, useEffect, useState } from "react";
+import type { FocusEvent } from "react";
 import { useFormContext } from "react-hook-form";
 import { ThemeContext } from "styled-components";
 import useDeepCompareEffect from "use-deep-compare-effect";
 import * as Yup from "yup";
 import { IGenericFieldProps } from "..";
 import { TestHelper, filterSchemaProps, generateRandomId } from "../../../utils";
-import { useFormSchema, useValidationConfig } from "../../../utils/hooks";
+import { useValidationConfig } from "../../../utils/hooks";
 import { Wrapper } from "../../elements/wrapper";
 import { Sanitize, Warning } from "../../shared";
 import {
@@ -48,7 +49,7 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 	// =============================================================================
 	// CONST, STATE, REFS
 	// =============================================================================
-	const { error, formattedLabel, id, onChange, schema, value, warning } = props;
+	const { error, formattedLabel, id, onBlur, onChange, schema, value, warning } = props;
 	const {
 		commonSchema: { customOptions, validation },
 		customSchema: { className, disabled, options, ...radioProps },
@@ -65,8 +66,7 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 			: undefined;
 
 	const theme = useContext(ThemeContext);
-	const { setValue, trigger, clearErrors, unregister, formState } = useFormContext();
-	const { formSchema } = useFormSchema(); // ← ADD THIS LINE
+	const { setValue, clearErrors, unregister } = useFormContext();
 	const [stateValue, setStateValue] = useState<string>(value || "");
 	const [currentBreakpoint, setCurrentBreakpoint] = useState<TBreakpoint>("desktop");
 	const { setFieldValidationConfig, removeFieldValidationConfig } = useValidationConfig();
@@ -140,13 +140,18 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 		}
 	};
 
-	const handleRadiogroupBlur = (): void => {
-		const { isSubmitted } = formState;
-		const revalidationMode = formSchema?.revalidationMode ?? "onChange";
+	const handleRadiogroupBlur = (event: FocusEvent<HTMLDivElement>): void => {
+		const nextFocusedElement = event.relatedTarget as Node | null;
 
-		if (isSubmitted && revalidationMode === "onBlur") {
-			trigger(id);
+		// Do not blur the field when focus moves between controls
+		// inside the same radio group.
+		if (nextFocusedElement && event.currentTarget.contains(nextFocusedElement)) {
+			return;
 		}
+
+		// React Hook Form marks the field as touched and applies
+		// the configured validation/revalidation behavior.
+		onBlur?.();
 	};
 
 	// =============================================================================

--- a/src/components/fields/radio-button/radio-button.tsx
+++ b/src/components/fields/radio-button/radio-button.tsx
@@ -140,17 +140,11 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 		}
 	};
 
-	const handleRadiogroupBlur = (event: FocusEvent<HTMLDivElement>): void => {
+	const handleBlur = (event: FocusEvent<HTMLDivElement>): void => {
 		const nextFocusedElement = event.relatedTarget as Node | null;
-
-		// Do not blur the field when focus moves between controls
-		// inside the same radio group.
 		if (nextFocusedElement && event.currentTarget.contains(nextFocusedElement)) {
 			return;
 		}
-
-		// React Hook Form marks the field as touched and applies
-		// the configured validation/revalidation behavior.
 		onBlur?.();
 	};
 
@@ -330,7 +324,7 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 	return (
 		<>
 			<Form.CustomField id={id} label={formattedLabel} errorMessage={error?.message}>
-				<div role="radiogroup" tabIndex={0} onBlur={handleRadiogroupBlur}>
+				<div role="radiogroup" tabIndex={0} onBlur={handleBlur}>
 					{renderOptions()}
 				</div>
 			</Form.CustomField>

--- a/src/components/fields/radio-button/radio-button.tsx
+++ b/src/components/fields/radio-button/radio-button.tsx
@@ -9,7 +9,7 @@ import useDeepCompareEffect from "use-deep-compare-effect";
 import * as Yup from "yup";
 import { IGenericFieldProps } from "..";
 import { TestHelper, filterSchemaProps, generateRandomId } from "../../../utils";
-import { useValidationConfig } from "../../../utils/hooks";
+import { useFormSchema, useValidationConfig } from "../../../utils/hooks";
 import { Wrapper } from "../../elements/wrapper";
 import { Sanitize, Warning } from "../../shared";
 import {
@@ -29,7 +29,6 @@ import {
 	TRadioButtonGroupSchema,
 	TResponsiveValue,
 } from "./types";
-
 const DEFAULT_MIN_ITEM_WIDTH = 164;
 
 const resolveResponsiveValue = <T,>(
@@ -66,11 +65,11 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 			: undefined;
 
 	const theme = useContext(ThemeContext);
-	const { setValue, trigger, clearErrors, unregister } = useFormContext();
+	const { setValue, trigger, clearErrors, unregister, formState } = useFormContext();
+	const { formSchema } = useFormSchema(); // ← ADD THIS LINE
 	const [stateValue, setStateValue] = useState<string>(value || "");
 	const [currentBreakpoint, setCurrentBreakpoint] = useState<TBreakpoint>("desktop");
 	const { setFieldValidationConfig, removeFieldValidationConfig } = useValidationConfig();
-
 	// =============================================================================
 	// EFFECTS
 	// =============================================================================
@@ -125,8 +124,7 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 	};
 
 	const handleDeselect = (clickedValue: string): void => {
-		onChange?.({ target: {} });
-		trigger(id);
+		onChange?.({ target: { value: undefined } });
 
 		const selectedOption = options.find((opt) => opt.value === clickedValue);
 		if (
@@ -139,6 +137,15 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 				removeFieldValidationConfig(childId);
 				unregister(childId);
 			});
+		}
+	};
+
+	const handleRadiogroupBlur = (): void => {
+		const { isSubmitted } = formState;
+		const revalidationMode = formSchema?.revalidationMode ?? "onChange";
+
+		if (isSubmitted && revalidationMode === "onBlur") {
+			trigger(id);
 		}
 	};
 
@@ -318,7 +325,7 @@ export const RadioButtonGroup = (props: IGenericFieldProps<TRadioButtonGroupSche
 	return (
 		<>
 			<Form.CustomField id={id} label={formattedLabel} errorMessage={error?.message}>
-				<div role="radiogroup" tabIndex={0}>
+				<div role="radiogroup" tabIndex={0} onBlur={handleRadiogroupBlur}>
 					{renderOptions()}
 				</div>
 			</Form.CustomField>


### PR DESCRIPTION
<!-- Put an `x` in the items that apply -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing apis or functionality to change)
- [ ] Documentation (change to documentation, comments or API descriptions)
- [x] Tests (improvements to unit tests or E2E tests)
- [ ] Other (technical improvements, refactoring, or changes that don't fall into the above categories)

**Description of changes**

- Link to ticket: `[DCUBESDQLR-2831](https://sgtechstack.atlassian.net/browse/DCUBESDQLR-2831)`
- Link to Figma: Not applicable
- Updated radio toggle deselection so that clearing the selected option is handled through the existing form `onChange` flow.
- Validation timing is now controlled by the configured `validationMode` and `revalidationMode`.
- Supports deselection behavior for `onSubmit`, `onChange`, `revalidationMode: "onChange"`, and `revalidationMode: "onBlur"`.
- Added validation handling on radio-group blur for submitted forms using `revalidationMode: "onBlur"`.
- Added unit tests covering radio toggle deselection and validation behavior.

**Checklist**

<!-- Put an `x` in items that apply -->

- [x] Changes follow the project guidelines in [CONTRIBUTING.md](https://github.com/LifeSG/react-design-system/blob/master/CONTRIBUTING.md)
- [x] Looks good on mobile and tablet
- [ ] Updated documentation
- [x] Added/updated unit tests

**Screenshots**

No screenshots included because this is a validation behavior fix with no visual UI changes.